### PR TITLE
add default JAIL_CONF_EXTRA, reduced boilerplate

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -280,11 +280,16 @@ add_jail_conf()
 		path = $ZFS_JAIL_MNT/${1};"
 	fi
 
+	if [ -z "$JAIL_CONF_EXTRA" ]; then
+		JAIL_CONF_EXTRA="mount += \"$ZFS_DATA_MNT/$1 \$path/data nullfs rw 0 0\";"
+	fi
+
 	tell_status "adding $1 to /etc/jail.conf"
 	tee -a /etc/jail.conf <<EO_JAIL_CONF
 
 $1	{
-		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};${_path}${JAIL_CONF_EXTRA}
+		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};${_path}
+		${JAIL_CONF_EXTRA}
 	}
 EO_JAIL_CONF
 }
@@ -395,7 +400,6 @@ start_staged_jail()
 		ip4.addr="$(get_jail_ip stage)" \
 		exec.start="/bin/sh /etc/rc" \
 		exec.stop="/bin/sh /etc/rc.shutdown" \
-		allow.sysvipc=1 \
 		mount.devfs \
 		$JAIL_START_EXTRA \
 		|| exit

--- a/provision-dns.sh
+++ b/provision-dns.sh
@@ -4,8 +4,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/dns \$path/data nullfs rw 0 0\";";
+export JAIL_CONF_EXTRA=""
 
 install_unbound()
 {

--- a/provision-haproxy.sh
+++ b/provision-haproxy.sh
@@ -4,8 +4,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/haproxy \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_haproxy()
 {

--- a/provision-joomla.sh
+++ b/provision-joomla.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/joomla \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_php()
 {

--- a/provision-letsencrypt.sh
+++ b/provision-letsencrypt.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/letsencrypt \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_letsencrypt()
 {

--- a/provision-memcached.sh
+++ b/provision-memcached.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/memcached \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_memcached()
 {

--- a/provision-nginx.sh
+++ b/provision-nginx.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/nginx \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_nginx()
 {

--- a/provision-nictool.sh
+++ b/provision-nictool.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/nictool \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 export NICTOOL_VER=${NICTOOL_VER:="2.33"}
 

--- a/provision-php7.sh
+++ b/provision-php7.sh
@@ -6,11 +6,6 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
-# shellcheck disable=2016
-#@TODO create a shared dir between nginx and php7
-#export JAIL_CONF_EXTRA="
-#		mount += \"$ZFS_DATA_MNT/php7 \$path/data nullfs rw 0 0\";"
-
 install_php()
 {
 	tell_status "installing PHP7"

--- a/provision-rainloop.sh
+++ b/provision-rainloop.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/rainloop \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_php()
 {

--- a/provision-redis.sh
+++ b/provision-redis.sh
@@ -4,8 +4,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/redis \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_redis()
 {

--- a/provision-roundcube.sh
+++ b/provision-roundcube.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/roundcube \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_php()
 {

--- a/provision-rsnapshot.sh
+++ b/provision-rsnapshot.sh
@@ -4,8 +4,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/rsnapshot \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_rsnapshot()
 {

--- a/provision-spamassassin.sh
+++ b/provision-spamassassin.sh
@@ -4,8 +4,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/spamassassin \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_dcc_cleanup()
 {

--- a/provision-squirrelmail.sh
+++ b/provision-squirrelmail.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/squirrelmail \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_php()
 {

--- a/provision-tinydns.sh
+++ b/provision-tinydns.sh
@@ -4,8 +4,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/tinydns \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_tinydns()
 {

--- a/provision-webmail.sh
+++ b/provision-webmail.sh
@@ -5,8 +5,7 @@
 
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/webmail \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_nginx()
 {


### PR DESCRIPTION
### Changes proposed in this pull request:
- if the provision script doesn't declare a JAIL_CONF_EXTRA, use default /data dir
- remove boilerplate from 16 scripts
