### PR TITLE
rspamd: only enable phishing when RAM > 4GB

### DIFF
--- a/provision-rspamd.sh
+++ b/provision-rspamd.sh
@@ -38,6 +38,12 @@ EO_DCC
 
 configure_phishing()
 {
+	local _physmem; _physmem=$(sysctl -n hw.physmem)
+	if [ "$_physmem" -le "4294967296" ]; then
+		tell_status "skipping phish, too little RAM"
+		return
+	fi
+
 	tell_status "enabling phish detection"
 	tee "$RSPAMD_ETC/local.d/phishing.conf" <<EO_PHISH
 	openphish_enabled = true;


### PR DESCRIPTION
Also, I added notes to the rspamd build page and the FAQ.

Fixes #302 

Checklist:
- [x] docs up-to-date
