### PR TITLE
in roadblock msg, show correct mount point

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -334,11 +334,12 @@ assure_data_volume_mount_is_declared()
 		return
 	fi
 
+        local _mp; _mp=$(data_mountpoint "$1" "\$path")
 	tell_status "roadblock: UPGRADE action required"
 	echo
 	echo "You MUST add this line to the $1 section in /etc/jail.conf to continue:"
 	echo
-	echo "	mount += \"/data/$1 \$path/data nullfs rw 0 0\";"
+	echo "	mount += \"/data/$1 $_mp nullfs rw 0 0\";"
 	echo
 	exit
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
- instead of stack \$path/data, use data_mountpoint() to show the correct path

Fixes # .

Checklist:
- [ ] docs up-to-date
