### PR TITLE
Syslog

### DIFF
--- a/provision-base.sh
+++ b/provision-base.sh
@@ -66,6 +66,20 @@ purgestat	/usr/bin/true
 EO_MAILER_CONF
 }
 
+configure_syslog()
+{
+	tell_status "forwarding syslog to host"
+	tee "$BASE_MNT/etc/syslog.conf" <<EO_SYSLOG
+*.*			@syslog
+EO_SYSLOG
+
+	tell_status "disabling newsyslog"
+	sysrc -f "$BASE_MNT/etc/rc.conf" newsyslog_enable=NO
+	sed -i .bak \
+		-e '/^0.*newsyslog/ s/^0/#0/' \
+		"$BASE_MNT/etc/crontab"
+}
+
 disable_syslog()
 {
 	tell_status "disabling syslog"
@@ -119,13 +133,13 @@ EO_MAKE_CONF
 	sysrc -f "$BASE_MNT/etc/rc.conf" \
 		hostname=base \
 		cron_flags='$cron_flags -J 15' \
-		syslogd_flags=-ss \
+		syslogd_flags="-s -cc" \
 		sendmail_enable=NONE \
 		update_motd=NO
 
 	configure_ssl_dirs
 	disable_cron_jobs
-	#disable_syslog
+	configure_syslog
 }
 
 install_bash()

--- a/provision-base.sh
+++ b/provision-base.sh
@@ -99,10 +99,13 @@ disable_root_password()
 
 disable_cron_jobs()
 {
-	tell_status "disabling adjkerntz & atrun"
+	tell_status "disabling adjkerntz, save-entropy, & atrun"
+	# nobody uses atrun, safe-entropy is done by the host, and
+	# the jail doesn't have permission to run adjkerntz.
 	sed -i .bak \
-		-e '/^1.*adjkerntz/ s/^1/#1/' \
-		-e '/^\*.*atrun/ s/^\*/#*/' \
+		-e '/^1.*adjkerntz/ s/^1/#1/'  \
+		-e '/^\*.*atrun/    s/^\*/#*/' \
+		-e '/^\*.*entropy/  s/^\*/#*/' \
 		"$BASE_MNT/etc/crontab" || exit
 
 	echo "done"

--- a/provision-geoip.sh
+++ b/provision-geoip.sh
@@ -15,8 +15,6 @@ install_geoip()
 
 configure_geoip()
 {
-	stage_sysrc syslogd_enable=NO
-	
 	local _weekly="$STAGE_MNT/usr/local/etc/periodic/weekly"
 	mkdir -p "$_weekly"
 	tee "$_weekly/999.maxmind-geolite-mirror" <<EO_GEO

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -314,7 +314,6 @@ $(get_jail_ip "$j")		$j"
 update_host() {
 	update_freebsd
 	configure_ntpd
-	update_syslogd
 	update_sendmail
 	constrain_sshd_to_host
 	check_global_listeners
@@ -324,6 +323,7 @@ update_host() {
 	install_jailmanage
 	plumb_jail_nic
 	assign_syslog_ip
+	update_syslogd
 	configure_etc_hosts
 	echo; echo "Success! Your host is ready to install Mail Toaster 6!"; echo
 }

--- a/provision-mysql.sh
+++ b/provision-mysql.sh
@@ -14,7 +14,8 @@ install_mysql()
 
 configure_mysql()
 {
-	true
+	tell_status "configuring mysql"
+	stage_sysrc mysql_args="--syslog"
 }
 
 start_mysql()

--- a/provision-redis.sh
+++ b/provision-redis.sh
@@ -20,10 +20,10 @@ configure_redis()
 		"$STAGE_MNT/usr/local/etc/newsyslog.conf.d" || exit
 	stage_exec chown redis:redis /data/db /data/log || exit
 
-	# -e 's/^# syslog-enabled no/syslog-enabled yes/'
 	sed -i .bak \
 		-e '/^stop-writes-on-bgsave-error/ s/yes/no/' \
 		-e 's/^dir \/var\/db\/redis\//dir \/data\/db\//' \
+		-e 's/^# syslog-enabled no/syslog-enabled yes/' \
 		-e 's/^logfile .*/logfile \/data\/log\/redis.log/' \
 		"$STAGE_MNT/usr/local/etc/redis.conf"
 

--- a/provision-rspamd.sh
+++ b/provision-rspamd.sh
@@ -9,23 +9,43 @@ install_rspamd()
 	stage_pkg_install rspamd || exit
 }
 
+configure_dmarc()
+{
+	if ! zfs_filesystem_exists "$ZFS_DATA_VOL/redis"; then
+		return
+	fi
+
+	tell_status "add Redis address, for DMARC stats"
+	echo "dmarc {
+	servers = \"$(get_jail_ip redis):6379\";
+}"  | tee -a "$_etc/rspamd/rspamd.conf"
+}
+
+configure_logging()
+{
+	tell_status "configuring syslog logging"
+	sed -i .bak \
+		-e 's/type = "file"/type = "syslog"/' \
+		-e 's/filename = ".*/facility = "LOG_MAIL";/' \
+		"$_etc/rspamd/rspamd.conf"
+
+#	mkdir -p "$_etc/newsyslog.conf.d/"
+#	echo '/var/log/rspamd/rspamd.log   nobody:nobody   644  7  *  @T00  JC  /var/run/rspamd/rspamd.pid  30' \
+#  		> "$_etc/newsyslog.conf.d/rspamd"
+
+}
+
 configure_rspamd()
 {
 	tell_status "configuring rspamd"
-	local _local_etc="$STAGE_MNT/usr/local/etc"
+	local _etc="$STAGE_MNT/usr/local/etc"
 
-	mkdir -p "$_local_etc/newsyslog.conf.d/"
-	echo '/var/log/rspamd/rspamd.log   nobody:nobody   644  7  *  @T00  JC  /var/run/rspamd/rspamd.pid  30' \
-  		> "$_local_etc/newsyslog.conf.d/rspamd"
-
-	# add Redis address, for DMARC stats
-	echo "dmarc {
-	servers = \"$(get_jail_ip redis):6379\";
-}"  >> "$_local_etc/rspamd/rspamd.conf"
-
+  	configure_logging
+  	configure_dmarc
 	# configure admin password?
 
-	sed -i -e '/^filters/ s/spf/spf,dmarc/' "$_local_etc/rspamd/options.inc"
+	sed -i -e '/^filters/ s/spf/spf,dmarc/' "$_etc/rspamd/options.inc"
+	echo "done"
 }
 
 start_rspamd()


### PR DESCRIPTION
* host: bind syslogd to ${JAIL_NET_PREFIX}.1 …
* base & all jails: forward syslog to host
* add syslog dns & ip settings
* mysql, redis, rspamd: use syslog logging
* other optimizations:
    * base: disable save-entropy in jails
