### PR TITLE
create /etc/ssl/private when missing

### DIFF
--- a/provision-host.sh
+++ b/provision-host.sh
@@ -186,7 +186,11 @@ configure_tls_certs()
 	fi
 
 	if [ ! -d /etc/ssl/certs ]; then
-		mkdir "/etc/ssl/certs" "/etc/ssl/private"
+		mkdir "/etc/ssl/certs"
+	fi
+
+	if [ ! -d /etc/ssl/private ]; then
+		mkdir "/etc/ssl/private"
 		chmod o-r "/etc/ssl/private"
 	fi
 


### PR DESCRIPTION
### Changes proposed in this pull request:
- do test on /etc/ssl/private as well, instead of piggybacking on /etc/ssl/certs test
