### PR TITLE
stronger settings for clamav

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -143,7 +143,7 @@ EO_JAIL_CONF_HEAD
 
 get_jail_ip()
 {
-	local _start=${TOASTER_NET_START:=1}
+	local _start=${JAIL_NET_START:=1}
 	local _incr=0
 
 	case "$1" in
@@ -389,6 +389,7 @@ promote_staged_jail()
 	stop_jail stage
 	stage_resolv_conf
 	stage_unmount "$1"
+	ipcrm -W
 	#stage_clear_caches
 
 	rename_staged_to_ready "$1"

--- a/provision-avg.sh
+++ b/provision-avg.sh
@@ -5,6 +5,8 @@
 export JAIL_START_EXTRA="allow.sysvipc=1"
 export JAIL_CONF_EXTRA="
 		allow.sysvipc = 1;
+		mount.fdescfs;
+		mount.procfs;
 		mount += \"$ZFS_DATA_MNT/avg \$path/data/avg nullfs rw 0 0\";"
 
 install_avg()
@@ -39,6 +41,9 @@ start_avg()
 {
 	tell_status "starting avgd"
 	stage_exec service avgd.sh restart
+
+	tell_status "downloading virus databases"
+	stage_exec avgupdate
 }
 
 test_avg()

--- a/provision-clamav.sh
+++ b/provision-clamav.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# shellcheck disable=1091
 . mail-toaster.sh || exit
 
 export JAIL_CONF_EXTRA="
@@ -8,10 +9,32 @@ export JAIL_CONF_EXTRA="
 install_clamav()
 {
 	stage_pkg_install clamav || exit
+	echo "done"
+
+	install_clamav_unofficial
 }
 
 install_clamav_unofficial()
 {
+	if [ -z "$CLAMAV_UNOFFICIAL" ]; then
+		local _es_mess="
+	eXtremeSHOK maintains the ClamAV UNOFFICIAL project at
+		https://github.com/extremeshok/clamav-unofficial-sigs
+
+	The project is a set of scripts that download and keep updated
+	a collection of unofficial ClamAV signatures that significantly
+	increase ClamAV's virus detection rate. However, they also
+	increase the False Positive hits.
+
+	Unofficial DBs are best used with Haraka's karma plugin (scoring)
+	and with the clamav plugin configured with [reject]virus=false.
+
+	Do you want to install ClamAV UNOFFICIAL?"
+
+		dialog --yesno "$_es_mess" 18 74 || return
+	fi
+
+	tell_status "installing ClamAV unofficial 4.8"
 	local CLAMAV_UV=4.8
 	local STAGE_ETC="$STAGE_MNT/usr/local/etc"
 
@@ -21,17 +44,39 @@ install_clamav_unofficial()
 	tar -xz -C "$STAGE_MNT/tmp/" -f "$STAGE_MNT/tmp/$CLAMAV_UV.tar.gz" || exit
 
 	local _dist="$STAGE_MNT/tmp/clamav-unofficial-sigs-4.8"
-	local _sigs_conf="$_dist/clamav-unofficial-sigs.conf"
-	sed -i .bak -e 's/\/var\/lib/\/var\/db/' "$_sigs_conf"
-	sed -i .bak -e 's/^clam_user="clam"/clam_user="clamav"/' "$_sigs_conf"
-	sed -i .bak -e 's/^clam_group="clam"/clam_group="clamav"/' "$_sigs_conf"
+	local _conf="$STAGE_ETC/clamav-unofficial-sigs.conf"
+
+	if [ ! -f "$_conf" ]; then
+		if [ -f "clamav-unofficial-sigs.conf" ]; then
+			tell_status "installing local clamav-unofficial-sigs.conf"
+			cp "clamav-unofficial-sigs.conf" "$STAGE_ETC/"
+		fi
+	fi
+
+	if [ ! -f "$_conf" ]; then
+		if [ -f "$ZFS_JAIL_MNT/clamav/usr/local/etc/clamav-unofficial-sigs.conf" ]; then
+			tell_status "preserving clamav-unofficial-sigs.conf"
+			cp "$ZFS_JAIL_MNT/clamav/usr/local/etc/clamav-unofficial-sigs.conf" \
+				"$STAGE_ETC/"
+		fi
+	fi
+
+	if [ ! -f "$_conf" ]; then
+		tell_status "updating clamav-unofficial-sigs.conf"
+		local _dist_conf="$_dist/clamav-unofficial-sigs.conf"
+		sed -i .bak \
+			-e 's/\/var\/lib/\/var\/db/' \
+			-e 's/^clam_user="clam"/clam_user="clamav"/' \
+			-e 's/^clam_group="clam"/clam_group="clamav"/' \
+			"$_dist_conf"
+		cp "$_dist_conf" "$_conf" || exit
+	fi
 
 	local _sigs_sh="$_dist/clamav-unofficial-sigs.sh"
 	sed -i .bak -e 's/^#!\/bin\/bash/#!\/usr\/local\/bin\/bash/' "$_sigs_sh"
 	chmod 755 "$_sigs_sh" || exit
 
 	cp "$_sigs_sh" "$STAGE_MNT/usr/local/bin" || exit
-	cp "$_sigs_conf" "$STAGE_ETC/" || exit
 	cp "$_dist/clamav-unofficial-sigs.8" "$STAGE_MNT/usr/local/man/man8" || exit
 	mkdir -p "$STAGE_MNT/var/log/clamav-unofficial-sigs" || exit
 	mkdir -p "$STAGE_ETC/periodic/daily" || exit
@@ -45,26 +90,62 @@ EOSIG
 	echo '/var/log/clamav-unofficial-sigs.log root:wheel 640  3 1000 * J' \
 		> "$STAGE_ETC/newsyslog.conf.d/clamav-unofficial-sigs"
 	stage_exec /usr/local/etc/periodic/daily/clamav-unofficial-sigs
+
+	dialog --msgbox "ClamAV UNOFFICIAL is installed. Be sure to visit
+	 https://github.com/extremeshok/clamav-unofficial-sigs and follow
+	 the steps *after* the Quick Install Guide." 10 70
+}
+
+configure_clamd()
+{
+	tell_status "configuring clamd"
+	local _conf="$STAGE_MNT/usr/local/etc/clamd.conf"
+
+	sed -i .bak \
+		-e 's/^#TCPAddr 127.0.0.1/TCPAddr 0.0.0.0/' \
+		-e 's/^#TCPSocket 3310/TCPSocket 3310/' \
+		-e 's/^#LogFacility LOG_MAIL/LogFacility LOG_MAIL/' \
+		-e 's/^#LogSyslog yes/LogSyslog yes/' \
+		-e 's/^LogFile /#LogFile /' \
+		-e 's/^#ExtendedDetectionInfo /ExtendedDetectionInfo /' \
+		-e 's/^#DetectPUA/DetectPUA/' \
+		-e 's/^#DetectBrokenExecutables/DetectBrokenExecutables/' \
+		-e 's/^#StructuredDataDetection/StructuredDataDetection/' \
+		-e 's/^#ArchiveBlockEncrypted no/ArchiveBlockEncrypted yes/' \
+		-e 's/^#OLE2BlockMacros no/OLE2BlockMacros yes/'  \
+		-e 's/^#PhishingSignatures yes/PhishingSignatures yes/' \
+		-e 's/^#PhishingScanURLs yes/PhishingScanURLs yes/' \
+		-e 's/#HeuristicScanPrecedence yes/HeuristicScanPrecedence no/' \
+		-e 's/^#StructuredDataDetection yes/StructuredDataDetection yes/' \
+		-e 's/^#StructuredMinCreditCardCount 5/StructuredMinCreditCardCount 5/' \
+		-e 's/^#StructuredMinSSNCount 5/StructuredMinSSNCount 5/' \
+		-e 's/^#StructuredSSNFormatStripped yes/StructuredSSNFormatStripped no/' \
+		-e 's/^#ScanArchive yes/ScanArchive yes/' \
+		"$_conf" || exit
+
+	echo "done"
+}
+
+configure_freshclam()
+{
+	tell_status "configuring freshclam"
+	local _conf="$STAGE_MNT/usr/local/etc/freshclam.conf"
+
+	sed -i .bak \
+		-e 's/^UpdateLogFile /#UpdateLogFile /' \
+		-e 's/^#LogSyslog yes/LogSyslog yes/' \
+		-e 's/^#LogFacility LOG_MAIL/LogFacility LOG_MAIL/' \
+		-e 's/^#SafeBrowsing yes/SafeBrowsing yes/' \
+		-e 's/^#DatabaseMirror db.XY.clamav.net/DatabaseMirror db.us.clamav.net/' \
+		"$_conf" || exit
+
+	echo "done"
 }
 
 configure_clamav()
 {
-	local _clamconf="$STAGE_MNT/usr/local/etc/clamd.conf"
-
-	sed -i .bak -e 's/#TCPAddr 127.0.0.1/TCPAddr 0.0.0.0/' "$_clamconf"
-	sed -i .bak -e 's/#TCPSocket 3310/TCPSocket 3310/' "$_clamconf"
-	sed -i .bak -e 's/#LogFacility LOG_MAIL/LogFacility LOG_MAIL/' "$_clamconf"
-	sed -i .bak -e 's/#LogSyslog yes/LogSyslog yes/' "$_clamconf"
-	sed -i .bak -e 's/^LogFile /#LogFile /' "$_clamconf"
-
-	# these are more prone to FPs
-	sed -i .bak -e 's/#DetectPUA/DetectPUA/' "$_clamconf"
-	sed -i .bak -e 's/#DetectBrokenExecutables/DetectBrokenExecutables/' "$_clamconf"
-	sed -i .bak -e 's/#StructuredDataDetection/StructuredDataDetection/' "$_clamconf"
-	sed -i .bak -e 's/#ArchiveBlockEncrypted no/ArchiveBlockEncrypted yes/' "$_clamconf"
-
-	#tell_status "installing ClamAV unofficial"
-	#install_clamav_unofficial
+	configure_clamd
+	configure_freshclam
 }
 
 start_clamav()

--- a/provision-dns.sh
+++ b/provision-dns.sh
@@ -19,13 +19,18 @@ configure_unbound()
 	fi
 
 	# for the munin status plugin
-	sed -i .bak -e 's/# control-enable: no/control-enable: yes/' "$UNB_DIR/unbound.conf"
-	sed -i .bak -e 's/# control-interface: 127./control-interface: 127./' "$UNB_DIR/unbound.conf"
+	sed -i -e 's/# interface: 192.0.2.153/interface 0.0.0.0/' "$UNB_DIR/unbound.conf"
+	sed -i -e 's/# interface: 192.0.2.154/interface ::0/' "$UNB_DIR/unbound.conf"
+	sed -i -e 's/# control-enable: no/control-enable: yes/' "$UNB_DIR/unbound.conf"
+	sed -i -e "s/# control-interface: 127.*/control-interface: $(get_jail_ip dns)/" "$UNB_DIR/unbound.conf"
 
 	get_public_ip
 
 	tee -a "$UNB_DIR/toaster.conf" <<EO_UNBOUND
 	   $UNB_LOCAL
+
+	   hide-identity: yes
+	   hide-version: yes
 
 	   access-control: 0.0.0.0/0 refuse
 	   access-control: 127.0.0.0/8 allow

--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -23,9 +23,14 @@ install_haraka()
 	local _ghu='https://raw.githubusercontent.com/haraka/Haraka/master'
 
 	# remove after Haraka > 2.7.2 release
+	fetch -o "$_ghi/plugins/spamassassin.js" "$_ghu/plugins/spamassassin.js"
 	fetch -o "$_ghi/plugins/karma.js" "$_ghu/plugins/karma.js"
 	fetch -o "$_ghi/plugins/redis.js" "$_ghu/plugins/redis.js"
 	fetch -o "$_ghi/plugins/rspamd.js" "$_ghu/plugins/rspamd.js"
+	fetch -o "$_ghi/plugins/watch/index.js" "$_ghu/plugins/watch/index.js"
+	fetch -o "$_ghi/plugins/watch/html/client.js" "$_ghu/plugins/watch/html/client.js"
+	fetch -o "$_ghi/plugins/connect.geoip.js" "$_ghu/plugins/connect.geoip.js"
+	fetch -o "$_ghi/plugins/connect.p0f.js" "$_ghu/plugins/connect.p0f.js"
 }
 
 install_geoip_dbs()

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# shellcheck disable=1091
 . mail-toaster.sh || exit
 
 update_host_ntpd()

--- a/provision-rspamd.sh
+++ b/provision-rspamd.sh
@@ -23,6 +23,8 @@ configure_rspamd()
 }"  >> "$_local_etc/rspamd/rspamd.conf"
 
     # configure admin password?
+
+    sed -i -e '/^filters/ s/spf/spf,dmarc/' "$_local_etc/rspamd/options.inc"
 }
 
 start_rspamd()


### PR DESCRIPTION
* when promoting a jail, clear shared IPC
* avg: try to d/l virus dbs when installing
    * mount fdescfs and procfs
* clamav:
    * prompt for installation of ClamAV Unofficial
    * match my production settings
* dns
    * listen on all IPv6 and IPv4 addresses
    * hide identity & version
* rspamd: enable dmarc report storage in redis
* haraka: update more plugins:
    * spamassassin, watch, geoip, and p0f (upstream bug fixes)
* webmail:
    * TLS config updates for squirrelmail
    * tell php where ssl ca certs are
* spamassassin: added bayes_ignore_header rules