### PR TITLE
refactor sockstat into stage_listening

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -520,6 +520,12 @@ stage_exec()
 	jexec "$SAFE_NAME" "$@"
 }
 
+stage_listening()
+{
+	echo "checking for port $1 listener in staged jail"
+	sockstat -l -4 -6 -p "$1" -j "$(jls -j stage jid)" || exit
+}
+
 stage_mount_ports()
 {
 	echo "mount $STAGE_MNT/usr/ports"

--- a/provision-avg.sh
+++ b/provision-avg.sh
@@ -58,7 +58,7 @@ test_avg()
 	ps ax -J stage | grep avg || exit
 
 	tell_status "verifying avgtcpd is listening"
-	sockstat -l | grep 54322 || exit
+	stage_listening 54322
 	echo "it works"
 }
 

--- a/provision-clamav.sh
+++ b/provision-clamav.sh
@@ -177,8 +177,8 @@ start_clamav()
 
 test_clamav()
 {
-	echo "testing ClamAV..."
-	stage_exec sockstat -l -4 | grep 3310 || exit
+	echo "testing ClamAV clamd"
+	stage_listening 3310
 	echo "It works! (clamd is listening)"
 }
 

--- a/provision-dovecot.sh
+++ b/provision-dovecot.sh
@@ -119,7 +119,7 @@ start_dovecot()
 test_dovecot()
 {
 	tell_status "testing dovecot"
-	stage_exec sockstat -l -4 | grep 143 || exit
+	stage_listening 143
 	echo "it worked"
 }
 

--- a/provision-dspam.sh
+++ b/provision-dspam.sh
@@ -76,7 +76,7 @@ test_dspam()
 {
 	tell_status "testing dspam"
 	sleep 2
-	stage_exec sockstat -l -4 | grep :24 || exit
+	stage_listening 24
 	echo "it worked"
 }
 

--- a/provision-elasticsearch.sh
+++ b/provision-elasticsearch.sh
@@ -97,11 +97,10 @@ test_elasticsearch()
 	sleep 10
 
 	tell_status "testing Elasticsearch (listening 9200)"
-	sockstat -l -4 -6 -j "$(jls -j stage jid)" -p 9200 || exit
-	echo "it worked"
+	stage_listening 9200
 
 	tell_status "testing Kibana (listening 5601)"
-	sockstat -l -4 -6 -j "$(jls -j stage jid)" -p 5601 || exit
+	stage_listening 5601
 	echo "it worked"
 }
 

--- a/provision-elasticsearch.sh
+++ b/provision-elasticsearch.sh
@@ -99,6 +99,9 @@ test_elasticsearch()
 	tell_status "testing Elasticsearch (listening 9200)"
 	stage_listening 9200
 
+	tell_status "waiting 10 seconds for kibana to start"
+	sleep 10
+
 	tell_status "testing Kibana (listening 5601)"
 	stage_listening 5601
 	echo "it worked"

--- a/provision-haproxy.sh
+++ b/provision-haproxy.sh
@@ -135,13 +135,13 @@ test_haproxy()
 {
 	tell_status "testing haproxy"
 	if [ ! -f "$ZFS_JAIL_MNT/haproxy/var/run/haproxy.pid" ]; then
-		stage_exec sockstat -l -4 | grep 443 || exit
+		stage_listening 443
 		echo "it worked"
 		return
 	fi
 
 	echo "previous haproxy is running, ignoring errors"
-	stage_exec sockstat -l -4 | grep 443
+	sockstat -l -4 -6 -p 443 -j "$(jls -j stage jid)"
 }
 
 base_snapshot_exists || exit

--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -528,7 +528,7 @@ test_haraka()
 	sleep 3
 
 	tell_status "testing Haraka"
-	stage_exec sockstat -l -4 | grep :25 || exit
+	stage_listening 25
 	echo "it worked"
 }
 

--- a/provision-joomla.sh
+++ b/provision-joomla.sh
@@ -143,8 +143,11 @@ start_joomla()
 test_joomla()
 {
 	tell_status "testing joomla"
-	stage_exec sockstat -l -4 | grep :80 || exit
-	stage_exec sockstat -l -4 | grep :9000 || exit
+	stage_listening 80
+	echo "httpd is listening"
+
+	stage_listening 9000
+	echo "php fpm is listening"
 	echo "it worked"
 }
 

--- a/provision-memcached.sh
+++ b/provision-memcached.sh
@@ -25,7 +25,7 @@ start_memcached()
 test_memcached()
 {
 	tell_status "testing memcached"
-	stage_exec sockstat -l -4 | grep :11211 || exit
+	stage_listening 11211
 	echo "it worked"
 }
 

--- a/provision-minecraft.sh
+++ b/provision-minecraft.sh
@@ -49,7 +49,7 @@ start_minecraft()
 test_minecraft()
 {
 	tell_status "testing minecraft"
-	stage_exec sockstat -l -4 | grep :25565 || exit
+	stage_listening 25565
 	echo "it worked"
 }
 

--- a/provision-mysql.sh
+++ b/provision-mysql.sh
@@ -63,7 +63,7 @@ test_mysql()
 	else
 		sleep 1
 		echo 'SHOW DATABASES' | stage_exec mysql || exit
-		stage_exec sockstat -l -4 | grep 3306 || exit
+		stage_listening 3306
 		echo "it worked"
 	fi
 }

--- a/provision-nginx.sh
+++ b/provision-nginx.sh
@@ -50,7 +50,7 @@ start_nginx()
 test_nginx()
 {
 	tell_status "testing nginx"
-	stage_exec sockstat -l -4 | grep :80 || exit
+	stage_listening 80
 	echo "it worked"
 }
 

--- a/provision-php7.sh
+++ b/provision-php7.sh
@@ -50,7 +50,7 @@ start_php()
 test_php()
 {
 	tell_status "testing php7"
-	stage_exec sockstat -l -4 | grep :9000 || exit
+	stage_listening 9000
 	echo "it worked"
     echo  "You probably need to created a shared source between Nginx and this PHP jail"
 }

--- a/provision-redis.sh
+++ b/provision-redis.sh
@@ -41,7 +41,7 @@ start_redis()
 test_redis()
 {
 	echo "testing redis"
-	stage_exec sockstat -l -4 | grep 6379 || exit
+	stage_listening 6379
 	echo "it worked"
 }
 

--- a/provision-rspamd.sh
+++ b/provision-rspamd.sh
@@ -58,7 +58,7 @@ start_rspamd()
 test_rspamd()
 {
 	tell_status "testing rspamd"
-	stage_exec sockstat -l -4 | grep 11334 || exit
+	stage_listening 11334
 	echo "it worked"
 }
 

--- a/provision-spamassassin.sh
+++ b/provision-spamassassin.sh
@@ -183,7 +183,7 @@ start_spamassassin()
 test_spamassassin()
 {
 	tell_status "testing spamassassin"
-	stage_exec sockstat -l -4 | grep :783 || exit
+	stage_listening 783
 	echo "it worked"
 }
 

--- a/provision-vpopmail.sh
+++ b/provision-vpopmail.sh
@@ -204,7 +204,7 @@ test_vpopmail()
 {
 	echo "testing vpopmail"
 	sleep 1 # give the daemons a second to start listening
-	stage_exec sockstat -l -4 | grep :89 || exit
+	stage_listening 89
 	echo "it worked"
 }
 

--- a/provision-webmail.sh
+++ b/provision-webmail.sh
@@ -395,8 +395,8 @@ install_webmail()
 
 install_index()
 {
-    tell_status "installing index.html"
-    tee "$_htdocs/index.html" <<'EO_INDEX'
+	tell_status "installing index.html"
+	tee "$_htdocs/index.html" <<'EO_INDEX'
 <html>
 <head>
  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
@@ -517,9 +517,11 @@ start_webmail()
 
 test_webmail()
 {
-	tell_status "testing webmail"
-	stage_exec sockstat -l -4 | grep :80 || exit
-	stage_exec sockstat -l -4 | grep :9000 || exit
+	tell_status "testing webmail httpd"
+	stage_listening 80
+
+	tell_status "testing webmail php"
+	stage_listening 9000
 	echo "it worked"
 }
 


### PR DESCRIPTION
### Changes proposed in this pull request:
* refactor many sockstat ... calls into stage_listening $port_num
* replace sockstat -l | grep NUM  with sockstat -p NUM
* add -6 to sockstat, so IPv6 only listeners will work 