### PR TITLE
change rspamd worker bind socket to ipv4

### DIFF
--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -143,7 +143,7 @@ EO_SURBL
 configure_worker()
 {
 	tee "$RSPAMD_ETC/local.d/worker-normal.inc" <<EO_WORKER
-	bind_socket = "*v6:11333";
+	bind_socket = "*v4:11333";
 	count = 4;
 EO_WORKER
 }


### PR DESCRIPTION
rsmapd is binding to ipv6 but in haraka config rpamd is accessed by ipv4, this causes that haraka cannot use rpamd and is raising errors, and doesn't use rspamd in karma calculations. In the end we have mail server without proper spam scanning.

### Changes proposed in this pull request:
- change rspamd worker bind socket to ipv4

