### PR TITLE
fix path for legacy mailfilter

### DIFF
--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -473,6 +473,14 @@ configure_haraka()
 		echo '3' > "$HARAKA_CONF/tarpit.timeout"
 	fi
 
+	if [ ! -f "$HARAKA_CONF/deny_includes_uuid" ]; then
+		echo '12' > "$HARAKA_CONF/deny_includes_uuid"
+	fi
+
+	if [ ! -f "$HARAKA_CONF/rate_limit.ini" ]; then
+		echo "redis_server = $(get_jail_ip redis)" > "$HARAKA_CONF/rate_limit.ini"
+	fi
+
 	if [ ! -f "$HARAKA_CONF/plugins" ]; then
 		config_install_default plugins
 	fi

--- a/provision-vpopmail.sh
+++ b/provision-vpopmail.sh
@@ -51,8 +51,8 @@ install_maildrop()
 	tell_status "adding legacy mailfilter for MT5 compatibility"
 	mkdir -p "$STAGE_MNT/usr/local/etc/mail"
 	cp "$STAGE_MNT/etc/mailfilter" "$STAGE_MNT/usr/local/etc/mail/"
-	stage_exec chown 89:89 "$STAGE_MNT/usr/local/etc/mailfilter"
-	stage_exec chmod 600 "$STAGE_MNT/usr/local/etc/mailfilter"
+	stage_exec chown 89:89 "$STAGE_MNT/usr/local/etc/mail/mailfilter"
+	stage_exec chmod 600 "$STAGE_MNT/usr/local/etc/mail/mailfilter"
 }
 
 install_lighttpd()


### PR DESCRIPTION
### Changes proposed in this pull request:
- legacy mailfilter is at etc/mail/mailfilter (not etc/mailfilter)
- set redis server location for Haraka rate_limit plugin
