### PR TITLE
mysql provision with root password

### DIFF
--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -1,30 +1,5 @@
 #!/bin/sh
 
-set_mysql_password()
-{
-    if [ -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
-        # mysql is already provisioned
-        return
-    fi
-
-    if [ -n "$TOASTER_MYSQL_PASS" ]; then
-        # the password is already set
-        return
-    fi
-
-    tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
-
-    TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
-    export TOASTER_MYSQL_PASS
-
-    if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
-        sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
-        rm mail-toaster.conf.bak
-    else
-        echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
-    fi
-}
-
 mysql_query()
 {
     if [ -n "$1" ]; then

--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set_mysql_password()
+{
+    if [ -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
+        # mysql is already provisioned
+        return
+    fi
+
+    if [ -n "$TOASTER_MYSQL_PASS" ]; then
+        # the password is already set
+        return
+    fi
+
+    tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
+
+    TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
+    export TOASTER_MYSQL_PASS
+
+    if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
+        sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
+        rm mail-toaster.conf.bak
+    else
+        echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
+    fi
+}
+
+mysql_query()
+{
+    if [ -n "$1" ]; then
+        echo "db: $1"
+        jexec mysql /usr/local/bin/mysql --password="$TOASTER_MYSQL_PASS" "$1" || return 1
+    else
+        jexec mysql /usr/local/bin/mysql --password="$TOASTER_MYSQL_PASS" || return 1
+    fi
+
+    return 0
+}
+
+mysql_create_db()
+{
+    if mysql_db_exists "$1"; then
+        tell_status "db '$1' exists in mysql"
+        return 0
+    fi
+
+    tell_status "creating mysql database $1"
+    echo "CREATE DATABASE $1;" | jexec mysql /usr/local/bin/mysql --password="$TOASTER_MYSQL_PASS" || return 1
+    return 0
+}
+
+mysql_db_exists()
+{
+    local _query="SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='$1';"
+    result=$(echo "$_query" | jexec mysql mysql -s -N --password="$TOASTER_MYSQL_PASS")
+
+    if [ -z "$result" ]; then
+        echo "$1 db does not exist"
+        return 1
+    fi
+
+    echo "$1 db exists"
+    return 0
+}

--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -1,12 +1,55 @@
 #!/bin/sh
 
+# shellcheck disable=SC2046
+
+_root="$ZFS_JAIL_MNT/mysql/root"
+
+mysql_password_set()
+{
+    if [ -f "$_root/.mylogin.cnf" ]; then return 0; fi
+    if grep -qs ^password "$_root/.my.cnf"; then return 0; fi
+
+    return 1
+}
+
+mysql_bin()
+{
+    if mysql_password_set; then
+        echo "/usr/local/bin/mysql"
+        return
+    fi
+
+    # unset in toaster-watcher.conf
+    if [ -z "$TOASTER_MYSQL_PASS" ]; then
+        echo "/usr/local/bin/mysql"
+        return
+    fi
+
+    # file exists and has [client] section
+    if [ -f "$_root/.my.cnf" ] && grep -q '^\[client\]' "$_root/.my.cnf"; then
+        # TODO: use sed to insert immediately after [client]?
+        echo "/usr/local/bin/mysql --password=\"$TOASTER_MYSQL_PASS\""
+        return
+    fi
+
+    local _before; _before=$(umask)
+    umask 077
+    tee -a "$_root/.my.cnf" <<EO_MY_CNF
+[client]
+user = root
+password = $TOASTER_MYSQL_PASS
+EO_MY_CNF
+    echo "/usr/local/bin/mysql"
+    umask "$_before"
+}
+
 mysql_query()
 {
     if [ -n "$1" ]; then
         echo "db: $1"
-        jexec mysql /usr/local/bin/mysql --password="$TOASTER_MYSQL_PASS" "$1" || return 1
+        jexec mysql $(mysql_bin) "$1" || return 1
     else
-        jexec mysql /usr/local/bin/mysql --password="$TOASTER_MYSQL_PASS" || return 1
+        jexec mysql $(mysql_bin) || return 1
     fi
 
     return 0
@@ -20,14 +63,14 @@ mysql_create_db()
     fi
 
     tell_status "creating mysql database $1"
-    echo "CREATE DATABASE $1;" | jexec mysql /usr/local/bin/mysql --password="$TOASTER_MYSQL_PASS" || return 1
+    echo "CREATE DATABASE $1;" | jexec mysql $(mysql_bin) || return 1
     return 0
 }
 
 mysql_db_exists()
 {
     local _query="SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='$1';"
-    result=$(echo "$_query" | jexec mysql mysql -s -N --password="$TOASTER_MYSQL_PASS")
+    result=$(echo "$_query" | jexec mysql $(mysql_bin) -s -N)
 
     if [ -z "$result" ]; then
         echo "$1 db does not exist"

--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -6,77 +6,77 @@ _root="$ZFS_JAIL_MNT/mysql/root"
 
 mysql_password_set()
 {
-    if [ -f "$_root/.mylogin.cnf" ]; then return 0; fi
-    if grep -qs ^password "$_root/.my.cnf"; then return 0; fi
+	if [ -f "$_root/.mylogin.cnf" ]; then return 0; fi
+	if grep -qs ^password "$_root/.my.cnf"; then return 0; fi
 
-    return 1
+	return 1
 }
 
 mysql_bin()
 {
-    if mysql_password_set; then
-        echo "/usr/local/bin/mysql"
-        return
-    fi
+	if mysql_password_set; then
+		echo "/usr/local/bin/mysql"
+		return
+	fi
 
-    # unset in toaster-watcher.conf
-    if [ -z "$TOASTER_MYSQL_PASS" ]; then
-        echo "/usr/local/bin/mysql"
-        return
-    fi
+	# unset in toaster-watcher.conf
+	if [ -z "$TOASTER_MYSQL_PASS" ]; then
+		echo "/usr/local/bin/mysql"
+		return
+	fi
 
-    # file exists and has [client] section
-    if [ -f "$_root/.my.cnf" ] && grep -q '^\[client\]' "$_root/.my.cnf"; then
-        # TODO: use sed to insert immediately after [client]?
-        echo "/usr/local/bin/mysql --password=\"$TOASTER_MYSQL_PASS\""
-        return
-    fi
+	# file exists and has [client] section
+	if [ -f "$_root/.my.cnf" ] && grep -q '^\[client\]' "$_root/.my.cnf"; then
+		# TODO: use sed to insert immediately after [client]?
+		echo "/usr/local/bin/mysql --password=\"$TOASTER_MYSQL_PASS\""
+		return
+	fi
 
-    local _before; _before=$(umask)
-    umask 077
-    tee -a "$_root/.my.cnf" <<EO_MY_CNF
+	local _before; _before=$(umask)
+	umask 077
+	tee -a "$_root/.my.cnf" <<EO_MY_CNF
 [client]
 user = root
 password = $TOASTER_MYSQL_PASS
 EO_MY_CNF
-    echo "/usr/local/bin/mysql"
-    umask "$_before"
+	echo "/usr/local/bin/mysql"
+	umask "$_before"
 }
 
 mysql_query()
 {
-    if [ -n "$1" ]; then
-        echo "db: $1"
-        jexec mysql $(mysql_bin) "$1" || return 1
-    else
-        jexec mysql $(mysql_bin) || return 1
-    fi
+	if [ -n "$1" ]; then
+		echo "db: $1"
+		jexec mysql $(mysql_bin) "$1" || return 1
+	else
+		jexec mysql $(mysql_bin) || return 1
+	fi
 
-    return 0
+	return 0
 }
 
 mysql_create_db()
 {
-    if mysql_db_exists "$1"; then
-        tell_status "db '$1' exists in mysql"
-        return 0
-    fi
+	if mysql_db_exists "$1"; then
+		tell_status "db '$1' exists in mysql"
+		return 0
+	fi
 
-    tell_status "creating mysql database $1"
-    echo "CREATE DATABASE $1;" | jexec mysql $(mysql_bin) || return 1
-    return 0
+	tell_status "creating mysql database $1"
+	echo "CREATE DATABASE $1;" | jexec mysql $(mysql_bin) || return 1
+	return 0
 }
 
 mysql_db_exists()
 {
-    local _query="SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='$1';"
-    result=$(echo "$_query" | jexec mysql $(mysql_bin) -s -N)
+	local _query="SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='$1';"
+	result=$(echo "$_query" | jexec mysql $(mysql_bin) -s -N)
 
-    if [ -z "$result" ]; then
-        echo "$1 db does not exist"
-        return 1
-    fi
+	if [ -z "$result" ]; then
+		echo "$1 db does not exist"
+		return 1
+	fi
 
-    echo "$1 db exists"
-    return 0
+	echo "$1 db exists"
+	return 0
 }

--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -19,25 +19,12 @@ mysql_bin()
 		return
 	fi
 
-	# unset in toaster-watcher.conf
-	if [ -z "$TOASTER_MYSQL_PASS" ]; then
-		echo "/usr/local/bin/mysql"
-		return
-	fi
-
-	# file exists and has [client] section
-	if [ -f "$_root/.my.cnf" ] && grep -q '^\[client\]' "$_root/.my.cnf"; then
-		# TODO: use sed to insert immediately after [client]?
+	# set in toaster-watcher.conf
+	if [ -n "$TOASTER_MYSQL_PASS" ]; then
 		echo "/usr/local/bin/mysql --password=\"$TOASTER_MYSQL_PASS\""
 		return
 	fi
 
-	tee -a "$_root/.my.cnf" <<EO_MY_CNF
-[client]
-user = root
-password = $TOASTER_MYSQL_PASS
-EO_MY_CNF
-	chmod 600 "$_root/.my.cnf"
 	echo "/usr/local/bin/mysql"
 }
 

--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -32,15 +32,13 @@ mysql_bin()
 		return
 	fi
 
-	local _before; _before=$(umask)
-	umask 077
 	tee -a "$_root/.my.cnf" <<EO_MY_CNF
 [client]
 user = root
 password = $TOASTER_MYSQL_PASS
 EO_MY_CNF
+	chmod 600 "$_root/.my.cnf"
 	echo "/usr/local/bin/mysql"
-	umask "$_before"
 }
 
 mysql_query()

--- a/include/shell.sh
+++ b/include/shell.sh
@@ -2,30 +2,30 @@
 
 install_bash()
 {
-    tell_status "installing bash"
-    stage_pkg_install bash || exit
-    stage_exec chpass -s /usr/local/bin/bash
+	tell_status "installing bash"
+	stage_pkg_install bash || exit
+	stage_exec chpass -s /usr/local/bin/bash
 
-    local _profile="$1/root/.bash_profile"
-    if [ -f "$_profile" ]; then
-        tell_status "preserving $_profile"
-        return
-    fi
+	local _profile="$1/root/.bash_profile"
+	if [ -f "$_profile" ]; then
+		tell_status "preserving $_profile"
+		return
+	fi
 
-    tell_status "adding .bash_profile for root@jail"
-    configure_bash "$_profile"
+	tell_status "adding .bash_profile for root@jail"
+	configure_bash "$_profile"
 }
 
 install_zsh()
 {
-    tell_status "installing zsh"
-    stage_pkg_install zsh || exit
-    stage_exec chpass -s /usr/local/bin/zsh
+	tell_status "installing zsh"
+	stage_pkg_install zsh || exit
+	stage_exec chpass -s /usr/local/bin/zsh
 }
 
 configure_bash()
 {
-    tee -a "$1" <<'EO_BASH_PROFILE'
+	tee -a "$1" <<'EO_BASH_PROFILE'
 
 export EDITOR="vim"
 export BLOCKSIZE=K;
@@ -42,13 +42,13 @@ EO_BASH_PROFILE
 
 configure_bourne_shell()
 {
-    if grep -q ^PS1 "$1/etc/profile"; then
-        tell_status "bourne shell configured"
-        return
-    fi
+	if grep -q ^PS1 "$1/etc/profile"; then
+		tell_status "bourne shell configured"
+		return
+	fi
 
-    tell_status "customizing bourne shell prompt"
-    tee -a "$1/etc/profile" <<'EO_BOURNE_SHELL'
+	tell_status "customizing bourne shell prompt"
+	tee -a "$1/etc/profile" <<'EO_BOURNE_SHELL'
 alias h='fc -l'
 alias j=jobs
 alias m=$PAGER
@@ -66,14 +66,14 @@ EO_BOURNE_SHELL
 
 configure_csh_shell()
 {
-    _cshrc="$1/etc/csh.cshrc"
-    if grep -q prompt "$_cshrc"; then
-        tell_status "preserving $_cshrc"
-        return
-    fi
+	_cshrc="$1/etc/csh.cshrc"
+	if grep -q prompt "$_cshrc"; then
+		tell_status "preserving $_cshrc"
+		return
+	fi
 
-    tell_status "configure C shell"
-    tee -a "$_cshrc" <<'EO_CSHRC'
+	tell_status "configure C shell"
+	tee -a "$_cshrc" <<'EO_CSHRC'
 alias h         history 25
 alias j         jobs -l
 alias la        ls -aF
@@ -108,15 +108,15 @@ EO_CSHRC
 
 configure_zsh_shell()
 {
-    tell_status "making zsh more comfy with ZIM"
+	tell_status "making zsh more comfy with ZIM"
 
-    fetch -o - https://github.com/Infern1/Mail-Toaster-6/raw/master/contrib/zim.tar.gz \
-    | tar -C "$1/root/" -xf -  || echo "Zsh config failed!"
-    stage_exec zsh -c '. /root/.zshrc;  source /root/.zlogin'
-    stage_exec mkdir /root/.config
-    stage_exec cp /root/.zim/modules/prompt/external-themes/liquidprompt/liquidpromptrc-dist /root/.config/liquidpromptrc
-    stage_exec sed -i .bak \
-                    -e 's/^LP_HOSTNAME_ALWAYS=0/LP_HOSTNAME_ALWAYS=1/' \
-                    "/root/.config/liquidpromptrc" || exit
+	fetch -o - https://github.com/Infern1/Mail-Toaster-6/raw/master/contrib/zim.tar.gz \
+	| tar -C "$1/root/" -xf -  || echo "Zsh config failed!"
+	stage_exec zsh -c '. /root/.zshrc;  source /root/.zlogin'
+	stage_exec mkdir /root/.config
+	stage_exec cp /root/.zim/modules/prompt/external-themes/liquidprompt/liquidpromptrc-dist /root/.config/liquidpromptrc
+	stage_exec sed -i .bak \
+					-e 's/^LP_HOSTNAME_ALWAYS=0/LP_HOSTNAME_ALWAYS=1/' \
+					"/root/.config/liquidpromptrc" || exit
 
 }

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1101,29 +1101,29 @@ mt6-include()
 
 jail_rename()
 {
-    if [ -z "$1" ] || [ -z "$2" ]; then
-        echo "$0 <existing jail name> <new jail name>"
-        exit
-    fi
+	if [ -z "$1" ] || [ -z "$2" ]; then
+		echo "$0 <existing jail name> <new jail name>"
+		exit
+	fi
 
-    echo "renaming $1 to $2"
-    service jail stop "$1"  || exit
+	echo "renaming $1 to $2"
+	service jail stop "$1"  || exit
 
-    for _f in data jails
-    do
-        zfs unmount "$ZFS_VOL/$_f/$1"
-        zfs rename "$ZFS_VOL/$_f/$1" "$ZFS_VOL/$_f/$2"  || exit
-        zfs set mountpoint="/$_f/$2" "$ZFS_VOL/$_f/$2"  || exit
-        zfs mount "$ZFS_VOL/$_f/$2"
-    done
+	for _f in data jails
+	do
+		zfs unmount "$ZFS_VOL/$_f/$1"
+		zfs rename "$ZFS_VOL/$_f/$1" "$ZFS_VOL/$_f/$2"  || exit
+		zfs set mountpoint="/$_f/$2" "$ZFS_VOL/$_f/$2"  || exit
+		zfs mount "$ZFS_VOL/$_f/$2"
+	done
 
-    sed -i .bak \
-        -e "/^$1\s/ s/$1/$2/" \
-        /etc/jail.conf || exit
+	sed -i .bak \
+		-e "/^$1\s/ s/$1/$2/" \
+		/etc/jail.conf || exit
 
-    service jail start "$2"
+	service jail start "$2"
 
-    echo "Don't forget to update your PF and/or Haproxy rules"
+	echo "Don't forget to update your PF and/or Haproxy rules"
 }
 
 configure_pkg_latest()

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -914,20 +914,6 @@ get_public_ip()
 	fi
 }
 
-mysql_db_exists()
-{
-	local _query="SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='$1';"
-	result=$(echo "$_query" | jexec mysql mysql -s -N)
-
-	if [ -z "$result" ]; then
-		echo "$1 db does not exist"
-		return 1
-	fi
-
-	echo "$1 db exists"
-	return 0
-}
-
 fetch_and_exec()
 {
 	if [ ! -d provision ]; then mkdir provision; fi

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # bump version when a change in this file effects a provision script(s)
-mt6_version() { echo "20200114"; }
+mt6_version() { echo "20200115"; }
 
 dec_to_hex() { printf '%04x\n' "$1"; }
 
@@ -52,6 +52,7 @@ export ZFS_VOL="zroot"
 export ZFS_JAIL_MNT="/jails"
 export ZFS_DATA_MNT="/data"
 export TOASTER_MYSQL="0"
+export TOASTER_MYSQL_PASS=""
 export TOASTER_MARIADB="0"
 export TOASTER_PKG_AUDIT="0"
 export ROUNDCUBE_SQL="0"
@@ -986,6 +987,7 @@ unprovision_filesystem()
 
 	if zfs_filesystem_exists "$ZFS_DATA_VOL/$1"; then
 		tell_status "destroying $ZFS_DATA_MNT/$1"
+		unmount_data "$1"
 		zfs destroy "$ZFS_DATA_VOL/$1"
 	fi
 
@@ -1040,7 +1042,7 @@ unprovision()
 			return
 		fi
 
-		service jail stop "$1"
+		service jail stop stage "$1"
 		unprovision_filesystem "$1"
 		return
 	fi

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -65,12 +65,20 @@ export TOASTER_MSA="haraka"
 export MAXMIND_LICENSE_KEY=""
 
 EO_MT_CONF
+
+	chmod 600 mail-toaster.conf
 }
 
 config()
 {
 	if [ ! -f "mail-toaster.conf" ]; then
 		create_default_config
+	fi
+
+	local _mode; _mode=$(stat -f "%OLp" mail-toaster.conf)
+	if [ "$_mode" -ne 600 ]; then
+		echo "tightening permissions on mail-toaster.conf"
+		chmod 600 mail-toaster.conf
 	fi
 
 	echo "loading mail-toaster.conf"

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -143,6 +143,7 @@ enable_security_periodic()
 
 	tee "$_daily/auto_security_upgrades" <<'EO_PKG_SECURITY'
 #!/bin/sh
+# packages that can be safely updated automatically
 for _pkg in curl expat vim-console;
 do
   /usr/sbin/pkg audit | grep "$_pkg" && pkg install -y "$_pkg"
@@ -582,10 +583,11 @@ freebsd_update
 configure_base
 start_staged_jail base "$BASE_MNT" || exit
 install_base
-jail -r stage
+stop_jail stage
 umount "$BASE_MNT/dev"
 rm -rf "$BASE_MNT/var/cache/pkg/*"
 echo "zfs snapshot ${BASE_SNAP}"
 zfs snapshot "${BASE_SNAP}" || exit
+add_jail_conf base
 
 proclaim_success base

--- a/provision/dspam.sh
+++ b/provision/dspam.sh
@@ -82,7 +82,7 @@ test_dspam()
 {
 	tell_status "testing dspam"
 	sleep 2
-	stage_listening 24
+	stage_listening 2424
 	echo "it worked"
 }
 

--- a/provision/dspam.sh
+++ b/provision/dspam.sh
@@ -6,6 +6,8 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
+mt6-include mysql
+
 install_dspam()
 {
 	assure_jail mysql
@@ -24,10 +26,7 @@ configure_dspam_mysql()
 	fi
 
 	local _last
-	if ! mysql_db_exists dspam; then
-		tell_status "creating dspam database"
-		echo "CREATE DATABASE dspam;" | jexec mysql /usr/local/bin/mysql || exit
-	fi
+	mysql_create_db dspam || exit
 
 	local _curcfg="$ZFS_JAIL_MNT/dspam/usr/local/etc/dspam.conf"
 	if [ -f "$_curcfg" ]; then
@@ -46,7 +45,7 @@ configure_dspam_mysql()
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
 			echo "GRANT ALL PRIVILEGES ON dspam.* to 'dspam'@'${_ip}' IDENTIFIED BY '${_dpass}';" \
-				| jexec mysql /usr/local/bin/mysql || exit
+				| mysql_query || exit
 		done
 	done
 }

--- a/provision/gitlab.sh
+++ b/provision/gitlab.sh
@@ -34,7 +34,7 @@ postgres:\
 		:tc=default:
 EO_LC
 
- 		stage_exec cap_mkdb /etc/login.conf
+		stage_exec cap_mkdb /etc/login.conf
 		stage_sysrc postgresql_class=postgres
 	fi
 

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -11,6 +11,7 @@ mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include 'php'
 mt6-include nginx
+mt6-include mysql
 
 install_horde()
 {
@@ -89,8 +90,7 @@ install_horde_mysql()
 {
 	local _init_db=0
 	if ! mysql_db_exists horde; then
-		tell_status "creating horde mysql db"
-		echo "CREATE DATABASE horde;" | jexec mysql /usr/local/bin/mysql || exit
+		mysql_create_db horde || exit
 		_init_db=1
 	fi
 
@@ -246,7 +246,7 @@ EO_HORDE_PREFS
 			for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 			do
 				echo "GRANT ALL PRIVILEGES ON horde.* to 'horde'@'${_ip}' IDENTIFIED BY '${_hordepass}';" \
-					| jexec mysql /usr/local/bin/mysql || exit
+					| mysql_query || exit
 			done
 		done
 	fi

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -9,7 +9,7 @@ export JAIL_CONF_EXTRA="
 mount += \"$ZFS_DATA_MNT/horde \$path/data nullfs rw 0 0\";
 mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
-mt6-include 'php'
+mt6-include php
 mt6-include nginx
 mt6-include mysql
 

--- a/provision/joomla.sh
+++ b/provision/joomla.sh
@@ -7,7 +7,7 @@ export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA=""
 
-mt6-include 'php'
+mt6-include php
 mt6-include nginx
 
 install_joomla()

--- a/provision/mediawiki.sh
+++ b/provision/mediawiki.sh
@@ -6,7 +6,7 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
-mt6-include 'php'
+mt6-include php
 mt6-include nginx
 
 install_mediawiki()

--- a/provision/monitor.sh
+++ b/provision/monitor.sh
@@ -79,7 +79,7 @@ fastcgi.server += (
 	"/munin-cgi/munin-cgi-graph" =>
 		( "munin-cgi-graph" => (
 			"bin-path"    => "/usr/local/www/cgi-bin/munin-cgi-graph",
-			"socket"      => "/var/spool/lighttpd/sockets/munin-cgi-graph.sock", 
+			"socket"      => "/var/spool/lighttpd/sockets/munin-cgi-graph.sock",
 			"bin-copy-environment" => ("PATH", "SHELL", "USER"),
 			"check-local" => "disable",
 			"broken-scriptfilename" => "enable",
@@ -179,7 +179,7 @@ configure_monitor()
 
 start_monitor()
 {
-   	tell_status "starting monitor"
+	tell_status "starting monitor"
 }
 
 test_monitor()

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -7,6 +7,8 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		mount += \"$ZFS_DATA_MNT/mysql \$path/var/db/mysql nullfs rw 0 0\";"
 
+mt6-include mysql
+
 install_db_server()
 {
 	#Check if MariaDB needs to be installed
@@ -104,20 +106,7 @@ test_mysql()
 	fi
 }
 
-# if mysql isn't already provisioned
-if [ ! -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
-	# and the password is unset...
-	if [ -z "$TOASTER_MYSQL_PASS" ]; then
-		tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
-		TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
-		export TOASTER_MYSQL_PASS
-		if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
-			sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
-		else
-			echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
-		fi
-	fi
-fi
+set_mysql_password
 
 if [ "$TOASTER_MYSQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ]; then
 	tell_status "installing MySQL"

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -87,23 +87,40 @@ test_mysql()
 {
 	tell_status "testing mysql"
 	if [ -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
-		true
-	else
-		sleep 1
-		_inital_pass=$(tail -n1 "$STAGE_MNT/root/.mysql_secret")
-		if [ -z "$_inital_pass" ]; then
-			echo "ERROR: unable to find the mysql intial password"
-			exit 1
-		fi
-		echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$TOASTER_MYSQL_PASS';" \
-			| stage_exec mysql -u root --connect-expired-password --password="$_inital_pass" \
-			|| exit
-		rm "$STAGE_MNT/root/.mysql_secret"
-
-		echo 'SHOW DATABASES' | stage_exec mysql --password="$TOASTER_MYSQL_PASS" || exit
-		stage_listening 3306
-		echo "it worked"
+		return
 	fi
+
+	sleep 1
+	_inital_pass=$(tail -n1 "$STAGE_MNT/root/.mysql_secret")
+	if [ -z "$_inital_pass" ]; then
+		echo "ERROR: unable to find the mysql intial password"
+		exit 1
+	fi
+	echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$TOASTER_MYSQL_PASS';" \
+		| stage_exec mysql -u root --connect-expired-password --password="$_inital_pass" \
+		|| exit
+	rm "$STAGE_MNT/root/.mysql_secret"
+
+	echo 'SHOW DATABASES' | stage_exec mysql --password="$TOASTER_MYSQL_PASS" || exit
+	stage_listening 3306
+	echo "it worked"
+}
+
+write_pass_to_conf()
+{
+	if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
+		sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
+		rm mail-toaster.conf.bak
+	else
+		echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
+	fi
+
+	tee "$STAGE_MNT/root/.my.cnf" <<EO_MY_CNF
+[client]
+user = root
+password = $TOASTER_MYSQL_PASS
+EO_MY_CNF
+	chmod 600 "$STAGE_MNT/root/.my.cnf"
 }
 
 set_mysql_password()
@@ -123,12 +140,7 @@ set_mysql_password()
 	TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
 	export TOASTER_MYSQL_PASS
 
-	if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
-		sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
-		rm mail-toaster.conf.bak
-	else
-		echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
-	fi
+	write_pass_to_conf
 }
 
 set_mysql_password

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -98,6 +98,8 @@ test_mysql()
 		echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$TOASTER_MYSQL_PASS';" \
 			| stage_exec mysql -u root --connect-expired-password --password="$_inital_pass" \
 			|| exit
+        rm "$STAGE_MNT/root/.mysql_secret"
+
 		echo 'SHOW DATABASES' | stage_exec mysql --password="$TOASTER_MYSQL_PASS" || exit
 		stage_listening 3306
 		echo "it worked"
@@ -131,7 +133,7 @@ set_mysql_password()
 
 set_mysql_password
 
-if [ "$TOASTER_MYSQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ]; then
+if [ "$TOASTER_MYSQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ] || [ "$ROUNDCUBE_SQL" = "1" ]; then
 	tell_status "installing MySQL"
 else
 	tell_status "skipping MySQL install, not configured"

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -130,20 +130,15 @@ set_mysql_password()
 		return
 	fi
 
-	if [ -n "$TOASTER_MYSQL_PASS" ]; then
-		# the password is already set
-		return
+	if [ -z "$TOASTER_MYSQL_PASS" ]; then
+		tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
+
+		TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
+		export TOASTER_MYSQL_PASS
 	fi
-
-	tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
-
-	TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
-	export TOASTER_MYSQL_PASS
 
 	write_pass_to_conf
 }
-
-set_mysql_password
 
 if [ "$TOASTER_MYSQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ] || [ "$ROUNDCUBE_SQL" = "1" ]; then
 	tell_status "installing MySQL"
@@ -154,6 +149,7 @@ fi
 
 base_snapshot_exists || exit
 create_staged_fs mysql
+set_mysql_password
 start_staged_jail mysql
 install_db_server
 start_mysql

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -98,7 +98,7 @@ test_mysql()
 		echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$TOASTER_MYSQL_PASS';" \
 			| stage_exec mysql -u root --connect-expired-password --password="$_inital_pass" \
 			|| exit
-        rm "$STAGE_MNT/root/.mysql_secret"
+		rm "$STAGE_MNT/root/.mysql_secret"
 
 		echo 'SHOW DATABASES' | stage_exec mysql --password="$TOASTER_MYSQL_PASS" || exit
 		stage_listening 3306
@@ -108,27 +108,27 @@ test_mysql()
 
 set_mysql_password()
 {
-    if [ -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
-        # mysql is already provisioned
-        return
-    fi
+	if [ -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
+		# mysql is already provisioned
+		return
+	fi
 
-    if [ -n "$TOASTER_MYSQL_PASS" ]; then
-        # the password is already set
-        return
-    fi
+	if [ -n "$TOASTER_MYSQL_PASS" ]; then
+		# the password is already set
+		return
+	fi
 
-    tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
+	tell_status "TOASTER_MYSQL_PASS unset in mail-toaster.conf, generating a password"
 
-    TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
-    export TOASTER_MYSQL_PASS
+	TOASTER_MYSQL_PASS=$(openssl rand -base64 15)
+	export TOASTER_MYSQL_PASS
 
-    if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
-        sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
-        rm mail-toaster.conf.bak
-    else
-        echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
-    fi
+	if grep -sq TOASTER_MYSQL_PASS mail-toaster.conf; then
+		sed -i .bak -e "/^export TOASTER_MYSQL_PASS=/ s/=.*$/=\"$TOASTER_MYSQL_PASS\"/" mail-toaster.conf
+		rm mail-toaster.conf.bak
+	else
+		echo "export TOASTER_MYSQL_PASS=\"$TOASTER_MYSQL_PASS\"" >> mail-toaster.conf
+	fi
 }
 
 set_mysql_password

--- a/provision/nictool.sh
+++ b/provision/nictool.sh
@@ -10,6 +10,8 @@ export JAIL_CONF_EXTRA=""
 export NICTOOL_VER=${NICTOOL_VER:="2.33"}
 export NICTOOL_UPGRADE=""
 
+mt6-include mysql
+
 install_nt_prereqs()
 {
 	assure_jail mysql
@@ -97,8 +99,7 @@ install_nictool_server() {
 		for _jail in nictool stage; do
 			for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 			do
-				echo "GRANT ALL PRIVILEGES ON nictool.* TO 'nictool'@'${_ip}' IDENTIFIED BY 'lootcin205';" \
-					| jexec mysql /usr/local/bin/mysql || exit
+				echo "GRANT ALL PRIVILEGES ON nictool.* TO 'nictool'@'${_ip}' IDENTIFIED BY 'lootcin205';" | mysql_query || exit
 			done
 		done
 	fi
@@ -161,17 +162,12 @@ install_nictool_db()
 {
 	if [ "$NICTOOL_UPGRADE" = "1" ]; then return; fi
 
-	if mysql_db_exists nictool; then
-		tell_status "nictool mysql db exists"
-		return
-	fi
+	create_mysql_db nictool || exit
 
-	tell_status "creating nictool mysql db"
-	echo "CREATE DATABASE nictool;" | jexec mysql /usr/local/bin/mysql || exit
 	for f in "$STAGE_MNT"/usr/local/nictool/server/sql/*.sql; do
 		tell_status "creating nictool table $f"
 		# shellcheck disable=SC2002
-		cat "$f" | jexec mysql /usr/local/bin/mysql nictool
+		cat "$f" | mysql_query nictool || exit
 		sleep 1;
 	done
 }

--- a/provision/php7.sh
+++ b/provision/php7.sh
@@ -6,7 +6,7 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
-mt6-include 'php'
+mt6-include php
 
 install_php7()
 {

--- a/provision/rainloop.sh
+++ b/provision/rainloop.sh
@@ -7,7 +7,7 @@ export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA=""
 
-mt6-include 'php'
+mt6-include php
 mt6-include nginx
 
 install_rainloop()

--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -9,6 +9,7 @@ export JAIL_CONF_EXTRA=""
 
 mt6-include 'php'
 mt6-include nginx
+mt6-include mysql
 
 mysql_error_warning()
 {
@@ -26,7 +27,7 @@ install_roundcube_mysql()
 	local _init_db=0
 	if ! mysql_db_exists roundcubemail; then
 		tell_status "creating roundcube mysql db"
-		echo "CREATE DATABASE roundcubemail;" | jexec mysql /usr/local/bin/mysql || mysql_error_warning
+		mysql_create_db roundcubemail || mysql_error_warning
 
 		if mysql_db_exists roundcubemail; then
 			_init_db=1
@@ -58,7 +59,7 @@ install_roundcube_mysql()
 			for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 			do
 				echo "GRANT ALL PRIVILEGES ON roundcubemail.* to 'roundcube'@'${_ip}' IDENTIFIED BY '${_rcpass}';" \
-					| jexec mysql /usr/local/bin/mysql || exit
+					| mysql_query || exit
 			done
 		done
 

--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -7,7 +7,7 @@ export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA=""
 
-mt6-include 'php'
+mt6-include php
 mt6-include nginx
 mt6-include mysql
 

--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -150,7 +150,7 @@ configure_roundcube()
 	sed -i .bak \
 		-e "/'default_host'/ s/'localhost'/'$_dovecot_ip'/" \
 		-e "/'smtp_server'/  s/= '.*'/= 'ssl:\/\/$TOASTER_MSA'/" \
-		-e "/'smtp_port'/    s/25;/465;/" \
+		-e "/'smtp_port'/    s/25;/465;/ ; s/587;/465;/" \
 		-e "/'smtp_user'/    s/'';/'%u';/" \
 		-e "/'smtp_pass'/    s/'';/'%p';/" \
 		-e "/'archive',/     s/,$/, 'managesieve',/" \

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -14,7 +14,7 @@ install_sa_update()
 	tell_status "adding sa-update periodic task"
 	local _periodic="$STAGE_MNT/usr/local/etc/periodic"
 	mkdir -p "$_periodic/daily"
-	cat <<EO_SAUPD > $_periodic/daily/502.sa-update
+	cat <<EO_SAUPD > "$_periodic/daily/502.sa-update"
 #!/bin/sh
 PATH=/usr/local/bin:/usr/bin:/bin
 /usr/local/bin/perl -T /usr/local/bin/sa-update \
@@ -41,13 +41,13 @@ install_spamassassin_port()
 	tell_status "install SpamAssassin from ports (w/opts)"
 	stage_pkg_install dialog4ports p5-Encode-Detect p5-Test-NoWarnings || exit
 
-	local _SA_OPTS="DCC DKIM RAZOR RELAY_COUNTRY SPF_QUERY GNUPG_NONE"
+	local _SA_OPTS="DCC DKIM DOCS RAZOR RELAY_COUNTRY SPF_QUERY GNUPG_NONE"
 	if [ "$TOASTER_MYSQL" = "1" ]; then
 		_SA_OPTS="MYSQL $_SA_OPTS"
 	fi
 
 	stage_make_conf mail_spamassassin_SET "mail_spamassassin_SET=$_SA_OPTS"
-	stage_make_conf mail_spamassassin_UNSET 'mail_spamassassin_UNSET=SSL DOCS GNUPG GNUPG2 PYZOR PGSQL RLIMIT'
+	stage_make_conf mail_spamassassin_UNSET 'mail_spamassassin_UNSET=SSL GNUPG GNUPG2 PYZOR PGSQL RLIMIT'
 	stage_make_conf dcc-dccd_SET 'mail_dcc-dccd_SET=DCCIFD IPV6'
 	stage_make_conf dcc-dccd_UNSET 'mail_dcc-dccd_UNSET=DCCGREY DCCD DCCM PORTS_MILTER'
 	stage_make_conf LICENSES_ACCEPTED 'LICENSES_ACCEPTED=DCC'
@@ -273,18 +273,20 @@ EO_MYSQL_CONF
 
 	mysql_create_db spamassassin || exit
 
-	for _import_file in awl_mysql bayes_mysql userpref_mysql;
+	# bayes_mysql
+	for _import_file in awl_mysql userpref_mysql;
 	do
 		local _f="$STAGE_MNT/usr/local/share/doc/spamassassin/sql/${_import_file}.sql"
 		# shellcheck disable=SC2002
-		cat "$_f" | mysql_query spamassassin
+		cat "$_f" | sed -e 's/TYPE=MyISAM//' | mysql_query spamassassin || exit
 	done
 
 	for _jail in spamassassin stage;
 	do
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
-			echo "GRANT spamassassin.* to 'spamassassin'@'$_ip' IDENTIFIED BY '$_my_pass'" | mysql_query || exit
+			echo "GRANT ALL PRIVILEGES ON spamassassin.* to 'spamassassin'@'$_ip' IDENTIFIED BY '$_my_pass'" \
+				| mysql_query || exit
 		done
 	done
 }

--- a/provision/squirrelmail.sh
+++ b/provision/squirrelmail.sh
@@ -7,7 +7,7 @@ export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA=""
 
-mt6-include 'php'
+mt6-include php
 mt6-include nginx
 mt6-include mysql
 

--- a/provision/squirrelmail.sh
+++ b/provision/squirrelmail.sh
@@ -9,6 +9,7 @@ export JAIL_CONF_EXTRA=""
 
 mt6-include 'php'
 mt6-include nginx
+mt6-include mysql
 
 SQ_DIR="$STAGE_MNT/usr/local/www/squirrelmail"
 
@@ -19,7 +20,7 @@ install_squirrelmail_mysql()
 
 	if ! mysql_db_exists squirrelmail; then
 		tell_status "creating squirrelmail database"
-		echo "CREATE DATABASE squirrelmail;" | jexec mysql /usr/local/bin/mysql || exit
+		mysql_create_db squirrelmail || exit
 		echo "
 CREATE TABLE address (
   owner varchar(128) DEFAULT '' NOT NULL,
@@ -48,7 +49,7 @@ CREATE TABLE userprefs (
   prefkey varchar(64) DEFAULT '' NOT NULL,
   prefval BLOB NOT NULL,
   PRIMARY KEY (user,prefkey)
-);" | jexec mysql /usr/local/bin/mysql squirrelmail || exit
+);" | mysql_query squirrelmail || exit
 
 	fi
 
@@ -67,7 +68,7 @@ EO_SQUIRREL_SQL
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
 			echo "GRANT ALL PRIVILEGES ON squirrelmail.* to 'squirrelmail'@'${_ip}' IDENTIFIED BY '${sqpass}';" \
-				| jexec mysql /usr/local/bin/mysql || exit
+				| mysql_query || exit
 		done
 	done
 }

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -10,6 +10,7 @@ export JAIL_CONF_EXTRA="
 		mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include vpopmail
+mt6-include mysql
 
 install_maildrop()
 {
@@ -107,8 +108,7 @@ install_vpopmail_mysql_grants()
 	fi
 
 	if ! mysql_db_exists vpopmail; then
-		tell_status "creating vpopmail database"
-		echo "CREATE DATABASE vpopmail;" | jexec mysql /usr/local/bin/mysql || mysql_error_warning
+		mysql_create_db vpopmail || mysql_error_warning
 	fi
 
 	if ! mysql_db_exists vpopmail; then
@@ -133,7 +133,7 @@ install_vpopmail_mysql_grants()
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
 			echo "GRANT ALL PRIVILEGES ON vpopmail.* to 'vpopmail'@'${_ip}' IDENTIFIED BY '${_vpass}';" \
-				| jexec mysql /usr/local/bin/mysql || exit
+				| mysql_query || exit
 		done
 	done
 }

--- a/test/get_jail_ip.sh
+++ b/test/get_jail_ip.sh
@@ -5,18 +5,18 @@
 
 IP=$(get_jail_ip mysql)
 if [ "$IP" = "172.16.15.4" ]; then
-    echo "mysql IP is $IP"
+	echo "mysql IP is $IP"
 else
-    echo "ERR: default mysql IP is not $IP"
-    exit 2
+	echo "ERR: default mysql IP is not $IP"
+	exit 2
 fi
 
 IP=$(get_jail_ip haraka)
 if [ "$IP" = "172.16.15.9" ]; then
-    echo "haraka IP is $IP"
+	echo "haraka IP is $IP"
 else
-    echo "ERR: haraka IP is not $IP"
-    exit 2
+	echo "ERR: haraka IP is not $IP"
+	exit 2
 fi
 
 exit 0

--- a/test/vmware.sh
+++ b/test/vmware.sh
@@ -14,75 +14,75 @@ GUESTPASS="passWord"
 
 _err()
 {
-    echo "ERROR: $1"
-    exit 1
+	echo "ERROR: $1"
+	exit 1
 }
 
 start()
 {
-    "$VMRUN" -T fusion start "$FREEBSD" || _err "start failed"
-    echo "started"
+	"$VMRUN" -T fusion start "$FREEBSD" || _err "start failed"
+	echo "started"
 }
 
 stop()
 {
-    "$VMRUN" -T fusion stop "$FREEBSD" || _err "start failed"
-    echo "stopped"
+	"$VMRUN" -T fusion stop "$FREEBSD" || _err "start failed"
+	echo "stopped"
 }
 
 listSnapshots()
 {
-    "$VMRUN" listSnapshots "$FREEBSD"
+	"$VMRUN" listSnapshots "$FREEBSD"
 }
 
 runProgramInGuest()
 {
-    PROG="$1"
-    if [ -z "$PROG" ]; then
-        PROG="/home/matt/hi.sh"
-    fi
+	PROG="$1"
+	if [ -z "$PROG" ]; then
+		PROG="/home/matt/hi.sh"
+	fi
 
-    "$VMRUN" -gu "$GUESTUSER" -gp "$GUESTPASS" runProgramInGuest "$FREEBSD" "$PROG"
+	"$VMRUN" -gu "$GUESTUSER" -gp "$GUESTPASS" runProgramInGuest "$FREEBSD" "$PROG"
 }
 
 revertToSnapshot()
 {
-    "$VMRUN" revertToSnapshot "$FREEBSD" "$1" || _err "revert failed"
-    echo "reverted to $1"
+	"$VMRUN" revertToSnapshot "$FREEBSD" "$1" || _err "revert failed"
+	echo "reverted to $1"
 }
 
 listProcessesInGuest()
 {
-    "$VMRUN" -gu "$GUESTUSER" -gp "$GUESTPASS" listProcessesInGuest "$FREEBSD"
+	"$VMRUN" -gu "$GUESTUSER" -gp "$GUESTPASS" listProcessesInGuest "$FREEBSD"
 }
 
 cleanstart() {
-    stop
-    revertToSnapshot "$VERSION"
-    start
+	stop
+	revertToSnapshot "$VERSION"
+	start
 }
 
 vm_setup() {
-    # install, no options, Auto ZFS, 8gb swap, sshd & powerd
-    pkg install -y vim-console sudo open-vm-tools-nox11 git-lite
-    chpass -s sh root
-    echo 'autoboot_delay="1"' >> /boot/loader.conf
+	# install, no options, Auto ZFS, 8gb swap, sshd & powerd
+	pkg install -y vim-console sudo open-vm-tools-nox11 git-lite
+	chpass -s sh root
+	echo 'autoboot_delay="1"' >> /boot/loader.conf
 
-    sed -i '' -e '/^#PermitRootLogin/ s/#//; s/no/without-password/' /etc/ssh/sshd_config
-    service sshd restart
+	sed -i '' -e '/^#PermitRootLogin/ s/#//; s/no/without-password/' /etc/ssh/sshd_config
+	service sshd restart
 
-    for d in usr/src var/audit var/crash var/mail var/tmp; do
-        zfs destroy "zroot/${d}"
-        mkdir "/${d}"
-    done
+	for d in usr/src var/audit var/crash var/mail var/tmp; do
+		zfs destroy "zroot/${d}"
+		mkdir "/${d}"
+	done
 
-    echo "All set, install your SSH keys, shut down & snapshot!"
+	echo "All set, install your SSH keys, shut down & snapshot!"
 }
 
 if [ "$1" = "cleanstart" ] || [ "$1" = "freshstart" ]; then
-    cleanstart
+	cleanstart
 elif [ "$1" ]; then
-    $1
+	$1
 else
-    echo "$0 cleanstart"
+	echo "$0 cleanstart"
 fi


### PR DESCRIPTION
## Issue

The FreeBSD mysql port now installs with an expired random password written to /root/.mysql_secret. In order to provision subsequent jails, a MySQL root password must be set. 

## Approach

To manage this requirement, a mysql root password is generated and stored in mail-toaster.conf *and* in mysql/root/.my.cnf. Because of the obvious potential for security issues, the permissions of mail-toaster.conf are now automatically set to `600`. When the provision script connects to MySQL, if ~root/.mylogin.cnf or ~root/.my.cnf are configured, they are used. Otherwise, the password is passed on the command line.

- When the password is passed on the CLI, mysql emits a warning upon every connection. There are [workarounds](https://stackoverflow.com/questions/20751352/suppress-warning-messages-using-mysql-from-within-terminal-but-password-written).
- pro: the mysql calls are now consolidated into `include/mysql.sh` and can be updated.
- Regarding storing the password in the `[client]` section of ~root/.my.cnf:
    - pro: the standard approach for MySQL, works on all versions of MySQL and likely for alternatives such as MariaDB too.
    - con: the password is stored within the MySQL jail in plain text

### Alternative

For MySQL 5.6+, use `mysql_config_editor set --login-path=local --host=localhost --user=root --password` to obfuscate the password to ~root/.mylogin.cnf. I expect this also works with MariaDB.

- pro: not clear text
- con: can't be set programmatically without a utility like `expect`

### Changes proposed in this pull request:

- mysql: on new provision, store and set root password in mail-toaster.conf and .my.cnf
- various: use include/mysql.sh functions
- remove unnecessary quotes
- dspam: test on port 2424 where dspam now listens
- roundcube: if smtp_port is 587, update to 465
- spamassassin: SQL fixes
- mt.sh: change perms to 600 on mail-toaster.conf
- whitespace cleanups

Fixes #429 

Checklist:
- [ ] docs up-to-date
