### PR TITLE
Change default theme to be more readable

### DIFF
--- a/provision/base.sh
+++ b/provision/base.sh
@@ -444,8 +444,7 @@ endif
 " ============================ theme and status line ============================
 
 " theme
-set background=dark
-colorscheme desert
+colorscheme molokai
 
 " set mark column color
 hi! link SignColumn   LineNr


### PR DESCRIPTION
### Changes proposed in this pull request:
- Change default vim theme


Fixes # 
Reading a `vimdiff`

### Before
![image](https://user-images.githubusercontent.com/928787/95120032-3485eb00-074d-11eb-8c20-9c88f62f5a61.png)

### After
![image](https://user-images.githubusercontent.com/928787/95120072-449dca80-074d-11eb-9378-34216d799de5.png)

 