### PR TITLE
haproxy: use data dir for haproxy.conf and ssl

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -532,6 +532,7 @@ has_data_fs()
 		lighttpd ) return 0;;
 		apache )   return 0;;
 		postgres ) return 0;;
+		haproxy )  return 0;;
 	esac
 
 	return 1


### PR DESCRIPTION
* enables local customizations to be preserved across provisions