### PR TITLE
always create AVG mountpoint

### DIFF
--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -204,14 +204,14 @@ relay_reject_threshold=7
 
 config_haraka_avg()
 {
+	mkdir -p "$STAGE_MNT/data/avg/spool" || exit
+
 	if ! zfs_filesystem_exists "$ZFS_DATA_VOL/avg"; then
-		echo "AVG not installed, skipping"
+		echo "AVG data FS missing, not enabling"
 		return
 	fi
 
 	tell_status "configuring Haraka avg plugin"
-	mkdir -p "$STAGE_MNT/data/avg/spool" || exit
-
 	JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
 		mount += \"$ZFS_DATA_MNT/avg \$path/data/avg nullfs rw 0 0\";"
 

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -333,10 +333,12 @@ $(get_jail_ip "$j")		$j"
     _hosts="$_hosts
 $(get_jail_ip "minecraft")		minecraft
 $(get_jail_ip "joomla")		joomla
-$(get_jail_ip "php7") php7
-$(get_jail_ip "memcached") memcached
-$(get_jail_ip "sphinxsearch") sphinxsearch
-$(get_jail_ip "elasticsearch") elasticsearch
+$(get_jail_ip "php7") 	php7
+$(get_jail_ip "memcached") 	memcached
+$(get_jail_ip "sphinxsearch") 	sphinxsearch
+$(get_jail_ip "elasticsearch") 	elasticsearch
+$(get_jail_ip "nictool") 	nictool
+$(get_jail_ip "sqwebmail") 	sqwebmail
 
 "
 	echo "$_hosts" | tee -a "/etc/hosts"


### PR DESCRIPTION
### Changes proposed in this pull request:
- always create AVG mountpoint
    - so users that have a haraka section in jail.conf with AVG and perform a reinstall and do not provision AVG the second time, do not have holes in their feet.
- add a couple missing entries to /etc/hosts

see #91