### PR TITLE
Haraka: store git co of Haraka to /root (vs /tmp)

### DIFF
--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -21,10 +21,10 @@ install_haraka()
 	stage_exec npm install -g --only=prod node-gyp || exit
 
 	tell_status "installing Haraka"
-	stage_exec git clone --depth=1 https://github.com/haraka/Haraka.git /tmp/Haraka
+	stage_exec git clone --depth=1 https://github.com/haraka/Haraka.git /root/Haraka
 	stage_exec npm set user 0
 	stage_exec npm set -g unsafe-perm true
-	stage_exec npm install -g --only=prod /tmp/Haraka || exit
+	stage_exec npm install -g --only=prod /root/Haraka || exit
 
 	local _plugins="ws express haraka-plugin-log-reader"
 	for _p in known-senders aliases; do

--- a/provision-wordpress.sh
+++ b/provision-wordpress.sh
@@ -14,7 +14,7 @@ install_wordpress()
 	assure_jail mysql
 
 	install_nginx
-	install_php 72 "curl ftp gd hash mysqli session tokenizer xml zip zlib"
+	install_php 72 "ctype curl ftp gd hash mysqli session tokenizer xml zip zlib"
 
 	stage_pkg_install dialog4ports
 	stage_port_install www/wordpress
@@ -32,6 +32,17 @@ configure_nginx_standalone()
 	server_name     wordpress;
 	index		index.php;
 	root		/usr/local/www;
+
+	location = /favicon.ico {
+		log_not_found off;
+		access_log off;
+	}
+
+	location = /robots.txt {
+		allow all;
+		log_not_found off;
+		access_log off;
+	}
 
 	location / {
 		# include "?$args" so non-default permalinks don't break


### PR DESCRIPTION
### Changes proposed in this pull request:
- haraka: store git co of Haraka to /root (vs /tmp)
- wordpress: disable logging for favicon.ico and robots.txt
