### PR TITLE
clamav-unofficial: update to 7.2.1

### DIFF
--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -26,7 +26,7 @@ install_clamav_unofficial()
 		dialog --yesno "$_es_mess" 18 74 || return
 	fi
 
-	local CLAMAV_UV=7.2
+	local CLAMAV_UV=7.2.1
 	tell_status "installing ClamAV unofficial $CLAMAV_UV"
 
 	stage_pkg_install gnupg1 rsync bind-tools gtar
@@ -77,6 +77,12 @@ install_clamav_unofficial()
 
 	tell_status "starting a ClamAV UNOFFICIAL update"
 	stage_exec /usr/local/bin/clamav-unofficial-sigs.sh
+
+	if [ ! -d "$STAGE_MNT/var/db/clamav-unofficial-sigs/configs" ]; then
+		mkdir -p "$STAGE_MNT/var/db/clamav-unofficial-sigs/configs"
+		touch "$STAGE_MNT/var/db/clamav-unofficial-sigs/configs/last-version-check.txt"
+		chown 106:106 "$STAGE_MNT/var/db/clamav-unofficial-sigs/configs/last-version-check.txt"
+	fi
 
 	for f in EMAIL_Cryptowall.yar antidebug_antivm.yar; do
 		if [ -f "$ZFS_DATA_MNT/clamav/$f" ]; then

--- a/provision/nsd.sh
+++ b/provision/nsd.sh
@@ -22,6 +22,7 @@ configure_nsd()
 {
 	stage_sysrc nsd_enable=YES
 	stage_sysrc nsd_config=/data/etc/nsd.conf
+	stage_sysrc sshd_enable=YES
 
 	if [ ! -d "$STAGE_MNT/data/etc" ]; then
 		mkdir "$STAGE_MNT/data/etc"
@@ -30,6 +31,10 @@ configure_nsd()
 	if [ ! -f "$STAGE_MNT/data/etc/nsd.conf" ]; then
 		tell_status "installing default nsd.conf"
 		cp "$STAGE_MNT/usr/local/etc/nsd/nsd.conf" "$STAGE_MNT/data/etc/"
+	else
+		tell_status "linking custom nsd.conf to /usr/local"
+		rm "$STAGE_MNT/usr/local/etc/nsd/nsd.conf"
+		stage_exec ln -s /data/etc/nsd.conf /usr/local/etc/nsd/nsd.conf
 	fi
 
 	for _f in master.password group;


### PR DESCRIPTION
### Changes proposed in this pull request:
- clamav-unofficial: update to 7.2.1
- nsd: start up sshd (for updates)
- nsd: if there's no nsd.conf in the data dir, symlink in the default one