### PR TITLE
assure successful build before deinstall

### DIFF
--- a/provision-host.sh
+++ b/provision-host.sh
@@ -142,7 +142,7 @@ constrain_sshd_to_host()
 	fi
 
 	tell_status "checking sshd listening scope"
-	if ! sockstat -L | egrep '\*:22 '; then
+	if ! sockstat -L | grep -E '\*:22 '; then
 		return
 	fi
 
@@ -227,7 +227,7 @@ check_global_listeners()
 {
 	tell_status "checking for host listeners on all IPs"
 
-	if sockstat -L -4 | egrep '\*:[0-9]' | grep -v 123; then
+	if sockstat -L -4 | grep -E '\*:[0-9]' | grep -v 123; then
 		echo "oops!, you should not having anything listening
 on all your IP addresses!"
 		exit 2

--- a/qmail/run.sh
+++ b/qmail/run.sh
@@ -377,7 +377,7 @@ EO_DELIVERABLED_RUN
 	if [ ! "$(pkg query %n -F p5-HTTP-Daemon)" ]; then
 		echo "Installing HTTP::Daemon"
 		pkg install -y p5-HTTP-Daemon
-		make -C /usr/ports/www/p5-HTTP-Daemon deinstall install clean
+		make -C /usr/ports/www/p5-HTTP-Daemon build deinstall install clean
 	fi
 
 	pkg install -y p5-Package-Constants


### PR DESCRIPTION
When building p5-HTTP-Daemon, make sure build succeeds before deinstall.
