### PR TITLE
add TOASTER_ADMIN_EMAIL setting

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -14,6 +14,7 @@ config()
 		tee mail-toaster.conf <<EO_MT_CONF
 export TOASTER_HOSTNAME="$_HOSTNAME"
 export TOASTER_MAIL_DOMAIN="$_EMAIL_DOMAIN"
+export TOASTER_ADMIN_EMAIL="postmaster@${_EMAIL_DOMAIN}"
 
 export JAIL_NET_PREFIX="172.16.15"
 export JAIL_NET_MASK="/12"
@@ -40,6 +41,7 @@ config
 # Required settings
 export TOASTER_HOSTNAME=${TOASTER_HOSTNAME:="mail.example.com"} || exit
 export TOASTER_MAIL_DOMAIN=${TOASTER_MAIL_DOMAIN:="example.com"}
+export TOASTER_ADMIN_EMAIL=${TOASTER_ADMIN_EMAIL:="postmaster@$TOASTER_MAIL_DOMAIN"}
 
 # export these in your environment to customize
 export BOURNE_SHELL=${BOURNE_SHELL:="bash"}

--- a/provision-base.sh
+++ b/provision-base.sh
@@ -52,7 +52,7 @@ install_ssmtp()
 	cp "$BASE_MNT/usr/local/etc/ssmtp/revaliases.sample" \
 	   "$BASE_MNT/usr/local/etc/ssmtp/revaliases" || exit
 
-	sed -e "/^root=/ s/postmaster/postmaster@$TOASTER_MAIL_DOMAIN/" \
+	sed -e "/^root=/ s/postmaster/$TOASTER_ADMIN_EMAIL/" \
 		-e "/^mailhub=/ s/=mail/=vpopmail/" \
 		-e "/^rewriteDomain=/ s/=\$/=$TOASTER_MAIL_DOMAIN/" \
 		"$BASE_MNT/usr/local/etc/ssmtp/ssmtp.conf.sample" \
@@ -224,9 +224,9 @@ weekly_local=""
 monthly_local=""
 
 # in case /etc/aliases isn't set up properly
-daily_output="postmaster@$TOASTER_MAIL_DOMAIN"
-weekly_output="postmaster@$TOASTER_MAIL_DOMAIN"
-monthly_output="postmaster@$TOASTER_MAIL_DOMAIN"
+daily_output="$TOASTER_ADMIN_EMAIL"
+weekly_output="$TOASTER_ADMIN_EMAIL"
+monthly_output="$TOASTER_ADMIN_EMAIL"
 
 security_show_success="NO"
 security_show_info="YES"

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -99,7 +99,7 @@ commonName_default = $TOASTER_HOSTNAME \
 
 	grep -q emailAddress_default /etc/ssl/openssl.cnf || \
 		sed -i -e "/^emailAddress_max.*/ a\ 
-emailAddress_default = postmaster@$TOASTER_HOSTNAME \
+emailAddress_default = $TOASTER_ADMIN_EMAIL \
 " /etc/ssl/openssl.cnf
 
 	if [ -f /etc/ssl/private/server.key ]; then

--- a/provision-vpopmail.sh
+++ b/provision-vpopmail.sh
@@ -27,9 +27,9 @@ install_qmail()
 	stage_exec /var/qmail/scripts/enable-qmail
 
 	local _alias="$STAGE_MNT/var/qmail/alias"
-	echo "postmaster@$TOASTER_MAIL_DOMAIN" | tee "$_alias/.qmail-root"
-	echo "postmaster@$TOASTER_MAIL_DOMAIN" | tee "$_alias/.qmail-postmaster"
-	echo "postmaster@$TOASTER_MAIL_DOMAIN" | tee "$_alias/.qmail-mailer-daemon"
+	echo "$TOASTER_ADMIN_EMAIL" | tee "$_alias/.qmail-root"
+	echo "$TOASTER_ADMIN_EMAIL" | tee "$_alias/.qmail-postmaster"
+	echo "$TOASTER_ADMIN_EMAIL" | tee "$_alias/.qmail-mailer-daemon"
 
 	stage_make_conf mail_qmail_ 'mail_qmail_SET=DNS_CNAME DOCS MAILDIRQUOTA_PATCH
 mail_qmail_UNSET=RCDLINK


### PR DESCRIPTION
### Changes proposed in this pull request:
- use TOASTER_ADMIN_EMAIL (defaults to postmaster@$TOASTER_EMAIL_DOMAIN) for admin email
