### PR TITLE
preserve AVG signatures across deployments

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -308,7 +308,7 @@ stage_unmount()
 	unmount_ports "$STAGE_MNT"
 	unmount_pkg_cache
 	if has_data_fs "$1"; then unmount_data "$1"; fi
-	unmount_aux_data "$1"
+	stage_unmount_aux_data "$1"
 }
 
 cleanup_staged_fs()
@@ -342,7 +342,7 @@ create_staged_fs()
 	echo
 }
 
-unmount_aux_data()
+stage_unmount_aux_data()
 {
 	case $1 in
 		spamassassin)  unmount_data geoip ;;
@@ -351,7 +351,7 @@ unmount_aux_data()
 	esac
 }
 
-mount_aux_data() {
+stage_mount_aux_data() {
 	case $1 in
 		spamassassin )  mount_data geoip ;;
 		haraka )        mount_data geoip ;;
@@ -383,7 +383,7 @@ start_staged_jail()
 		$JAIL_START_EXTRA \
 		|| exit
 
-	mount_aux_data "$_name"
+	stage_mount_aux_data "$_name"
 
 	pkg -j stage update
 }

--- a/provision-avg.sh
+++ b/provision-avg.sh
@@ -10,6 +10,24 @@ export JAIL_CONF_EXTRA="
 		mount.procfs;
 		mount += \"$ZFS_DATA_MNT/avg \$path/data/avg nullfs rw 0 0\";"
 
+install_avg_data_fs()
+{
+	tell_status "setting up AVG data filesystem"
+	for d in $ZFS_DATA_MNT/avg/spool $ZFS_DATA_MNT/avg/update $ZFS_DATA_MNT/avg/var-data; do
+		if [ ! -d "$d" ]; then
+			echo "mkdir $d"
+			mkdir "$d" || exit
+		fi
+	done
+
+	tell_status "linking AVG dirs to data FS"
+	mkdir -p "$STAGE_MNT/opt/avg/av"  || exit
+	stage_exec ln -s /data/avg/update /opt/avg/av/update || exit
+
+	mkdir -p "$STAGE_MNT/opt/avg/av/var" || exit
+	stage_exec ln -s /data/avg/var-data /opt/avg/av/var/data || exit
+}
+
 install_avg()
 {
 	tell_status "making FreeBSD like 2008 (32-bit)"
@@ -22,12 +40,14 @@ install_avg()
 	fetch -o "$STAGE_MNT/usr/lib32/libiconv.so.3" http://mail-toaster.org/install/libiconv.so.3
 	sysrc -R "$STAGE_MNT" ldconfig32_paths="\$ldconfig32_paths /opt/avg/av/lib"
 
-	tell_status "downloading avg"
+	install_avg_data_fs
+
+	tell_status "downloading avg2013ffb-r3115-a6155.i386.tar.gz"
 	fetch -m http://download.avgfree.com/filedir/inst/avg2013ffb-r3115-a6155.i386.tar.gz || exit
 
 	tell_status "installing avg"
 	tar -C "$STAGE_MNT/tmp" -xzf avg2013ffb-r3115-a6155.i386.tar.gz || exit
-	mkdir -p "$STAGE_MNT/usr/local/etc/rc.d" "$STAGE_MNT/opt/avg" || exit
+	mkdir -p "$STAGE_MNT/usr/local/etc/rc.d" || exit
 	stage_exec /tmp/avg2013ffb-r3115-a6155.i386/install.sh
 }
 

--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -210,14 +210,14 @@ config_haraka_avg()
 	fi
 
 	tell_status "configuring Haraka avg plugin"
-	mkdir -p "$STAGE_MNT/data/avg" || exit
+	mkdir -p "$STAGE_MNT/data/avg/spool" || exit
 
 	JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
 		mount += \"$ZFS_DATA_MNT/avg \$path/data/avg nullfs rw 0 0\";"
 
 	if ! grep -qs ^host "$HARAKA_CONF/avg.ini"; then
 		echo "host = $(get_jail_ip avg)
-tmpdir=/data/avg
+tmpdir=/data/avg/spool
 " | tee -a "$HARAKA_CONF/avg.ini"
 	fi
 

--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -221,6 +221,13 @@ tmpdir=/data/avg/spool
 " | tee -a "$HARAKA_CONF/avg.ini"
 	fi
 
+	if ! grep -qs spool "$HARAKA_CONF/avg.ini"; then
+		tell_status "update tmpdir in avg.ini"
+		sed -i .bak -e \
+			'/^tmpdir/ s/avg$/avg\/spool/g' \
+			"$HARAKA_CONF/avg.ini"
+	fi
+
 	if ! grep -q ^avg "$HARAKA_CONF/plugins"; then
 		tell_status "enabling avg plugin"
 		# shellcheck disable=1004


### PR DESCRIPTION
### Changes proposed in this pull request:
- store tmp files in avg/spool (vs avg)
- use symlinks to store AVG signatures on data FS

Fixes #82

Checklist:
- [x] docs up-to-date