### PR TITLE
port rename vim-lite -> vim-console

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -450,7 +450,7 @@ create_staged_fs()
 
 stage_unmount_aux_data()
 {
-	case $1 in
+	case "$1" in
 		spamassassin)  unmount_data geoip ;;
 		haraka)        unmount_data geoip ;;
 		whmcs )        unmount_data geoip ;;
@@ -458,7 +458,7 @@ stage_unmount_aux_data()
 }
 
 stage_mount_aux_data() {
-	case $1 in
+	case "$1" in
 		spamassassin )  mount_data geoip ;;
 		haraka )        mount_data geoip ;;
 		whmcs )         mount_data geoip ;;
@@ -491,6 +491,7 @@ start_staged_jail()
 
 	stage_mount_aux_data "$_name"
 
+	tell_status "updating pkg database"
 	pkg -j stage update
 }
 
@@ -788,7 +789,7 @@ data_mountpoint()
 		_base_dir="$STAGE_MNT"  # default to stage
 	fi
 
-	case $1 in
+	case "$1" in
 		avg )       echo "$_base_dir/data/avg"; return ;;
 		clamav )	echo "$_base_dir/var/db/clamav"; return ;;
 		geoip )     echo "$_base_dir/usr/local/share/GeoIP"; return ;;

--- a/provision-base.sh
+++ b/provision-base.sh
@@ -538,7 +538,7 @@ EO_VIMRC
 install_base()
 {
 	tell_status "installing packages desired in every jail"
-	stage_pkg_install pkg vim-lite ca_root_nss || exit
+	stage_pkg_install pkg vim-console ca_root_nss || exit
 
 	stage_exec newaliases || exit
 

--- a/provision-elasticsearch.sh
+++ b/provision-elasticsearch.sh
@@ -38,6 +38,7 @@ configure_elasticsearch()
 
 	tell_status "installing elasticsearch.yml"
 	local _conf="$STAGE_MNT/usr/local/etc/elasticsearch/elasticsearch.yml"
+	mkdir -p "$STAGE_MNT/data/etc"
 	echo "cp $_conf $_data_conf"
 	cp "$_conf" "$_data_conf" || exit
 	chown 965 "$_data_conf"
@@ -46,6 +47,10 @@ configure_elasticsearch()
 #	if [ ! -f "$STAGE_MNT/data/etc/logging.yml" ]; then
 #		cp "$STAGE_MNT/usr/local/etc/elasticsearch/logging.yml" "$STAGE_MNT/data/etc/"
 #	fi
+
+	if [ -f "$ZFS_JAIL_MNT/elasticsearch/usr/local/etc/elasticsesarch/jvm.options" ]; then
+		cp "$STAGE_MNT/usr/local/etc/elasticsearch/jvm.options" "$STAGE_MNT/usr/local/etc/elasticsearch/"
+	fi
 
 	if [ ! -f "$STAGE_MNT/data/etc/log4j2.properties" ]; then
 		cp "$STAGE_MNT/usr/local/etc/elasticsearch/log4j2.properties" "$STAGE_MNT/data/etc/"
@@ -80,9 +85,6 @@ start_elasticsearch()
 {
 	tell_status "starting Elasticsearch"
 	stage_sysrc elasticsearch_enable=YES
-	stage_sysrc elasticsearch_min_mem=4g
-	stage_sysrc elasticsearch_max_mem=4g
-	stage_sysrc elasticsearch_heap_newsize=4g
 	stage_exec service elasticsearch start
 
 	tell_status "starting Kibana"

--- a/provision-geoip.sh
+++ b/provision-geoip.sh
@@ -11,6 +11,8 @@ install_geoip()
 {
 	tell_status "install GeoIP updater"
 	stage_pkg_install npm-node8 || exit
+	stage_exec npm set user 0
+	stage_exec npm set -g unsafe-perm true
 	stage_exec npm install -g maxmind-geolite-mirror || exit
 }
 

--- a/provision-haproxy.sh
+++ b/provision-haproxy.sh
@@ -13,8 +13,11 @@ install_haproxy()
 		return
 	fi
 
-	tell_status "installing haproxy"
-	stage_pkg_install haproxy || exit 1
+	tell_status "installing haproxy devel (1.8)"
+	stage_pkg_install haproxy-devel || exit 1
+
+	tell_status "consider installing hatop for a 'top' style haproxy dashboard"
+	#stage_pkg_install hatop || exit 1
 }
 
 install_haproxy_libressl()
@@ -22,7 +25,7 @@ install_haproxy_libressl()
 	tell_status "compiling haproxy against libressl"
 	echo 'DEFAULT_VERSIONS+=ssl=libressl' >> "$STAGE_MNT/etc/make.conf"
 	stage_pkg_install pcre gmake libressl || exit 1
-	stage_port_install net/haproxy || exit 1
+	stage_port_install net/haproxy-devel || exit 1
 }
 
 configure_haproxy_dot_conf()
@@ -69,8 +72,8 @@ defaults
 
 frontend http-in
 	bind :::80 v4v6
-	bind :::443 v4v6 ssl crt /etc/ssl/private
-	#bind :::443 v4v6 ssl crt /etc/ssl/private crt /data/ssl.d
+	bind :::443 v4v6 alpn h2,http/1.1 ssl crt /etc/ssl/private
+	#bind :::443 v4v6 alpn h2,http/1.1 ssl crt /etc/ssl/private crt /data/ssl.d
 	# ciphers AES128+EECDH:AES128+EDH
 
 	http-request  set-header X-Forwarded-Proto https if { ssl_fc }

--- a/provision-knot.sh
+++ b/provision-knot.sh
@@ -18,7 +18,17 @@ install_knot()
 
 configure_knot()
 {
-	stage_sysrc knot_enable="YES"
+	stage_sysrc sshd_enable=YES
+	stage_sysrc knot_enable=YES
+	stage_sysrc knot_config=/data/etc/knot.conf
+
+	for _f in master.password group;
+	do
+		if [ -f "$ZFS_JAIL_MNT/knot/etc/$_f" ]; then
+			cp "$ZFS_JAIL_MNT/knot/etc/$_f" "$STAGE_MNT/etc/"
+			stage_exec pwd_mkdb -p /etc/master.passwd
+		fi
+	done
 }
 
 start_knot()
@@ -47,7 +57,6 @@ create_staged_fs knot
 start_staged_jail knot
 install_knot
 configure_knot
-configure_axfrdns
 start_knot
 test_knot
 promote_staged_jail knot

--- a/provision-mediawiki.sh
+++ b/provision-mediawiki.sh
@@ -13,10 +13,11 @@ install_mediawiki()
 {
 	assure_jail mysql
 
-	install_php 71 "ctype iconv gd json mbstring openssl session xml zlib"
+	install_php 71 "ctype dom fileinfo hash iconv intl gd json mbstring mysqli openssl readline session sockets xml xmlreader zlib"
 	install_nginx
 
-	stage_pkg_install mediawiki130
+	stage_pkg_install dialog4ports mysql56-client
+	stage_port_install www/mediawiki130
 	mkdir -p "$STAGE_MNT/var/cache/mediawiki"
 	chown 80:80 "$STAGE_MNT/var/cache/mediawiki"
 }

--- a/provision-monitor.sh
+++ b/provision-monitor.sh
@@ -156,8 +156,8 @@ configure_nrpe()
 	fi
 
 	stage_exec ln -s /data/etc/nrpe.cfg /usr/local/etc/nrpe.cfg
-	stage_sysrc nrpe2_enable="YES"
-	stage_sysrc nrpe2_configfile=/data/etc/nrpe.cfg
+	stage_sysrc nrpe3_enable="YES"
+	stage_sysrc nrpe3_configfile=/data/etc/nrpe.cfg
 }
 
 configure_monitor()

--- a/provision-nictool.sh
+++ b/provision-nictool.sh
@@ -28,8 +28,7 @@ install_nt_from_git()
 {
 	stage_pkg_install git-lite || exit
 	cd "$STAGE_MNT/usr/local" || exit
-	stage_exec git clone https://github.com/msimerson/NicTool.git /usr/local/nictool || exit
-	stage_exec sh -c 'cd /usr/local/nictool/server && git checkout travis-more-testing'
+	stage_exec git clone --depth=1 https://github.com/msimerson/NicTool.git /usr/local/nictool || exit
 	stage_pkg_install p5-App-Cpanminus
 	stage_exec sh -c 'cd /usr/local/nictool/server; perl Makefile.PL; cpanm -n .'
 	stage_exec sh -c 'cd /usr/local/nictool/client; perl Makefile.PL; cpanm -n .'
@@ -165,6 +164,17 @@ install_nictool_db()
 	done
 }
 
+install_nictool_user()
+{
+	for _f in master.password group;
+	do
+		if [ -f "$ZFS_JAIL_MNT/nictool/etc/$_f" ]; then
+			cp "$ZFS_JAIL_MNT/nictool/etc/$_f" "$STAGE_MNT/etc/"
+			stage_exec pwd_mkdb -p /etc/master.passwd
+		fi
+	done
+}
+
 install_nictool()
 {
 	install_nt_prereqs
@@ -174,6 +184,7 @@ install_nictool()
 	install_nictool_client
 	install_apache_setup
 	install_nictool_db
+	install_nictool_user
 }
 
 start_nictool()
@@ -187,7 +198,7 @@ test_nictool()
 {
 	tell_status "testing nictool"
 
-	stage_listening 443
+	stage_listening 80
 	stage_test_running httpd
 
 	echo "it worked"

--- a/provision-nsd.sh
+++ b/provision-nsd.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# shellcheck disable=1091
+. mail-toaster.sh || exit
+
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+
+install_nsd()
+{
+	tell_status "installing NSD"
+	stage_pkg_install nsd rsync dialog4ports || exit
+
+	if [ ! -d "$STAGE_MNT/data/home/nsd" ]; then
+		mkdir -p "$STAGE_MNT/data/home/nsd" || exit
+		chown 216:216 "$STAGE_MNT/data/home/nsd"
+	fi
+
+	stage_exec pw user mod nsd -u 216 -g 216 -s /bin/sh -d /data/home/nsd 
+}
+
+configure_nsd()
+{
+	stage_sysrc nsd_enable=YES
+	stage_sysrc nsd_config=/data/etc/nsd.conf
+
+	for _f in master.password group;
+	do
+		if [ -f "$ZFS_JAIL_MNT/nsd/etc/$_f" ]; then
+			cp "$ZFS_JAIL_MNT/nsd/etc/$_f" "$STAGE_MNT/etc/"
+			stage_exec pwd_mkdb -p /etc/master.passwd
+		fi
+	done
+}
+
+start_nsd()
+{
+	tell_status "starting nsd daemon"
+	stage_exec service nsd start || exit
+}
+
+test_nsd()
+{
+	tell_status "testing nsd"
+	stage_test_running nsd
+
+	stage_listening 53
+	echo "it worked."
+
+	tell_status "testing UDP DNS query"
+	drill    www.example.com @"$(get_jail_ip stage)" || exit
+
+	tell_status "testing TCP DNS query"
+	drill -t www.example.com @"$(get_jail_ip stage)" || exit
+}
+
+base_snapshot_exists || exit
+create_staged_fs nsd
+start_staged_jail nsd
+install_nsd
+configure_nsd
+start_nsd
+test_nsd
+promote_staged_jail nsd

--- a/provision-postfix.sh
+++ b/provision-postfix.sh
@@ -16,9 +16,13 @@ configure_postfix()
 {
 	stage_sysrc postfix_enable=YES
 	stage_sysrc sshd_enable=YES
-	stage_sysrc nrpe2_enable=YES
 	stage_sysrc milteropendkim_enable=YES
 	stage_sysrc milteropendkim_cfgfile=/data/etc/opendkim.conf
+
+	if [ -n "$TOASTER_NRPE" ]; then
+		stage_sysrc nrpe3_enable=YES
+		stage_sysrc nrpe3_configfile="/data/etc/nrpe.cfg"
+	fi
 
 	for _f in master main
 	do

--- a/provision-smf.sh
+++ b/provision-smf.sh
@@ -19,10 +19,10 @@ install_smf()
 	fi
 
 	fetch -m -o "$STAGE_MNT/data/smf.tar.bz2" \
-		http://download.simplemachines.org/index.php/smf_2-0-13_install.tar.bz2
+		http://download.simplemachines.org/index.php/smf_2-0-15_install.tar.bz2 || exit
 
 	stage_exec sh -c 'cd /usr/local/www/smf; bunzip2 -c /data/smf.tar.bz2 | tar -xf -' || exit
-	stage_exec sh -c 'cd /usr/local/www/smf; chown www:www attachments avatars cache Packages Packages/installed.list Smileys Themes agreement.txt Settings.php Settings_bak.php'
+	stage_exec sh -c 'cd /usr/local/www/smf; chown www:www attachments avatars cache Packages Packages/installed.list Smileys Themes agreement.txt Settings.php Settings_bak.php' || exit
 
 	stage_pkg_install aspell
 }

--- a/provision-squirrelcart.sh
+++ b/provision-squirrelcart.sh
@@ -50,7 +50,7 @@ install_squirrelcart()
 	mv "$STAGE_MNT/tmp/$_verdir/upload" "$STAGE_MNT/usr/local/www/squirrelcart" || exit
 	ln -s /data/sc_images "$STAGE_MNT/usr/local/www/squirrelcart/sc_images"
 	install_nginx || exit
-	install_php 72 "mysqli session curl openssl gd json soap xml" || exit
+	install_php 71 "mysqli session curl openssl gd json soap xml" || exit
 
 	stage_pkg_install postfix || exit
 }

--- a/provision-squirrelcart.sh
+++ b/provision-squirrelcart.sh
@@ -52,6 +52,12 @@ install_squirrelcart()
 	install_nginx || exit
 	install_php 71 "mysqli session curl openssl gd json soap xml" || exit
 
+	if [ -f "$ZFS_JAIL_MNT/usr/local/www/squirrelcart/squirrelcart/themes/sc_custom/images/store_logo.png" ]; then
+		tell_status "preserving store logo"
+		cp "$ZFS_JAIL_MNT/usr/local/www/squirrelcart/squirrelcart/themes/sc_custom/images/store_logo.png" \
+			"$STAGE_MNT/usr/local/www/squirrelcart/squirrelcart/themes/sc_custom/images/store_logo.png"
+	fi
+
 	stage_pkg_install postfix || exit
 }
 

--- a/provision-wordpress.sh
+++ b/provision-wordpress.sh
@@ -16,7 +16,7 @@ install_wordpress()
 	install_nginx
 	install_php 72 "curl ftp gd hash mysqli session tokenizer xml zip zlib"
 
-	# stage_pkg_install wordpress
+	stage_pkg_install dialog4ports
 	stage_port_install www/wordpress
 }
 

--- a/test/vmware.sh
+++ b/test/vmware.sh
@@ -65,7 +65,7 @@ cleanstart() {
 vm_setup() {
     # install, no options, Auto ZFS, 8gb swap, sshd & powerd
     #!/bin/sh
-    pkg install -y vim-lite sudo open-vm-tools-nox11 git-lite
+    pkg install -y vim-console sudo open-vm-tools-nox11 git-lite
     chpass -s sh root
     echo 'autoboot_delay="1"' >> /boot/loader.conf
 


### PR DESCRIPTION
- port rename vim-lite -> vim-console
- geoip: work around npm attempts to be clever
- mediawiki: working php7 install support
- smf: update smf version to 2.0.15
- squirrelcart: php 7.2 -> 7.1, for now
- squirrelcart: preserve store logo
- nsd: newly added build
- knot: preserve sys users & start sshd
- nictool: preserve system users
- elasticsearch: update where mem settings are set
- haproxy: install -devel with HTTP2 support, add "alpn h2,http/1.1" to each bind block to enable
