### PR TITLE
net mgmt: make use of NRPE/munin config settings

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -47,6 +47,8 @@ export TOASTER_MYSQL="1"
 export TOASTER_MARIADB="0"
 export TOASTER_PKG_AUDIT="0"
 export SQUIRREL_SQL="1"
+export TOASTER_NRPE=""
+export TOASTER_MUNIN=""
 
 EO_MT_CONF
 }

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1068,7 +1068,7 @@ assure_ip6_addr_is_declared()
 	fi
 
 	if awk "/^$1/,/}/" /etc/jail.conf | grep -q ip6; then
-		echo "ip6.addr is already declared in $1"
+		echo "ip6.addr is already declared"
 		return
 	fi
 

--- a/provision-monitor.sh
+++ b/provision-monitor.sh
@@ -28,12 +28,22 @@ install_lighttpd()
 
 install_nagios()
 {
+	if [ -z "$TOASTER_NRPE" ]; then
+		echo "TOASTER_NRPE unset, skipping nagios install"
+		return
+	fi
+
 	tell_status "installing nagios & nrpe"
 	stage_pkg_install nagios nrpe-ssl
 }
 
 install_munin()
 {
+	if [ -z "$TOASTER_MUNIN" ]; then
+		echo "TOASTER_MUNIN unset, skipping munin install"
+		return
+	fi
+
 	tell_status "installing munin"
 	stage_pkg_install munin-node munin-master
 }
@@ -158,8 +168,13 @@ configure_monitor()
 	fi
 
 	configure_lighttpd
-	configure_nrpe
-	configure_munin
+	if [ -n "$TOASTER_NRPE" ]; then
+		configure_nrpe
+	fi
+
+	if [ -n "$TOASTER_MUNIN" ]; then
+		configure_munin
+	fi
 }
 
 start_monitor()

--- a/qmail/run.sh
+++ b/qmail/run.sh
@@ -383,8 +383,8 @@ EO_DELIVERABLED_RUN
 	pkg install -y p5-Package-Constants
 
 	echo "installing Qmail::Deliverable"
-	pkg install -y p5-Log-Message p5-Archive-Extract p5-Object-Accessor p5-Module-Pluggable p5-CPANPLUS
-	perl -MCPANPLUS -e 'install Qmail::Deliverable'
+	pkg install -y p5-Log-Message p5-Archive-Extract p5-Object-Accessor p5-Module-Pluggable p5-App-Cpanminus
+	cpanm Qmail::Deliverable
 }
 
 install_qmail_chkuser()


### PR DESCRIPTION
### Changes proposed in this pull request:
- shorten ip6.addr installed message
- qmd: install with cpanminus (was CPANPLUS)
- add TOASTER_MUNIN setting
- only install nagios/munin in monitoring jail when enabled

Fixes #283 

Checklist:
- [ ] docs up-to-date