### PR TITLE
php updates

### DIFF
--- a/include/php.sh
+++ b/include/php.sh
@@ -15,13 +15,8 @@ install_php()
 	_modules="$2"
 
 	if [ "$TOASTER_MYSQL" = "1" ]; then
-		tell_status "including php mysql module"
-		if [ "$_version" = "70" ]; then
-			# php 70 doesn't have a plain mysql driver
-			_modules="$_modules pdo_mysql"
-		else
-			_modules="$_modules pdo_mysql mysql"
-		fi
+		tell_status "including php mysqli & PDO_mysql modules"
+		_modules="$_modules pdo_mysql mysqli"
 	fi
 
 	for m in $_modules
@@ -55,8 +50,8 @@ configure_php_ini()
 	fi
 
 	tell_status "getting the timezone"
-	TZ=`md5 -q /etc/localtime`
-	TIMEZONE=`find /usr/share/zoneinfo -type f | xargs md5 -r | grep  $TZ | awk '{print $2}' |cut -c21- `
+	TZ=$(md5 -q /etc/localtime)
+	TIMEZONE=$(find /usr/share/zoneinfo -type f | xargs md5 -r | grep "$TZ" | awk '{print $2}' |cut -c21-)
 
 	if [ -z "$TIMEZONE" ]; then
 		TIMEZONE="America\/Los_Angeles"

--- a/provision-php7.sh
+++ b/provision-php7.sh
@@ -6,57 +6,34 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
-install_php()
+mt6-include 'php'
+
+install_php7()
 {
-	tell_status "installing PHP7"
-	stage_pkg_install php70 php70-bcmath php70-bz2 php70-ctype php70-curl php70-dom php70-exif \
-php70-fileinfo php70-filter php70-ftp php70-gd php70-gettext php70-hash \
-php70-iconv php70-json php70-mbstring php70-mcrypt php70-mysqli \
-php70-opcache php70-openssl php70-pdo php70-pdo_mysql php70-pdo_sqlite \
-php70-phar php70-posix php70-recode php70-session php70-simplexml php70-soap \
-php70-sockets php70-sqlite3 php70-sysvmsg php70-sysvsem php70-tokenizer php70-wddx \
-php70-xml php70-xmlreader php70-xmlrpc php70-xmlwriter php70-xsl \
-php70-zip php70-zlib
-}
-
-configure_php()
-{
-	local _php_ini="$STAGE_MNT/usr/local/etc/php.ini"
-
-	if [ -f "$ZFS_JAIL_MNT/php7/usr/local/etc/php.ini" ]; then
-		tell_status "preserving php.ini"
-		cp "$ZFS_JAIL_MNT/php7/usr/local/etc/php.ini" "$_php_ini"
-		return
-	fi
-
-	cp "$STAGE_MNT/usr/local/etc/php.ini-production" "$_php_ini" || exit
-	sed -i .bak \
-		-e 's/^;date.timezone =/date.timezone = America\/Los_Angeles/' \
-		-e '/^post_max_size/ s/8M/25M/' \
-		-e '/^upload_max_filesize/ s/2M/25M/' \
-		"$_php_ini"
+	install_php "70" "bcmath bz2 ctype curl dom exif fileinfo filter ftp gd gettext hash \
+iconv json mbstring mcrypt mysqli opcache openssl pdo pdo_mysql pdo_sqlite \
+phar posix recode session simplexml soap sockets sqlite3 sysvmsg sysvsem tokenizer wddx \
+xml xmlreader xmlrpc xmlwriter xsl zip zlib"
 }
 
 start_php()
 {
-	tell_status "starting PHP"
-	stage_sysrc php_fpm_enable=YES
-	stage_exec service php-fpm start
+	start_php_fpm
 }
 
 test_php()
 {
-	tell_status "testing php7"
-	stage_listening 9000
+	test_php_fpm || exit 1
+
 	echo "it worked"
-    echo  "You probably need to created a shared source between Nginx and this PHP jail"
+	echo "You probably need to created a shared source between Nginx and this PHP jail"
 }
 
-base_snapshot_exists || exit
+base_snapshot_exists || exit 1
 create_staged_fs php7
 start_staged_jail php7
-install_php
-configure_php
+install_php7
+configure_php php7
 start_php
 test_php
 promote_staged_jail php7


### PR DESCRIPTION
### Changes proposed in this pull request:

* when TOASTER_MYSQL, install `mysqli` and `pdo_mysql` only
    * both are maintained
    * drops `mysql` from PHP < 7 installs
* update php7 jail to use include/php.sh (DRY)
