### PR TITLE
Rainloop webmail

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1,21 +1,20 @@
 #!/bin/sh
 
-config()
+create_default_config()
 {
-	if [ ! -f "mail-toaster.conf" ]; then
-		local _HOSTNAME;
-		local _EMAIL_DOMAIN;
+	local _HOSTNAME;
+	local _EMAIL_DOMAIN;
 
-		echo "editing prefs"
-		_HOSTNAME=$(dialog --stdout --nocancel --backtitle "mail-toaster.sh" --title TOASTER_HOSTNAME --inputbox "the hostname of this [virtual] machine" 8 70 "mail.example.com")
-		_EMAIL_DOMAIN=$(dialog --stdout --nocancel --backtitle "mail-toaster.sh" --title TOASTER_MAIL_DOMAIN --inputbox "the primary email domain" 8 70 "example.com")
+	echo "editing prefs"
+	_HOSTNAME=$(dialog --stdout --nocancel --backtitle "mail-toaster.sh" --title TOASTER_HOSTNAME --inputbox "the hostname of this [virtual] machine" 8 70 "mail.example.com")
+	_EMAIL_DOMAIN=$(dialog --stdout --nocancel --backtitle "mail-toaster.sh" --title TOASTER_MAIL_DOMAIN --inputbox "the primary email domain" 8 70 "example.com")
 
-		# for Travis (Linux) where dialog doesn't exist
-		if [ -z "$_HOSTNAME"     ]; then _HOSTNAME=$(hostname); fi
-		if [ -z "$_EMAIL_DOMAIN" ]; then _EMAIL_DOMAIN=$(hostname); fi
+	# for Travis CI (Linux) where dialog doesn't exist
+	if [ -z "$_HOSTNAME"     ]; then _HOSTNAME=$(hostname); fi
+	if [ -z "$_EMAIL_DOMAIN" ]; then _EMAIL_DOMAIN=$(hostname); fi
 
-		echo "creating mail-toaster.conf with defaults"
-		tee mail-toaster.conf <<EO_MT_CONF
+	echo "creating mail-toaster.conf with defaults"
+	tee mail-toaster.conf <<EO_MT_CONF
 export TOASTER_HOSTNAME="$_HOSTNAME"
 export TOASTER_MAIL_DOMAIN="$_EMAIL_DOMAIN"
 export TOASTER_ADMIN_EMAIL="postmaster@${_EMAIL_DOMAIN}"
@@ -31,11 +30,18 @@ export ZFS_DATA_MNT="/data"
 export TOASTER_MYSQL="1"
 export TOASTER_MARIADB="0"
 export TOASTER_PKG_AUDIT="0"
+export SQUIRREL_SQL="1"
 
 EO_MT_CONF
+}
+
+config()
+{
+	if [ ! -f "mail-toaster.conf" ]; then
+		create_default_config
 	fi
 
-	echo "loading config from mail-toaster.conf"
+	echo "loading mail-toaster.conf"
 	# shellcheck disable=SC1091,SC2039
 	. mail-toaster.conf
 }
@@ -65,6 +71,8 @@ export FBSD_MIRROR=${FBSD_MIRROR:="ftp://ftp.freebsd.org"}
 # See https://github.com/msimerson/Mail-Toaster-6/wiki/MySQL
 export TOASTER_MYSQL=${TOASTER_MYSQL:="1"}
 export TOASTER_MARIADB=${TOASTER_MARIADB:="0"}
+export SQUIRREL_SQL=${SQUIRREL_SQL:="1"}
+
 if [ "$TOASTER_MYSQL" = "1" ]; then
 	echo "mysql enabled"
 fi

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -54,8 +54,8 @@ export BOURNE_SHELL=${BOURNE_SHELL:="bash"}
 export JAIL_NET_PREFIX=${JAIL_NET_PREFIX:="172.16.15"}
 export JAIL_NET_MASK=${JAIL_NET_MASK:="/12"}
 export JAIL_NET_INTERFACE=${JAIL_NET_INTERFACE:="lo1"}
-export JAIL_STARTUP_LIST=${JAIL_STARTUP_LIST:="dns mysql vpopmail dovecot webmail haproxy clamav avg redis rspamd geoip spamassassin haraka monitor"}
-export JAIL_ORDERED_LIST="syslog base dns mysql clamav spamassassin dspam vpopmail haraka webmail monitor haproxy rspamd avg dovecot redis geoip nginx lighttpd apache postgres minecraft joomla php7 memcached spinxsearch elasticsearch nictool sqwebmail dhcp letsencrypt tinydns"
+export JAIL_STARTUP_LIST=${JAIL_STARTUP_LIST:="dns mysql vpopmail dovecot webmail roundcube haproxy clamav avg redis rspamd geoip spamassassin haraka monitor"}
+export JAIL_ORDERED_LIST="syslog base dns mysql clamav spamassassin dspam vpopmail haraka webmail monitor haproxy rspamd avg dovecot redis geoip nginx lighttpd apache postgres minecraft joomla php7 memcached spinxsearch elasticsearch nictool sqwebmail dhcp letsencrypt tinydns roundcube squirrelmail rainloop"
 
 export ZFS_VOL=${ZFS_VOL:="zroot"}
 export ZFS_JAIL_MNT=${ZFS_JAIL_MNT:="/jails"}

--- a/provision-base.sh
+++ b/provision-base.sh
@@ -232,7 +232,7 @@ weekly_output="$TOASTER_ADMIN_EMAIL"
 monthly_output="$TOASTER_ADMIN_EMAIL"
 
 security_show_success="NO"
-security_show_info="YES"
+security_show_info="NO"
 security_status_pkgaudit_enable="YES"
 security_status_tcpwrap_enable="YES"
 daily_status_security_inline="NO"

--- a/provision-haproxy.sh
+++ b/provision-haproxy.sh
@@ -28,6 +28,12 @@ global
     maxconn     256  # Total Max Connections. This is dependent on ulimit
     nbproc      1
     ssl-default-bind-options no-sslv3 no-tls-tickets
+    ssl-dh-param-file /data/ssl/dhparam.pem
+    tune.ssl.default-dh-param 2048
+    option      httpclose
+    option      http-server-close
+    option      log-separate-errors
+    log         global
 
 defaults
     mode        http
@@ -56,7 +62,7 @@ frontend http-in
 
 frontend https-in
     bind *:443 ssl crt /etc/ssl/private
-    # ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128:AES256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK
+    # ciphers AES128+EECDH:AES128+EDH
     reqadd X-Forwarded-Proto:\ https
     default_backend www_webmail
 
@@ -74,16 +80,22 @@ frontend https-in
     acl sqwebmail    path_beg /cgi-bin/sqwebmail
     acl isoqlog      path_beg /isoqlog
     acl rspamd       path_beg /rspamd
+    acl roundcube    path_beg /roundcube
+    acl rainloop     path_beg /rainloop
+    acl squirrelmail path_beg /squirrelmail
 
     use_backend websocket_haraka if  is_websocket
-    use_backend www_monitor    if  munin
-    use_backend www_monitor    if  nagios
-    use_backend www_haraka     if  watch
-    use_backend www_vpopmail   if  qmailadmin
-    use_backend www_sqwebmail  if  sqwebmail
-    use_backend www_vpopmail   if  isoqlog
-    use_backend www_haraka     if  haraka
-    use_backend www_rspamd     if  rspamd
+    use_backend www_monitor      if  munin
+    use_backend www_monitor      if  nagios
+    use_backend www_haraka       if  watch
+    use_backend www_vpopmail     if  qmailadmin
+    use_backend www_sqwebmail    if  sqwebmail
+    use_backend www_vpopmail     if  isoqlog
+    use_backend www_haraka       if  haraka
+    use_backend www_rspamd       if  rspamd
+    use_backend www_roundcube    if  roundcube
+    use_backend www_rainloop     if  rainloop
+    use_backend www_squirrelmail if  squirrelmail
 
     default_backend www_webmail
 
@@ -131,8 +143,18 @@ EO_HAPROXY_CONF
 	else
 		tell_status "concatenating server key and crt to PEM"
 		cat /etc/ssl/private/server.key /etc/ssl/certs/server.crt \
-			> "$STAGE_MNT/etc/ssl/private/server.pem" || exit
+			> "$STAGE_MNT/etc/ssl/private/server.pem" || exit 1
 	fi
+
+    if [ ! -d "$ZFS_DATA_MNT/haproxy/ssl" ]; then
+        mkdir -p "$ZFS_DATA_MNT/haproxy/ssl" || exit 1
+    fi
+
+    if [ ! -f "$ZFS_DATA_MNT/haproxy/ssl" ]; then
+        tell_status "creating dhparam file for haproxy"
+        openssl dharam 2048 -out "$ZFS_DATA_MNT/haproxy/ssl/dhparam.pem"
+    fi
+
 }
 
 start_haproxy()

--- a/provision-haproxy.sh
+++ b/provision-haproxy.sh
@@ -108,12 +108,14 @@ backend www_webmail
 
 backend www_roundcube
     server roundcube $(get_jail_ip roundcube):80
+    reqirep ^([^\ :]*)\ /roundcube/(.*)    \1\ /\2
 
 backend www_squirrelmail
     server squirrelmail $(get_jail_ip squirrelmail):80
 
 backend www_rainloop
     server rainloop $(get_jail_ip rainloop):80
+    reqirep ^([^\ :]*)\ /rainloop/(.*)    \1\ /\2
 
 backend www_monitor
     server monitor $(get_jail_ip monitor):80

--- a/provision-haproxy.sh
+++ b/provision-haproxy.sh
@@ -106,6 +106,15 @@ backend websocket_haraka
 backend www_webmail
     server webmail $(get_jail_ip webmail):80
 
+backend www_roundcube
+    server roundcube $(get_jail_ip roundcube):80
+
+backend www_squirrelmail
+    server squirrelmail $(get_jail_ip squirrelmail):80
+
+backend www_rainloop
+    server rainloop $(get_jail_ip rainloop):80
+
 backend www_monitor
     server monitor $(get_jail_ip monitor):80
 

--- a/provision-letsencrypt.sh
+++ b/provision-letsencrypt.sh
@@ -15,7 +15,7 @@ install_letsencrypt()
 	local _installer="$STAGE_MNT/acme.sh"
 	fetch -o $_installer https://raw.githubusercontent.com/Neilpang/acme.sh/master/acme.sh
 	sed -i.bak -e '/^DEFAULT_INSTALL_HOME=/ s/=.*$/="\/data"/' $_installer
-	stage_exec sh /acme.sh --install
+	stage_exec sh /data/acme.sh --install
 }
 
 # shellcheck disable=SC2120
@@ -29,41 +29,42 @@ install_deploy_haproxy()
 
 #domain keyfile certfile cafile fullchain
 haproxy_deploy() {
-  _cdomain="$1"
-  _ckey="$2"
-  _ccert="$3"
-  _cca="$4"
-  _cfullchain="$5"
+	_cdomain="$1"
+	_ckey="$2"
+	_ccert="$3"
+	_cca="$4"
+	_cfullchain="$5"
 
-  if [ ! -f $_ccert ]; then
-    _err "missing certificate"
-    exit 2
-  fi
+	if [ ! -f $_ccert ]; then
+		_err "missing certificate"
+		exit 2
+	fi
 
-  local _tmp="/tmp/${_cdomain}.pem"
-  cat $_ckey $_ccert $_cfullchain > $_tmp
-  if [ -s "$_tmp" ]; then
-    _debug "$_tmp created"
-    local _installed="/data/haproxy/ssl.d/$_cdomain.pem"
-    if diff -q $_tmp $_installed; then
-      _debug "cert is the same, skip deploy"
-      return 0
-    fi
+	local _tmp="/tmp/${_cdomain}.pem"
+	cat $_ckey $_ccert $_cfullchain > $_tmp
+	if [ ! -s "$_tmp" ]; then
+		_err "Unable to create $_tmp"
+		return 1
+	fi
 
-    cp $_tmp $_installed || return 1
-    if [ -s "$_installed" ]; then
-      rm $_tmp
-      _debug "restarting haproxy"
-      jexec haproxy service haproxy restart
-      return 0
-    fi
+	_debug "$_tmp created"
+	local _installed="/data/haproxy/ssl.d/$_cdomain.pem"
+	if diff -q $_tmp $_installed; then
+		_debug "cert is the same, skip deploy"
+		return 0
+	fi
 
-    _err "install to $_installed failed"
-    return 1
-  fi
+	_debug "cp $_tmp $_installed"
+	cp $_tmp $_installed || return 1
+	if [ ! -s "$_installed" ]; then
+		_err "install to $_installed failed"
+		return 1
+	fi
 
-  _err "Unable to create $_tmp"
-  return 1
+	rm $_tmp
+	_debug "restarting haproxy"
+	jexec haproxy service haproxy restart
+	return 0
 }
 EO_LE_HAPROXY
 }
@@ -77,42 +78,42 @@ install_deploy_dovecot()
 
 #domain keyfile certfile cafile fullchain
 dovecot_deploy() {
-  _cdomain="$1"
-  _ckey="$2"
-  _ccert="$3"
-  _cca="$4"
-  _cfullchain="$5"
+	_cdomain="$1"
+	_ckey="$2"
+	_ccert="$3"
+	_cca="$4"
+	_cfullchain="$5"
 
-  if [ ! -f $_ccert ]; then
-    _err "missing certificate"
-    exit 2
-  fi
+	if [ ! -f $_ccert ]; then
+		_err "missing certificate"
+		exit 2
+	fi
 
-  local _tmp_crt="/tmp/dovecot-cert-${_cdomain}.pem"
-  cat $_ccert $_cfullchain > $_tmp_crt
-  if [ -s "$_tmp_crt" ]; then
-    _debug "$_tmp_crt created"
-    local _installed="/data/dovecot/etc/ssl/certs/dovecot.pem"
-    if diff -q $_tmp_crt $_installed; then
-      _debug "cert is the same, skip deploy"
-      return 0
-    fi
+	local _tmp_crt="/tmp/dovecot-cert-${_cdomain}.pem"
+	cat $_ccert $_cfullchain > $_tmp_crt
+	if [ ! -s "$_tmp_crt" ]; then
+		_err "Unable to create $_tmp_crt"
+		return 1
+	fi
 
-    cp $_tmp $_installed || return 1
-    cp $_ckey /data/dovecot/etc/ssl/private/dovecot.pem || return 1
-    if [ -s "$_installed" ]; then
-      rm $_tmp
-      _debug "restarting dovecot"
-      jexec dovecot service dovecot restart
-      return 0
-    fi
+	_debug "$_tmp_crt created"
+	local _installed="/data/dovecot/etc/ssl/certs/dovecot.pem"
+	if diff -q $_tmp_crt $_installed; then
+		_debug "cert is the same, skip deploy"
+		return 0
+	fi
 
-    _err "install to $_installed failed"
-    return 1
-  fi
+	cp $_tmp_crt $_installed || return 1
+	cp $_ckey /data/dovecot/etc/ssl/private/dovecot.pem || return 1
+	if [ -s "$_installed" ]; then
+		rm $_tmp_crt
+		_debug "restarting dovecot"
+		jexec dovecot service dovecot restart
+		return 0
+	fi
 
-  _err "Unable to create $_tmp"
-  return 1
+	_err "install to $_installed failed"
+	return 1
 }
 EO_LE_DOVECOT
 }
@@ -128,43 +129,43 @@ install_deploy_haraka()
 
 #domain keyfile certfile cafile fullchain
 haraka_deploy() {
-  _cdomain="$1"
-  _ckey="$2"
-  _ccert="$3"
-  _cca="$4"
-  _cfullchain="$5"
+	_cdomain="$1"
+	_ckey="$2"
+	_ccert="$3"
+	_cca="$4"
+	_cfullchain="$5"
 
-  if [ ! -f $_ccert ]; then
-    _err "missing certificate"
-    exit 2
-  fi
+	if [ ! -f $_ccert ]; then
+		_err "missing certificate"
+		exit 2
+	fi
 
-  local _tmp="/tmp/${_cdomain}.pem"
-  cat $_ckey $_ccert $_cfullchain > $_tmp
-  if [ -s "$_tmp" ]; then
-    _debug "$_tmp created"
-    local _installed="/data/haraka/config/tls_cert.pem"
-    if diff -q $_tmp $_installed; then
-      _debug "cert is the same, skip deploy"
-      return 0
-    fi
+	local _tmp="/tmp/${_cdomain}.pem"
+	cat $_ckey $_ccert $_cfullchain > $_tmp
+	if [ -s "$_tmp" ]; then
+		_debug "$_tmp created"
+		local _installed="/data/haraka/config/tls_cert.pem"
+		if diff -q $_tmp $_installed; then
+			_debug "cert is the same, skip deploy"
+			return 0
+		fi
 
-    cp $_tmp $_installed || return 1
-    cp $_ckey /data/haraka/config/tls_key.pem || return 1
+		cp $_tmp $_installed || return 1
+		cp $_ckey /data/haraka/config/tls_key.pem || return 1
 
-    if [ -s "$_installed" ]; then
-      rm $_tmp
-      _debug "restarting haraka"
-      service jail restart haraka
-      return 0
-    fi
+		if [ -s "$_installed" ]; then
+			rm $_tmp
+			_debug "restarting haraka"
+			service jail restart haraka
+			return 0
+		fi
 
-    _err "install to $_installed failed"
-    return 1
-  fi
+		_err "install to $_installed failed"
+		return 1
+	fi
 
-  _err "Unable to create $_tmp"
-  return 1
+	_err "Unable to create $_tmp"
+	return 1
 }
 EO_LE_HARAKA
 }
@@ -187,24 +188,50 @@ configure_letsencrypt()
 
 	install_deploy_scripts
 
-	local _HTTPDIR="/data/webmail/htdocs"
-	stage_exec /data/acme.sh --issue  --staging -d $TOASTER_HOSTNAME -w $_HTTPDIR
-	stage_exec /data/acme.sh --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook haproxy
-	stage_exec /data/acme.sh --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook dovecot
-	stage_exec /data/acme.sh --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook haraka
+	sed -i.bak \
+		-e '/^DEFAULT_INSTALL_HOME=/ s/=.*$/="\/data\/letsencrypt"/' \
+		"$ZFS_DATA_MNT/letsencrypt/acme.sh"
+
+	local _HTTPDIR="$ZFS_DATA_MNT/webmail/htdocs"
+	local _acme="$ZFS_DATA_MNT/letsencrypt/acme.sh"
+	$_acme --issue --force -d $TOASTER_HOSTNAME -w $_HTTPDIR
+	$_acme --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook haproxy
+	$_acme --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook dovecot
+	$_acme --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook haraka
 }
 
 start_letsencrypt()
 {
 	tell_status "starting Let's Encrypt"
 
+	if [ ! -d "/usr/local/etc/periodic/daily" ]; then
+		mkdir "/usr/local/etc/periodic/daily" || exit
+	fi
 
-	echo "TODO: add a periodic task to keep certs up-to-date"
+	local _script="/usr/local/etc/periodic/daily/mt6-letsencrypt"
+	if [ -f $_script ]; then
+		tell_status "periodic installed"
+		return
+	fi
+
+	tell_status "installing periodic job to keep certs updated"
+	tee $_script <<EO_LE_PERIODIC
+#!/bin/sh
+
+_acme="$ZFS_DATA_MNT/letsencrypt/acme.sh"
+\$_acme --issue -d $TOASTER_HOSTNAME -w $_HTTPDIR || exit 0
+\$_acme --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook haproxy
+\$_acme --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook dovecot
+\$_acme --deploy -d $TOASTER_HOSTNAME -w $_HTTPDIR --deploy-hook haraka
+
+EO_LE_PERIODIC
+
+	chmod 755 $_script
 }
 
 test_letsencrypt()
 {
-	if [ ! -f "$ZFS_DATA_MNT/letsencrypt/.acme.sh" ]; then
+	if [ ! -f "$ZFS_DATA_MNT/letsencrypt/acme.sh" ]; then
 		echo "not installed!"
 		exit
 	fi

--- a/provision-nginx.sh
+++ b/provision-nginx.sh
@@ -10,12 +10,7 @@ export JAIL_CONF_EXTRA="
 
 install_nginx()
 {
-	stage_pkg_install nginx dialog4ports || exit
-
-	tell_status "building nginx with HTTP_REALIP option"
-	export BATCH=${BATCH:="1"}
-	stage_make_conf www_nginx 'www_nginx_SET=HTTP_REALIP'
-	stage_exec make -C /usr/ports/www/nginx build deinstall install clean
+	stage_pkg_install nginx || exit
 }
 
 configure_nginx()

--- a/provision-php7.sh
+++ b/provision-php7.sh
@@ -47,7 +47,6 @@ start_php()
 	tell_status "starting PHP"
 	stage_sysrc php_fpm_enable=YES
 	stage_exec service php-fpm start
-
 }
 
 test_php()

--- a/provision-rainloop.sh
+++ b/provision-rainloop.sh
@@ -6,12 +6,12 @@
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/roundcube \$path/data nullfs rw 0 0\";"
+		mount += \"$ZFS_DATA_MNT/rainloop \$path/data nullfs rw 0 0\";"
 
 install_php()
 {
 	tell_status "installing PHP"
-	stage_pkg_install php56 php56-fileinfo php56-mcrypt php56-exif php56-openssl
+	stage_pkg_install php56
 
 	local _php_ini="$STAGE_MNT/usr/local/etc/php.ini"
 	cp "$STAGE_MNT/usr/local/etc/php.ini-production" "$_php_ini" || exit
@@ -27,112 +27,112 @@ install_php()
 	fi
 }
 
-install_roundcube_mysql()
+install_rainloop_mysql()
 {
 	local _init_db=0
-	if ! mysql_db_exists roundcubemail; then
-		tell_status "creating roundcube mysql db"
-		echo "CREATE DATABASE roundcubemail;" | jexec mysql /usr/local/bin/mysql || exit
+	if ! mysql_db_exists rainloopmail; then
+		tell_status "creating rainloop mysql db"
+		echo "CREATE DATABASE rainloopmail;" | jexec mysql /usr/local/bin/mysql || exit
 		_init_db=1
 	fi
 
-	local _active_cfg="$ZFS_JAIL_MNT/roundcube/usr/local/www/roundcube/config/config.inc.php"
+	local _active_cfg="$ZFS_JAIL_MNT/rainloop/usr/local/www/rainloop/config/config.inc.php"
 	if [ -f "$_active_cfg" ]; then
 		local _rcpass
 		# shellcheck disable=2086
-		_rcpass=$(grep '//roundcube:' $_active_cfg | grep ^\$config | cut -f3 -d: | cut -f1 -d@)
+		_rcpass=$(grep '//rainloop:' $_active_cfg | grep ^\$config | cut -f3 -d: | cut -f1 -d@)
 		if [ -n "$_rcpass" ] && [ "$_rcpass" != "pass" ]; then
-			echo "preserving roundcube password $_rcpass"
+			echo "preserving rainloop password $_rcpass"
 		fi
 	else
 		_rcpass=$(openssl rand -hex 18)
 	fi
 
-	local _rcc_dir="$STAGE_MNT/usr/local/www/roundcube/config"
+	local _rcc_dir="$STAGE_MNT/usr/local/www/rainloop/config"
 	sed -i .bak \
-		-e "s/roundcube:pass@/roundcube:${_rcpass}@/" \
+		-e "s/rainloop:pass@/rainloop:${_rcpass}@/" \
 		-e "s/@localhost\//@$(get_jail_ip mysql)\//" \
 		"$_rcc_dir/config.inc.php" || exit
 
 	if [ "$_init_db" = "1" ]; then
-		tell_status "configuring roundcube mysql permissions"
-		local _grant='GRANT ALL PRIVILEGES ON roundcubemail.* to'
+		tell_status "configuring rainloop mysql permissions"
+		local _grant='GRANT ALL PRIVILEGES ON rainloopmail.* to'
 
-		echo "$_grant 'roundcube'@'$(get_jail_ip roundcube)' IDENTIFIED BY '${_rcpass}';" \
+		echo "$_grant 'rainloop'@'$(get_jail_ip rainloop)' IDENTIFIED BY '${_rcpass}';" \
 			| jexec mysql /usr/local/bin/mysql || exit
 
-		echo "$_grant 'roundcube'@'$(get_jail_ip stage)' IDENTIFIED BY '${_rcpass}';" \
+		echo "$_grant 'rainloop'@'$(get_jail_ip stage)' IDENTIFIED BY '${_rcpass}';" \
 			| jexec mysql /usr/local/bin/mysql || exit
 
-		roundcube_init_db
+		rainloop_init_db
 	fi
 }
 
-roundcube_init_db()
+rainloop_init_db()
 {
-	tell_status "initializating roundcube db"
+	tell_status "initializating rainloop db"
 	pkg install -y curl || exit
 	stage_exec service php-fpm restart
 	curl -i -F initdb='Initialize database' -XPOST \
-		"http://$(get_jail_ip stage)/roundcube/installer/index.php?_step=3" || exit
+		"http://$(get_jail_ip stage)/rainloop/installer/index.php?_step=3" || exit
 }
 
-install_roundcube()
+install_rainloop()
 {
 	install_php || exit
 	install_nginx || exit
 
-	tell_status "installing roundcube"
-	stage_pkg_install roundcube
+	tell_status "installing rainloop"
+	stage_pkg_install rainloop-community
 
 	# for sqlite storage
-	mkdir -p "$STAGE_MNT/data"
-	chown 80:80 "$STAGE_MNT/data"
+	# mkdir -p "$STAGE_MNT/data"
+	# chown 80:80 "$STAGE_MNT/data"
 
-	local _rcc_conf="$STAGE_MNT/usr/local/www/roundcube/config/config.inc.php"
-	cp "$_rcc_conf.sample" "$_rcc_conf" || exit
+	# local _rcc_conf="$STAGE_MNT/usr/local/www/rainloop/config/config.inc.php"
+	# cp "$_rcc_conf.sample" "$_rcc_conf" || exit
 
-	local _dovecot_ip; _dovecot_ip=$(get_jail_ip dovecot)
-	sed -i .bak \
-		-e "/'default_host'/ s/'localhost'/'$_dovecot_ip'/" \
-		-e "/'smtp_server'/  s/'';/'tls:\/\/haraka';/" \
-		-e "/'smtp_port'/    s/25;/587;/" \
-		-e "/'smtp_user'/    s/'';/'%u';/" \
-		-e "/'smtp_pass'/    s/'';/'%p';/" \
-		"$_rcc_conf"
+	# local _dovecot_ip; _dovecot_ip=$(get_jail_ip dovecot)
+	# sed -i .bak \
+	# 	-e "/'default_host'/ s/'localhost'/'$_dovecot_ip'/" \
+	# 	-e "/'smtp_server'/  s/'';/'tls:\/\/haraka';/" \
+	# 	-e "/'smtp_port'/    s/25;/587;/" \
+	# 	-e "/'smtp_user'/    s/'';/'%u';/" \
+	# 	-e "/'smtp_pass'/    s/'';/'%p';/" \
+	# 	"$_rcc_conf"
 
-	tee -a "$_rcc_conf" <<'EO_RC_ADD'
+# 	tee -a "$_rcc_conf" <<'EO_RC_ADD'
 
-$config['log_driver'] = 'syslog';
-$config['session_lifetime'] = 30;
-$config['enable_installer'] = true;
-$config['mime_types'] = '/usr/local/etc/mime.types';
-$config['smtp_conn_options'] = array(
- 'ssl'            => array(
-   'verify_peer'  => false,
-   'verify_peer_name' => false,
-   'verify_depth' => 3,
-   'cafile'       => '/etc/ssl/cert.pem',
- ),
-);
-EO_RC_ADD
+# $config['log_driver'] = 'syslog';
+# $config['session_lifetime'] = 30;
+# $config['enable_installer'] = true;
+# $config['mime_types'] = '/usr/local/etc/mime.types';
+# $config['smtp_conn_options'] = array(
+#  'ssl'            => array(
+#    'verify_peer'  => false,
+#    'verify_peer_name' => false,
+#    'verify_depth' => 3,
+#    'cafile'       => '/etc/ssl/cert.pem',
+#  ),
+# );
+# EO_RC_ADD
 
 	if [ "$TOASTER_MYSQL" = "1" ]; then
-		install_roundcube_mysql
+		# install_rainloop_mysql
 	else
-		stage_pkg_install php56-pdo_sqlite
-		sed -i.bak \
-			-e "/^\$config\['db_dsnw'/ s/= .*/= 'sqlite:\/\/\/\/data\/sqlite.db?mode=0646';/" \
-			"$_rcc_conf"
+		# stage_pkg_install php56-pdo_sqlite
+		# sed -i.bak \
+		# 	-e "/^\$config\['db_dsnw'/ s/= .*/= 'sqlite:\/\/\/\/data\/sqlite.db?mode=0646';/" \
+		# 	"$_rcc_conf"
 
-		if [ ! -f "$ZFS_DATA_MNT/roundcube/sqlite.db" ]; then
-			roundcube_init_db
-		fi
+		# if [ ! -f "$ZFS_DATA_MNT/rainloop/sqlite.db" ]; then
+		# 	rainloop_init_db
+		# fi
 	fi
 
-	sed -i.bak \
-		-e "s/enable_installer'] = true;/enable_installer'] = false;/" \
-		"$_rcc_conf"
+	# sed -i.bak \
+	# 	-e "s/enable_installer'] = true;/enable_installer'] = false;/" \
+	# 	"$_rcc_conf"
 }
 
 install_nginx()
@@ -147,7 +147,7 @@ install_nginx()
      server {
          listen       80;
 -        server_name  localhost;
-+        server_name  roundcube;
++        server_name  rainloop;
  
          #charset koi8-r;
  
@@ -156,11 +156,11 @@ install_nginx()
          location / {
 -            root   /usr/local/www/nginx;
 -            index  index.html index.htm;
-+            root   /usr/local/www/roundcube;
++            root   /usr/local/www/rainloop;
 +            index  index.php;
          }
  
-+        location /roundcube/ {
++        location /rainloop/ {
 +            root /usr/local/www;
 +            index  index.php;
 +        }
@@ -184,7 +184,7 @@ install_nginx()
 -        #    include        fastcgi_params;
 -        #}
 +        location ~ \.php$ {
-+            root           /usr/local/www;
++            root           /usr/local/www/rainloop;
 +            fastcgi_pass   127.0.0.1:9000;
 +            fastcgi_index  index.php;
 +            fastcgi_param  SCRIPT_FILENAME  $document_root/$fastcgi_script_name;
@@ -196,14 +196,14 @@ install_nginx()
 EO_NGINX_CONF
 }
 
-configure_roundcube()
+configure_rainloop()
 {
 	tell_status "installing mime.types"
 	fetch -o "$STAGE_MNT/usr/local/etc/mime.types" \
 		http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
 }
 
-start_roundcube()
+start_rainloop()
 {
 	tell_status "starting PHP"
 	stage_sysrc php_fpm_enable=YES
@@ -214,21 +214,21 @@ start_roundcube()
 	stage_exec service nginx start
 }
 
-test_roundcube()
+test_rainloop()
 {
-	tell_status "testing roundcube httpd"
+	tell_status "testing rainloop httpd"
 	stage_listening 80
 
-	tell_status "testing roundcube php"
+	tell_status "testing rainloop php"
 	stage_listening 9000
 	echo "it worked"
 }
 
 base_snapshot_exists || exit
-create_staged_fs roundcube
+create_staged_fs rainloop
 start_staged_jail
-install_roundcube
-configure_roundcube
-start_roundcube
-test_roundcube
-promote_staged_jail roundcube
+install_rainloop
+configure_rainloop
+start_rainloop
+test_rainloop
+promote_staged_jail rainloop

--- a/provision-roundcube.sh
+++ b/provision-roundcube.sh
@@ -141,8 +141,8 @@ install_nginx()
 
 	patch -d "$STAGE_MNT/usr/local/etc/nginx" <<'EO_NGINX_CONF'
 --- nginx.conf-dist	2016-11-03 05:11:28.000000000 -0700
-+++ nginx.conf	2016-12-07 16:29:52.835309001 -0800
-@@ -41,17 +41,26 @@
++++ nginx.conf	2016-12-07 14:54:31.075259094 -0800
+@@ -41,17 +41,21 @@
  
      server {
          listen       80;

--- a/provision-roundcube.sh
+++ b/provision-roundcube.sh
@@ -141,8 +141,8 @@ install_nginx()
 
 	patch -d "$STAGE_MNT/usr/local/etc/nginx" <<'EO_NGINX_CONF'
 --- nginx.conf-dist	2016-11-03 05:11:28.000000000 -0700
-+++ nginx.conf	2016-12-07 14:54:31.075259094 -0800
-@@ -41,17 +41,21 @@
++++ nginx.conf	2016-12-07 16:29:52.835309001 -0800
+@@ -41,17 +41,26 @@
  
      server {
          listen       80;

--- a/provision-roundcube.sh
+++ b/provision-roundcube.sh
@@ -184,10 +184,10 @@ install_nginx()
 -        #    include        fastcgi_params;
 -        #}
 +        location ~ \.php$ {
-+            root           /usr/local/www;
++            root           /usr/local/www/roundcube;
 +            fastcgi_pass   127.0.0.1:9000;
 +            fastcgi_index  index.php;
-+            fastcgi_param  SCRIPT_FILENAME  $document_root/$fastcgi_script_name;
++            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
 +            include        fastcgi_params;
 +        }
  

--- a/provision-roundcube.sh
+++ b/provision-roundcube.sh
@@ -1,0 +1,234 @@
+#!/bin/sh
+
+# shellcheck disable=1091
+. mail-toaster.sh || exit
+
+export JAIL_START_EXTRA=""
+# shellcheck disable=2016
+export JAIL_CONF_EXTRA="
+		mount += \"$ZFS_DATA_MNT/roundcube \$path/data nullfs rw 0 0\";"
+
+install_php()
+{
+	tell_status "installing PHP"
+	stage_pkg_install php56 php56-fileinfo php56-mcrypt php56-exif php56-openssl
+
+	local _php_ini="$STAGE_MNT/usr/local/etc/php.ini"
+	cp "$STAGE_MNT/usr/local/etc/php.ini-production" "$_php_ini" || exit
+	sed -i .bak \
+		-e 's/^;date.timezone =/date.timezone = America\/Los_Angeles/' \
+		-e '/^post_max_size/ s/8M/25M/' \
+		-e '/^upload_max_filesize/ s/2M/25M/' \
+		"$_php_ini"
+
+	if [ "$TOASTER_MYSQL" = "1" ]; then
+		tell_status "install php mysql module"
+		stage_pkg_install php56-mysql
+	fi
+}
+
+install_roundcube_mysql()
+{
+	local _init_db=0
+	if ! mysql_db_exists roundcubemail; then
+		tell_status "creating roundcube mysql db"
+		echo "CREATE DATABASE roundcubemail;" | jexec mysql /usr/local/bin/mysql || exit
+		_init_db=1
+	fi
+
+	local _active_cfg="$ZFS_JAIL_MNT/roundcube/usr/local/www/roundcube/config/config.inc.php"
+	if [ -f "$_active_cfg" ]; then
+		local _rcpass
+		# shellcheck disable=2086
+		_rcpass=$(grep '//roundcube:' $_active_cfg | grep ^\$config | cut -f3 -d: | cut -f1 -d@)
+		if [ -n "$_rcpass" ] && [ "$_rcpass" != "pass" ]; then
+			echo "preserving roundcube password $_rcpass"
+		fi
+	else
+		_rcpass=$(openssl rand -hex 18)
+	fi
+
+	local _rcc_dir="$STAGE_MNT/usr/local/www/roundcube/config"
+	sed -i .bak \
+		-e "s/roundcube:pass@/roundcube:${_rcpass}@/" \
+		-e "s/@localhost\//@$(get_jail_ip mysql)\//" \
+		"$_rcc_dir/config.inc.php" || exit
+
+	if [ "$_init_db" = "1" ]; then
+		tell_status "configuring roundcube mysql permissions"
+		local _grant='GRANT ALL PRIVILEGES ON roundcubemail.* to'
+
+		echo "$_grant 'roundcube'@'$(get_jail_ip roundcube)' IDENTIFIED BY '${_rcpass}';" \
+			| jexec mysql /usr/local/bin/mysql || exit
+
+		echo "$_grant 'roundcube'@'$(get_jail_ip stage)' IDENTIFIED BY '${_rcpass}';" \
+			| jexec mysql /usr/local/bin/mysql || exit
+
+		roundcube_init_db
+	fi
+}
+
+roundcube_init_db()
+{
+	tell_status "initializating roundcube db"
+	pkg install -y curl || exit
+	stage_exec service php-fpm restart
+	curl -i -F initdb='Initialize database' -XPOST \
+		"http://$(get_jail_ip stage)/roundcube/installer/index.php?_step=3" || exit
+}
+
+install_roundcube()
+{
+	install_php || exit
+	install_nginx || exit
+
+	tell_status "installing roundcube"
+	stage_pkg_install roundcube
+
+	# for sqlite storage
+	mkdir -p "$STAGE_MNT/data/roundcube"
+	chown 80:80 "$STAGE_MNT/data/roundcube"
+
+	local _rcc_conf="$STAGE_MNT/usr/local/www/roundcube/config/config.inc.php"
+	cp "$_rcc_conf.sample" "$_rcc_conf" || exit
+
+	local _dovecot_ip; _dovecot_ip=$(get_jail_ip dovecot)
+	sed -i .bak \
+		-e "/'default_host'/ s/'localhost'/'$_dovecot_ip'/" \
+		-e "/'smtp_server'/  s/'';/'tls:\/\/haraka';/" \
+		-e "/'smtp_port'/    s/25;/587;/" \
+		-e "/'smtp_user'/    s/'';/'%u';/" \
+		-e "/'smtp_pass'/    s/'';/'%p';/" \
+		"$_rcc_conf"
+
+	tee -a "$_rcc_conf" <<'EO_RC_ADD'
+
+$config['log_driver'] = 'syslog';
+$config['session_lifetime'] = 30;
+$config['enable_installer'] = true;
+$config['mime_types'] = '/usr/local/etc/mime.types';
+$config['smtp_conn_options'] = array(
+ 'ssl'            => array(
+   'verify_peer'  => false,
+   'verify_peer_name' => false,
+   'verify_depth' => 3,
+   'cafile'       => '/etc/ssl/cert.pem',
+ ),
+);
+EO_RC_ADD
+
+	if [ "$TOASTER_MYSQL" = "1" ]; then
+		install_roundcube_mysql
+	else
+		stage_pkg_install php56-pdo_sqlite
+		sed -i.bak \
+			-e "/^\$config\['db_dsnw'/ s/= .*/= 'sqlite:\/\/\/\/data\/roundcube\/sqlite.db?mode=0646';/" \
+			"$_rcc_conf"
+
+		if [ ! -f "$ZFS_DATA_MNT/roundcube/roundcube/sqlite.db" ]; then
+			roundcube_init_db
+		fi
+	fi
+
+	sed -i.bak \
+		-e "s/enable_installer'] = true;/enable_installer'] = false;/" \
+		"$_rcc_conf"
+}
+
+install_nginx()
+{
+	stage_pkg_install nginx || exit
+
+	patch -d "$STAGE_MNT/usr/local/etc/nginx" <<'EO_NGINX_CONF'
+--- nginx.conf-dist	2016-11-03 05:11:28.000000000 -0700
++++ nginx.conf	2016-12-07 16:29:52.835309001 -0800
+@@ -41,17 +41,26 @@
+ 
+     server {
+         listen       80;
+-        server_name  localhost;
++        server_name  roundcube;
+ 
+         #charset koi8-r;
+ 
+         #access_log  logs/host.access.log  main;
+ 
+         location / {
+-            root   /usr/local/www/nginx;
+-            index  index.html index.htm;
++            root   /usr/local/www/roundcube;
++            index  index.php;
+         }
+ 
++        location /roundcube/ {
++            root /usr/local/www;
++            index  index.php;
++        }
++
++        set_real_ip_from 172.16.15.12;
++        real_ip_header X-Forwarded-For;
++        client_max_body_size 25m;
++
+         #error_page  404              /404.html;
+ 
+         # redirect server error pages to the static page /50x.html
+@@ -69,13 +78,13 @@
+ 
+         # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+         #
+-        #location ~ \.php$ {
+-        #    root           html;
+-        #    fastcgi_pass   127.0.0.1:9000;
+-        #    fastcgi_index  index.php;
+-        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+-        #    include        fastcgi_params;
+-        #}
++        location ~ \.php$ {
++            root           /usr/local/www/roundcube;
++            fastcgi_pass   127.0.0.1:9000;
++            fastcgi_index  index.php;
++            fastcgi_param  SCRIPT_FILENAME  $document_root/$fastcgi_script_name;
++            include        fastcgi_params;
++        }
+ 
+         # deny access to .htaccess files, if Apache's document root
+         # concurs with nginx's one
+EO_NGINX_CONF
+}
+
+configure_roundcube()
+{
+	tell_status "installing mime.types"
+	fetch -o "$STAGE_MNT/usr/local/etc/mime.types" \
+		http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+}
+
+start_roundcube()
+{
+	tell_status "starting PHP"
+	stage_sysrc php_fpm_enable=YES
+	stage_exec service php-fpm start
+
+	tell_status "starting nginx"
+	stage_sysrc nginx_enable=YES
+	stage_exec service nginx start
+}
+
+test_roundcube()
+{
+	tell_status "testing roundcube httpd"
+	stage_listening 80
+
+	tell_status "testing roundcube php"
+	stage_listening 9000
+	echo "it worked"
+}
+
+base_snapshot_exists || exit
+create_staged_fs roundcube
+start_staged_jail
+install_roundcube
+configure_roundcube
+start_roundcube
+test_roundcube
+promote_staged_jail roundcube

--- a/provision-sphinxsearch.sh
+++ b/provision-sphinxsearch.sh
@@ -35,5 +35,3 @@ start_staged_jail
 install_sphinxsearch
 start_sphinxsearch
 promote_staged_jail sphinxsearch
-
-

--- a/provision-squirrelmail.sh
+++ b/provision-squirrelmail.sh
@@ -13,7 +13,7 @@ install_php()
 	tell_status "installing PHP"
 	stage_pkg_install php56 php56-fileinfo php56-mcrypt php56-exif php56-openssl
 
-	if [ "$TOASTER_MYSQL" = "1" ]; then
+	if [ "$SQUIRREL_SQL" = "1" ]; then
 		tell_status "install php mysql module"
 		stage_pkg_install php56-mysql
 	fi
@@ -29,9 +29,8 @@ install_php()
 
 install_squirrelmail_mysql()
 {
-	if [ "$TOASTER_MYSQL" != "1" ]; then return; fi
+	if [ "$SQUIRREL_SQL" != "1" ]; then return; fi
 
-	local _init_db=0
 	if ! mysql_db_exists squirrelmail; then
 		tell_status "creating squirrelmail database"
 		echo "CREATE DATABASE squirrelmail;" | jexec mysql /usr/local/bin/mysql || exit
@@ -92,7 +91,7 @@ install_squirrelmail()
 
 	_sq_dir="$STAGE_MNT/usr/local/www/squirrelmail/config"
 
-	local _active_cfg; _active_cfg="$_sq_dir/config.inc.php"
+	local _active_cfg; _active_cfg="$_sq_dir/config_local.php"
 	if [ -f "$_active_cfg" ]; then
 		_sqpass=$(grep '//squirrelmail:' "$_active_cfg" | cut -f3 -d: | cut -f1 -d@)
 		echo "preserving existing squirrelmail mysql password: $_sqpass"

--- a/provision-squirrelmail.sh
+++ b/provision-squirrelmail.sh
@@ -1,0 +1,248 @@
+#!/bin/sh
+
+# shellcheck disable=1091
+. mail-toaster.sh || exit
+
+export JAIL_START_EXTRA=""
+# shellcheck disable=2016
+export JAIL_CONF_EXTRA="
+		mount += \"$ZFS_DATA_MNT/squirrelmail \$path/data nullfs rw 0 0\";"
+
+install_php()
+{
+	tell_status "installing PHP"
+	stage_pkg_install php56 php56-fileinfo php56-mcrypt php56-exif php56-openssl
+
+	if [ "$TOASTER_MYSQL" = "1" ]; then
+		tell_status "install php mysql module"
+		stage_pkg_install php56-mysql
+	fi
+
+	local _php_ini="$STAGE_MNT/usr/local/etc/php.ini"
+	cp "$STAGE_MNT/usr/local/etc/php.ini-production" "$_php_ini" || exit
+	sed -i .bak \
+		-e 's/^;date.timezone =/date.timezone = America\/Los_Angeles/' \
+		-e '/^post_max_size/ s/8M/25M/' \
+		-e '/^upload_max_filesize/ s/2M/25M/' \
+		"$_php_ini"
+}
+
+install_squirrelmail_mysql()
+{
+	if [ "$TOASTER_MYSQL" != "1" ]; then return; fi
+
+	local _init_db=0
+	if ! mysql_db_exists squirrelmail; then
+		tell_status "creating squirrelmail database"
+		echo "CREATE DATABASE squirrelmail;" | jexec mysql /usr/local/bin/mysql || exit
+		echo "
+CREATE TABLE address (
+  owner varchar(128) DEFAULT '' NOT NULL,
+  nickname varchar(16) DEFAULT '' NOT NULL,
+  firstname varchar(128) DEFAULT '' NOT NULL,
+  lastname varchar(128) DEFAULT '' NOT NULL,
+  email varchar(128) DEFAULT '' NOT NULL,
+  label varchar(255),
+  PRIMARY KEY (owner,nickname),
+  KEY firstname (firstname,lastname)
+);
+
+CREATE TABLE global_abook (
+  owner varchar(128) DEFAULT '' NOT NULL,
+  nickname varchar(16) DEFAULT '' NOT NULL,
+  firstname varchar(128) DEFAULT '' NOT NULL,
+  lastname varchar(128) DEFAULT '' NOT NULL,
+  email varchar(128) DEFAULT '' NOT NULL,
+  label varchar(255),
+  PRIMARY KEY (owner,nickname),
+  KEY firstname (firstname,lastname)
+);
+
+CREATE TABLE userprefs (
+  user varchar(128) DEFAULT '' NOT NULL,
+  prefkey varchar(64) DEFAULT '' NOT NULL,
+  prefval BLOB NOT NULL,
+  PRIMARY KEY (user,prefkey)
+);" | jexec mysql /usr/local/bin/mysql squirrelmail || exit
+
+	fi
+
+	tee -a "$_sq_dir/config_local.php" <<EO_SQUIRREL_SQL
+\$prefs_dsn = 'mysql://squirrelmail:${_sqpass}@$(get_jail_ip mysql)/squirrelmail';
+\$addrbook_dsn = 'mysql://squirrelmail:${_sqpass}@$(get_jail_ip mysql)/squirrelmail';
+EO_SQUIRREL_SQL
+
+	local _grant='GRANT ALL PRIVILEGES ON squirrelmail.* to'
+
+	echo "$_grant 'squirrelmail'@'$(get_jail_ip squirrelmail)' IDENTIFIED BY '${_sqpass}';" \
+		| jexec mysql /usr/local/bin/mysql || exit
+
+	echo "$_grant 'squirrelmail'@'$(get_jail_ip stage)' IDENTIFIED BY '${_sqpass}';" \
+		| jexec mysql /usr/local/bin/mysql || exit
+}
+
+install_squirrelmail()
+{
+	install_php || exit
+	install_nginx || exit
+
+	tell_status "installing squirrelmail"
+	stage_pkg_install squirrelmail squirrelmail-sasql-plugin \
+		squirrelmail-quota_usage-plugin || exit
+
+	_sq_dir="$STAGE_MNT/usr/local/www/squirrelmail/config"
+
+	local _active_cfg; _active_cfg="$_sq_dir/config.inc.php"
+	if [ -f "$_active_cfg" ]; then
+		_sqpass=$(grep '//squirrelmail:' "$_active_cfg" | cut -f3 -d: | cut -f1 -d@)
+		echo "preserving existing squirrelmail mysql password: $_sqpass"
+	else
+		_sqpass=$(openssl rand -hex 18)
+	fi
+
+	cp "$_sq_dir/config_local.php.sample" "$_sq_dir/config_local.php"
+	cp "$_sq_dir/config_default.php" "$_sq_dir/config.php"
+	cp "$_sq_dir/../plugins/sasql/sasql_conf.php.dist" \
+	   "$_sq_dir/../plugins/sasql/sasql_conf.php"
+	cp "$_sq_dir/../plugins/quota_usage/config.php.sample" \
+	   "$_sq_dir/../plugins/quota_usage/config.php"
+
+	tee -a "$_sq_dir/config_local.php" <<EO_SQUIRREL
+\$signout_page = 'https://$TOASTER_HOSTNAME/';
+\$domain = '$TOASTER_MAIL_DOMAIN';
+
+\$smtpServerAddress = '$(get_jail_ip haraka)';
+\$smtpPort = 465;
+\$use_smtp_tls = true;
+// PHP 5.6 enables verify_peer by default, which is good but in this context,
+// unnecessary. Setting smtp_stream_options *should* disable that, but doesn't.
+// Leave squirrelmail disabled until squirrelmail gets this sorted out.
+\$smtp_stream_options = [
+    'ssl' => [
+       'verify_peer'      => false,
+       'verify_peer_name' => false,
+       'verify_depth' => 3,
+       'cafile' => '/etc/ssl/cert.pem',
+       // 'allow_self_signed' => true,
+    ],
+];
+\$smtp_auth_mech = 'login';
+
+\$imapServerAddress = '$(get_jail_ip dovecot)';
+\$imap_server_type = 'dovecot';
+\$use_imap_tls     = false;
+
+\$data_dir = '/data/data';
+\$attachment_dir = '/data/attach';
+// \$check_referrer = '$TOASTER_MAIL_DOMAIN';
+\$check_mail_mechanism = 'advanced';
+
+EO_SQUIRREL
+
+	mkdir -p "$STAGE_MNT/data/attach" "$STAGE_MNT/data/data"
+	cp "$_sq_dir/../data/default_pref" "$STAGE_MNT/data/data/"
+	chown -R www:www "$STAGE_MNT/data"
+	chmod 733 "$STAGE_MNT/data/attach"
+
+	install_squirrelmail_mysql
+}
+
+install_nginx()
+{
+	stage_pkg_install nginx || exit
+
+	patch -d "$STAGE_MNT/usr/local/etc/nginx" <<'EO_NGINX_CONF'
+--- nginx.conf-dist	2016-11-03 05:11:28.000000000 -0700
++++ nginx.conf	2016-12-07 16:23:22.184892048 -0800
+@@ -41,17 +41,26 @@
+ 
+     server {
+         listen       80;
+-        server_name  localhost;
++        server_name  squirrelmail;
+ 
+         #charset koi8-r;
+ 
+         #access_log  logs/host.access.log  main;
+ 
+         location / {
+-            root   /usr/local/www/nginx;
+-            index  index.html index.htm;
++            root   /usr/local/www/squirrelmail;
++            index  index.php;
+         }
+ 
++        location /squirrelmail/ {
++            root /usr/local/www;
++            index  index.php;
++        }
++
++        set_real_ip_from 172.16.15.12;
++        real_ip_header X-Forwarded-For;
++        client_max_body_size 25m;
++
+         #error_page  404              /404.html;
+ 
+         # redirect server error pages to the static page /50x.html
+@@ -69,13 +78,13 @@
+ 
+         # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+         #
+-        #location ~ \.php$ {
+-        #    root           html;
+-        #    fastcgi_pass   127.0.0.1:9000;
+-        #    fastcgi_index  index.php;
+-        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+-        #    include        fastcgi_params;
+-        #}
++        location ~ \.php$ {
++            alias          /usr/local/www;
++            fastcgi_pass   127.0.0.1:9000;
++            fastcgi_index  index.php;
++            fastcgi_param  SCRIPT_FILENAME  $document_root/$fastcgi_script_name;
++            include        fastcgi_params;
++        }
+ 
+         # deny access to .htaccess files, if Apache's document root
+         # concurs with nginx's one
+EO_NGINX_CONF
+
+}
+
+configure_squirrelmail()
+{
+	_htdocs="$ZFS_DATA_MNT/squirrelmail/htdocs"
+	if [ ! -d "$_htdocs" ]; then
+	   mkdir -p "$_htdocs"
+	fi
+}
+
+start_squirrelmail()
+{
+	tell_status "starting PHP"
+	stage_sysrc php_fpm_enable=YES
+	stage_exec service php-fpm start
+
+	tell_status "starting nginx"
+	stage_sysrc nginx_enable=YES
+	stage_exec service nginx start
+}
+
+test_squirrelmail()
+{
+	tell_status "testing squirrelmail httpd"
+	stage_listening 80
+
+	tell_status "testing squirrelmail php"
+	stage_listening 9000
+	echo "it worked"
+}
+
+base_snapshot_exists || exit
+create_staged_fs squirrelmail
+start_staged_jail
+install_squirrelmail
+configure_squirrelmail
+start_squirrelmail
+test_squirrelmail
+promote_staged_jail squirrelmail

--- a/provision-webmail.sh
+++ b/provision-webmail.sh
@@ -8,243 +8,9 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		mount += \"$ZFS_DATA_MNT/webmail \$path/data nullfs rw 0 0\";"
 
-install_php()
-{
-	tell_status "installing PHP"
-	stage_pkg_install php56 php56-fileinfo php56-mcrypt php56-exif php56-openssl
-
-	local _php_ini="$STAGE_MNT/usr/local/etc/php.ini"
-	cp "$STAGE_MNT/usr/local/etc/php.ini-production" "$_php_ini" || exit
-	sed -i .bak \
-		-e 's/^;date.timezone =/date.timezone = America\/Los_Angeles/' \
-		-e '/^post_max_size/ s/8M/25M/' \
-		-e '/^upload_max_filesize/ s/2M/25M/' \
-		"$_php_ini"
-}
-
-install_roundcube_mysql()
-{
-	local _init_db=0
-	if ! mysql_db_exists roundcubemail; then
-		tell_status "creating roundcube mysql db"
-		echo "CREATE DATABASE roundcubemail;" | jexec mysql /usr/local/bin/mysql || exit
-		_init_db=1
-	fi
-
-	local _active_cfg="$ZFS_JAIL_MNT/webmail/usr/local/www/roundcube/config/config.inc.php"
-	if [ -f "$_active_cfg" ]; then
-		local _rcpass
-		# shellcheck disable=2086
-		_rcpass=$(grep '//roundcube:' $_active_cfg | cut -f3 -d: | cut -f1 -d@)
-		if [ -n "$_rcpass" ] && [ "$_rcpass" != "pass" ]; then
-			echo "preserving roundcube password $_rcpass"
-		fi
-	else
-		_rcpass=$(openssl rand -hex 18)
-	fi
-
-	local _rcc_dir="$STAGE_MNT/usr/local/www/roundcube/config"
-	sed -i .bak \
-		-e "s/roundcube:pass@/roundcube:${_rcpass}@/" \
-		-e "s/@localhost\//@$(get_jail_ip mysql)\//" \
-		"$_rcc_dir/config.inc.php" || exit
-
-	if [ "$_init_db" = "1" ]; then
-		tell_status "configuring roundcube mysql permissions"
-		local _grant='GRANT ALL PRIVILEGES ON roundcubemail.* to'
-
-		echo "$_grant 'roundcube'@'$(get_jail_ip webmail)' IDENTIFIED BY '${_rcpass}';" \
-			| jexec mysql /usr/local/bin/mysql || exit
-
-		echo "$_grant 'roundcube'@'$(get_jail_ip stage)' IDENTIFIED BY '${_rcpass}';" \
-			| jexec mysql /usr/local/bin/mysql || exit
-
-		roundcube_init_db
-	fi
-}
-
-roundcube_init_db()
-{
-	tell_status "initializating roundcube db"
-	pkg install -y curl || exit
-	stage_exec service php-fpm restart
-	curl -i -F initdb='Initialize database' -XPOST \
-		"http://$(get_jail_ip stage)/roundcube/installer/index.php?_step=3" || exit
-}
-
-install_roundcube()
-{
-	tell_status "installing roundcube"
-	stage_pkg_install roundcube
-
-	# for sqlite storage
-	mkdir -p "$STAGE_MNT/data/roundcube"
-	chown 80:80 "$STAGE_MNT/data/roundcube"
-
-	local _rcc_conf="$STAGE_MNT/usr/local/www/roundcube/config/config.inc.php"
-	cp "$_rcc_conf.sample" "$_rcc_conf" || exit
-
-	local _dovecot_ip; _dovecot_ip=$(get_jail_ip dovecot)
-	sed -i .bak \
-		-e "/'default_host'/ s/'localhost'/'$_dovecot_ip'/" \
-		-e "/'smtp_server'/  s/'';/'tls:\/\/haraka';/" \
-		-e "/'smtp_port'/    s/25;/587;/" \
-		-e "/'smtp_user'/    s/'';/'%u';/" \
-		-e "/'smtp_pass'/    s/'';/'%p';/" \
-		"$_rcc_conf"
-
-	tee -a "$_rcc_conf" <<'EO_RC_ADD'
-
-$config['log_driver'] = 'syslog';
-$config['session_lifetime'] = 30;
-$config['enable_installer'] = true;
-$config['mime_types'] = '/usr/local/etc/mime.types';
-$config['smtp_conn_options'] = array(
- 'ssl'            => array(
-   'verify_peer'  => false,
-   'verify_peer_name' => false,
-   'verify_depth' => 3,
-   'cafile'       => '/etc/ssl/cert.pem',
- ),
-);
-EO_RC_ADD
-
-	if [ "$TOASTER_MYSQL" = "1" ]; then
-		install_roundcube_mysql
-	else
-		stage_pkg_install php56-pdo_sqlite
-		sed -i.bak \
-			-e "/^\$config\['db_dsnw'/ s/= .*/= 'sqlite:\/\/\/\/data\/roundcube\/sqlite.db?mode=0646';/" \
-			"$_rcc_conf"
-
-		if [ ! -f "$ZFS_DATA_MNT/webmail/roundcube/sqlite.db" ]; then
-			roundcube_init_db
-		fi
-	fi
-
-	sed -i -e "s/enable_installer'] = true;/enable_installer'] = false;/" "$_rcc_conf"
-}
-
-install_squirrelmail_mysql()
-{
-	if [ "$TOASTER_MYSQL" != "1" ]; then return; fi
-
-	local _init_db=0
-	if ! mysql_db_exists squirrelmail; then
-		tell_status "creating squirrelmail database"
-		echo "CREATE DATABASE squirrelmail;" | jexec mysql /usr/local/bin/mysql || exit
-		echo "
-CREATE TABLE address (
-  owner varchar(128) DEFAULT '' NOT NULL,
-  nickname varchar(16) DEFAULT '' NOT NULL,
-  firstname varchar(128) DEFAULT '' NOT NULL,
-  lastname varchar(128) DEFAULT '' NOT NULL,
-  email varchar(128) DEFAULT '' NOT NULL,
-  label varchar(255),
-  PRIMARY KEY (owner,nickname),
-  KEY firstname (firstname,lastname)
-);
-
-CREATE TABLE global_abook (
-  owner varchar(128) DEFAULT '' NOT NULL,
-  nickname varchar(16) DEFAULT '' NOT NULL,
-  firstname varchar(128) DEFAULT '' NOT NULL,
-  lastname varchar(128) DEFAULT '' NOT NULL,
-  email varchar(128) DEFAULT '' NOT NULL,
-  label varchar(255),
-  PRIMARY KEY (owner,nickname),
-  KEY firstname (firstname,lastname)
-);
-
-CREATE TABLE userprefs (
-  user varchar(128) DEFAULT '' NOT NULL,
-  prefkey varchar(64) DEFAULT '' NOT NULL,
-  prefval BLOB NOT NULL,
-  PRIMARY KEY (user,prefkey)
-);" | jexec mysql /usr/local/bin/mysql squirrelmail || exit
-
-	fi
-
-	tee -a "$_sq_dir/config_local.php" <<EO_SQUIRREL_SQL
-\$prefs_dsn = 'mysql://squirrelmail:${_sqpass}@$(get_jail_ip mysql)/squirrelmail';
-\$addrbook_dsn = 'mysql://squirrelmail:${_sqpass}@$(get_jail_ip mysql)/squirrelmail';
-EO_SQUIRREL_SQL
-
-	local _grant='GRANT ALL PRIVILEGES ON squirrelmail.* to'
-
-	echo "$_grant 'squirrelmail'@'$(get_jail_ip webmail)' IDENTIFIED BY '${_sqpass}';" \
-		| jexec mysql /usr/local/bin/mysql || exit
-
-	echo "$_grant 'squirrelmail'@'$(get_jail_ip stage)' IDENTIFIED BY '${_sqpass}';" \
-		| jexec mysql /usr/local/bin/mysql || exit
-}
-
-install_squirrelmail()
-{
-	tell_status "installing squirrelmail"
-	stage_pkg_install squirrelmail squirrelmail-sasql-plugin \
-		squirrelmail-quota_usage-plugin || exit
-
-	_sq_dir="$STAGE_MNT/usr/local/www/squirrelmail/config"
-
-	local _active_cfg; _active_cfg="$_sq_dir/config.inc.php"
-	if [ -f "$_active_cfg" ]; then
-		_sqpass=$(grep '//squirrelmail:' "$_active_cfg" | cut -f3 -d: | cut -f1 -d@)
-		echo "preserving existing squirrelmail mysql password: $_sqpass"
-	else
-		_sqpass=$(openssl rand -hex 18)
-	fi
-
-	cp "$_sq_dir/config_local.php.sample" "$_sq_dir/config_local.php"
-	cp "$_sq_dir/config_default.php" "$_sq_dir/config.php"
-	cp "$_sq_dir/../plugins/sasql/sasql_conf.php.dist" \
-	   "$_sq_dir/../plugins/sasql/sasql_conf.php"
-	cp "$_sq_dir/../plugins/quota_usage/config.php.sample" \
-	   "$_sq_dir/../plugins/quota_usage/config.php"
-
-	tee -a "$_sq_dir/config_local.php" <<EO_SQUIRREL
-\$signout_page = 'https://$TOASTER_HOSTNAME/';
-\$domain = '$TOASTER_MAIL_DOMAIN';
-
-\$smtpServerAddress = '$(get_jail_ip haraka)';
-\$smtpPort = 465;
-\$use_smtp_tls = true;
-// PHP 5.6 enables verify_peer by default, which is good but in this context,
-// unnecessary. Setting smtp_stream_options *should* disable that, but doesn't.
-// Leave squirrelmail disabled until squirrelmail gets this sorted out.
-\$smtp_stream_options = [
-    'ssl' => [
-       'verify_peer'      => false,
-       'verify_peer_name' => false,
-       'verify_depth' => 3,
-       'cafile' => '/etc/ssl/cert.pem',
-       // 'allow_self_signed' => true,
-    ],
-];
-\$smtp_auth_mech = 'login';
-
-\$imapServerAddress = '$(get_jail_ip dovecot)';
-\$imap_server_type = 'dovecot';
-\$use_imap_tls     = false;
-
-\$data_dir = '/data/squirrelmail/data';
-\$attachment_dir = '/data/squirrelmail/attach';
-// \$check_referrer = '$TOASTER_MAIL_DOMAIN';
-\$check_mail_mechanism = 'advanced';
-
-EO_SQUIRREL
-
-	mkdir -p "$STAGE_MNT/data/squirrelmail/attach" "$STAGE_MNT/data/squirrelmail/data"
-	cp "$_sq_dir/../data/default_pref" "$STAGE_MNT/data/squirrelmail/data/"
-	chown -R www:www "$STAGE_MNT/data/squirrelmail"
-	chmod 733 "$STAGE_MNT/data/squirrelmail/attach"
-
-	install_squirrelmail_mysql
-}
-
 install_nginx()
 {
-	stage_pkg_install nginx dialog4ports openssl || exit
+	stage_pkg_install nginx || exit
 
 	local _nginx_conf="$STAGE_MNT/usr/local/etc/nginx/conf.d"
 	mkdir -p "$_nginx_conf" || exit
@@ -259,23 +25,6 @@ location / {
    index  index.html index.htm;
 }
 
-location ~  ^/(squirrelmail|roundcube)/(.+\.php)\$ {
-    alias /usr/local/www;
-    fastcgi_pass   127.0.0.1:9000;
-    fastcgi_index  index.php;
-    fastcgi_param  SCRIPT_FILENAME  \$document_root/\$1/\$2;
-    include        fastcgi_params;
-}
-
-location /squirrelmail/ {
-    root /usr/local/www/;
-    index  index.php;
-}
-
-location /roundcube/ {
-    root /usr/local/www/;
-    index  index.php;
-}
 EO_NGINX_MT6
 
 	patch -d "$STAGE_MNT/usr/local/etc/nginx" <<'EO_NGINX_CONF'
@@ -329,14 +78,6 @@ install_lighttpd()
 server.modules += ( "mod_alias" )
 
 alias.url = ( "/cgi-bin/"        => "/usr/local/www/cgi-bin/",
-              "/squirrelmail/"   => "/usr/local/www/squirrelmail/",
-              "/roundcube/"      => "/usr/local/www/roundcube/",
-              "/v-webmail/"      => "/usr/local/www/v-webmail/htdocs/",
-              "/horde/"          => "/usr/local/www/horde/",
-              "/awstatsclasses"  => "/usr/local/www/awstats/classes/",
-              "/awstatscss"      => "/usr/local/www/awstats/css/",
-              "/awstatsicons"    => "/usr/local/www/awstats/icons/",
-              "/awstats/"        => "/usr/local/www/awstats/cgi-bin/",
            )
 
 server.modules += ( "mod_cgi" )
@@ -349,53 +90,17 @@ $HTTP["url"] =~ "^/cgi-bin" {
 }
 
 server.modules += ( "mod_fastcgi" )
-fastcgi.server = (
-                   ".php" =>
-                    ( "php-tcp" =>
-                      (
-                        "host" => "172.16.15.10",
-                        "port" => 9000,
-                        "check-local" => "disable",
-                        "broken-scriptfilename" => "enable",
-                      )
-                    )
-                 )
 EO_LIGHTTPD_MT6
-}
-
-install_php_mysql()
-{
-	if [ "$TOASTER_MYSQL" != "1" ]; then
-		return
-	fi
-
-	tell_status "install php mysql module"
-	stage_pkg_install php56-mysql
 }
 
 install_webmail()
 {
-	install_php || exit
-	install_php_mysql
-
-	tell_status "starting PHP"
-	stage_sysrc php_fpm_enable=YES
-	stage_exec service php-fpm start
 
 	if [ "$WEBMAIL_HTTPD" = "lighttpd" ]; then
 		install_lighttpd || exit
-		tell_status "starting lighttpd"
-		stage_sysrc lighttpd_enable=YES
-		stage_exec service lighttpd start
 	else
 		install_nginx || exit
-		tell_status "starting nginx"
-		stage_sysrc nginx_enable=YES
-		stage_exec service nginx start
 	fi
-
-	install_roundcube || exit
-	install_squirrelmail || exit
 }
 
 install_index()
@@ -517,17 +222,21 @@ EO_ROBOTS_TXT
 
 start_webmail()
 {
-	true
+	if [ "$WEBMAIL_HTTPD" = "lighttpd" ]; then
+		tell_status "starting lighttpd"
+		stage_sysrc lighttpd_enable=YES
+		stage_exec service lighttpd start
+	else
+		tell_status "starting nginx"
+		stage_sysrc nginx_enable=YES
+		stage_exec service nginx start
+	fi
 }
 
 test_webmail()
 {
 	tell_status "testing webmail httpd"
 	stage_listening 80
-
-	tell_status "testing webmail php"
-	stage_listening 9000
-	echo "it worked"
 }
 
 base_snapshot_exists || exit

--- a/provision-webmail.sh
+++ b/provision-webmail.sh
@@ -51,9 +51,6 @@ EO_NGINX_MT6
  
 EO_NGINX_CONF
 
-	export BATCH=${BATCH:="1"}
-	stage_make_conf www_nginx 'www_nginx_SET=HTTP_REALIP'
-	stage_exec make -C /usr/ports/www/nginx build deinstall install clean
 }
 
 install_lighttpd()
@@ -119,13 +116,16 @@ install_index()
   });
   function changeWebmail(sel) {
       if (sel.value === 'roundcube') $('#webmail-item').prop('src','/roundcube/');
+      if (sel.value === 'rainloop') $('#webmail-item').prop('src','/rainloop/');
       if (sel.value === 'squirrelmail') $('#webmail-item').prop('src','/squirrelmail/');
+      if (sel.value === 'sqwebmail') $('#webmail-item').prop('src','/cgi-bin/sqwebmail?index=1');
       console.log(sel);
   };
   function changeAdmin(sel) {
       if (sel.value === 'qmailadmin') $('#admin-item').prop('src','/cgi-bin/qmailadmin/qmailadmin/');
       if (sel.value === 'rspamd') $('#admin-item').prop('src','/rspamd/');
       if (sel.value === 'watch') $('#admin-item').prop('src','/watch/');
+      if (sel.value === 'rainloop') $('#admin-item').prop('src','/rainloop/?admin');
   };
   function changeStats(sel) {
       if (sel.value === 'munin') $('#stats-item').prop('src','/munin/');
@@ -146,7 +146,9 @@ body {
            <select id="webmail-select" onChange="changeWebmail(this);">
                <option value=webmail>Webmail</option>
                <option value=roundcube>Roundcube</option>
+               <option value=rainloop>Rainloop</option>
                <option value=squirrelmail>Squirrelmail</option>
+               <option value=sqwebmail>Sqwebmail</option>
            </select>
        </a>
        </li>
@@ -156,6 +158,7 @@ body {
                <option value=qmailadmin>Qmailadmin</option>
                <option value=rspamd>Rspamd</option>
                <option value=watch>Haraka Watch</option>
+               <option value=rainloop>Rainloop Admin</option>
            </select>
        </a>
        </li>

--- a/qmail/qqtool.pl
+++ b/qmail/qqtool.pl
@@ -502,17 +502,13 @@ Community funding was contributed by the following mail-toaster@simerson.net mai
 Report to author. Patches welcome.
 
 
-=head1 TODO
+=head1 FEATURE WISHES
 
 In list mode, when showing messages in the queue, show which addresses delivery has failed for, so you know exactly why a message is still in the queue (useful for mailing lists with many recipients)
 
 Interactive mode - step through messages offering to delete/expire/skip each
 
 Clean mode - Leave qmail down after stopping it, useful for multiple invocations
-
-Write the messages into a "inactive" queue before deleting them.
-
-Ability to restore messages from "inactive" to the real queue.
 
 
 =head1 SEE ALSO


### PR DESCRIPTION
### Changes proposed in this pull request:
- adds support for [rainloop webmail](http://www.rainloop.net)
- move squirrelmail & roundcube out of webmail to their own jails
- adds SQUIRREL_SQL settings
- install a 2048 DH params file for haproxy
- fixed letsencrypt deployment script for dovecot

### Upgade Issues
- haproxy rules need updating
- if squirrelmail had sqlite (default) storage, move data from webmail to squirrelmail data volume
    - `mv /data/webmail/squirrelmail/* /data/squirrelmail/`
- if roundcube had sqlite storage, move data from webmail to roundcube data volume

Checklist:
- [x] docs up-to-date