### PR TITLE
fix duplicate line in provision-nictool.sh

### DIFF
--- a/provision-nictool.sh
+++ b/provision-nictool.sh
@@ -30,7 +30,7 @@ install_nt_from_git()
 	stage_exec sh -c 'cd /usr/local/nictool/server && git checkout travis-more-testing'
 	stage_pkg_install p5-App-Cpanminus
 	stage_exec sh -c 'cd /usr/local/nictool/server; perl Makefile.PL; cpanm -n .'
-	stage_exec sh -c 'cd /usr/local/nictool/server; perl Makefile.PL; cpanm -n .'
+	stage_exec sh -c 'cd /usr/local/nictool/client; perl Makefile.PL; cpanm -n .'
 	exit
 }
 


### PR DESCRIPTION
### Changes proposed in this pull request:
- change duplicate line 33 to install perl dependenciess for the client rather than the server twice

Checklist:
- [ ] docs up-to-date
