### PR TITLE
fix: python not found during compilation

### DIFF
--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -19,6 +19,7 @@ install_haraka()
 		stage_pkg_install bash || exit
 	fi
 	export PYTHON=/usr/local/bin/python2
+  stage_exec ln -s /usr/local/bin/python2.7 /usr/local/bin/python
 	stage_exec npm install -g --only=prod node-gyp || exit
 
 	tell_status "installing Haraka"

--- a/provision-haraka.sh
+++ b/provision-haraka.sh
@@ -19,7 +19,7 @@ install_haraka()
 		stage_pkg_install bash || exit
 	fi
 	export PYTHON=/usr/local/bin/python2
-  stage_exec ln -s /usr/local/bin/python2.7 /usr/local/bin/python
+	stage_exec ln -s /usr/local/bin/python2.7 /usr/local/bin/python
 	stage_exec npm install -g --only=prod node-gyp || exit
 
 	tell_status "installing Haraka"


### PR DESCRIPTION
### Changes proposed in this pull request:
- python not found during compilation

Fixes # .
```
  ACTION deps_sqlite3_gyp_action_before_build_target_unpack_sqlite_dep Release/obj/gen/sqlite-autoconf-3280000/sqlite3.c
/bin/sh: python: not found
```
See: https://gist.github.com/Infern1/fcf642570f85604ea274526e3d393665

Checklist:
- [ ] docs up-to-date
