### PR TITLE
Rspamd: disable syslog logging (broken upstream)

### DIFF
--- a/provision/base.sh
+++ b/provision/base.sh
@@ -144,7 +144,7 @@ enable_security_periodic()
 	tee "$_daily/auto_security_upgrades" <<'EO_PKG_SECURITY'
 #!/bin/sh
 # packages that can be safely updated automatically
-for _pkg in curl expat vim-console;
+for _pkg in curl expat pkg sudo vim-console;
 do
   /usr/sbin/pkg audit | grep "$_pkg" && pkg install -y "$_pkg"
 done

--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -167,7 +167,7 @@ configure_rspamd()
 		fi
 	done
 
-  	configure_logging
+	#configure_logging
   	configure_redis
 	configure_dmarc
 	configure_stats


### PR DESCRIPTION
### Changes proposed in this pull request:
- rspamd: disable syslog until unbroken upstream
- base: add pkg & sudo to list of ports to autoupgrade

Fixes #432 

Checklist:
- [ ] docs up-to-date
