### PR TITLE
vpopmail: get correct remote IP in lighttpd

### DIFF
--- a/provision-vpopmail.sh
+++ b/provision-vpopmail.sh
@@ -46,6 +46,12 @@ server.modules += ( "mod_cgi" )
 \$HTTP["url"] =~ "^/cgi-bin" {
    cgi.assign = ( "" => "" )
 }
+
+server.modules += ( "mod_extforward" )
+extforward.forwarder = (
+     "$(get_jail_ip haproxy)"  => "trust",
+     "$(get_jail_ip haprox6)"  => "trust",
+)
 EO_LIGHTTPD
 
 	stage_sysrc lighttpd_enable=YES


### PR DESCRIPTION
### Changes proposed in this pull request:
- add proxy directives to lighttpd.conf
