### PR TITLE
Update rspamd provision jail to make use of our Redis server

### DIFF
--- a/provision-rspamd.sh
+++ b/provision-rspamd.sh
@@ -19,10 +19,13 @@ configure_redis()
 	fi
 
 	tell_status "add Redis address, for default Lua modules backend"
-	echo "redis {
-	servers = \"$(get_jail_ip redis):6379\";
-	db    = \"5\";
-}"  | tee -a "$_etc/rspamd/rspamd.conf"
+    tee -a "$_etc/rspamd/rspamd.conf" <<  EO_REDIS
+    redis {
+        servers = "$(get_jail_ip redis):6379";
+        db    = "5";
+    }
+EO_REDIS
+
 }
 
 configure_dmarc()
@@ -32,14 +35,17 @@ configure_dmarc()
 	fi
 
 	tell_status "add Redis address, for DMARC stats"
-	echo "dmarc {
-	# Enables storing reporting information to redis
-     	reporting = true;
-  	actions = {
-        	quarantine = "add_header";
+	tee -a "$_etc/rspamd/rspamd.conf" <<EO_DMARC
+	dmarc {
+		# Enables storing reporting information to redis
+		reporting = true;
+		actions = {
+			quarantine = "add_header";
 	        reject = "reject";
-	}
-}"  | tee -a "$_etc/rspamd/rspamd.conf"
+		}
+}
+EO_DMARC
+
 }
 
 configure_stats()

--- a/provision-rspamd.sh
+++ b/provision-rspamd.sh
@@ -83,7 +83,7 @@ classifier "bayes" {
             spam = false;
     }
     #per_user = true;
-    autolearn = true;    
+    autolearn = [-5, 5];    
 }
 EO_RSPAMD_STAT
 


### PR DESCRIPTION

### Changes proposed in this pull request:
- use redis for Lua [see here for details](https://github.com/vstakhov/rspamd/issues/766#issuecomment-240105002)
- Use for Storing BAYES tokens [from here](https://rspamd.com/doc/configuration/statistic.html)

Redis:
db=5 for Lua modules
db=6 for Bayes tokens


Fixes # .

Checklist:
- [ ] docs up-to-date
