### PR TITLE
Add the option to install MariaDB

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -16,6 +16,7 @@ export ZFS_VOL="zroot"
 export ZFS_JAIL_MNT="/jails"
 export ZFS_DATA_MNT="/data"
 export TOASTER_MYSQL="1"
+export TOASTER_MARIADB="0"
 
 EO_MT_CONF
 	fi
@@ -45,6 +46,7 @@ export FBSD_MIRROR=${FBSD_MIRROR:="ftp://ftp.freebsd.org"}
 
 # See https://github.com/msimerson/Mail-Toaster-6/wiki/MySQL
 export TOASTER_MYSQL=${TOASTER_MYSQL:="1"}
+export TOASTER_MARIADB=${TOASTER_MARIADB:="0"}
 if [ "$TOASTER_MYSQL" = "1" ]; then
 	echo "mysql enabled"
 fi

--- a/provision-mysql.sh
+++ b/provision-mysql.sh
@@ -6,11 +6,29 @@
 export JAIL_CONF_EXTRA="
 		mount += \"$ZFS_DATA_MNT/mysql \$path/var/db/mysql nullfs rw 0 0\";"
 
+install_db_server()
+{
+	#Check if MariaDB needs to be installed
+	if [ "$TOASTER_MARIADB" = "1" ]; then
+	        install_mariadb
+    else
+		install_mysql
+	fi
+
+}
+
 install_mysql()
 {
 	tell_status "installing mysql"
 	stage_pkg_install mysql56-server || exit
 }
+
+install_mariadb()
+{
+	tell_status "installing mariadb"
+	stage_pkg_install mariadb101-server || exit
+}
+
 
 configure_mysql()
 {
@@ -53,7 +71,7 @@ test_mysql()
 base_snapshot_exists || exit
 create_staged_fs mysql
 start_staged_jail
-install_mysql
+install_db_server
 start_mysql
 configure_mysql
 test_mysql


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add the option to install MariaDB, decided to add an extra ENV var, since the TOASTER_MYSQL is used in multiple provision, would mean lot more code changes and no backward compatibility
-
-

Fixes # .

Checklist:
- [ ] docs up-to-date

