### PR TITLE
Fix timezone detection

### DIFF
--- a/include/php.sh
+++ b/include/php.sh
@@ -50,7 +50,7 @@ configure_php_ini()
 
 	tell_status "getting the timezone"
 	TZ=$(md5 -q /etc/localtime)
-	TIMEZONE=$(find /usr/share/zoneinfo -type f -print0 | xargs md5 -r | grep "$TZ" | awk '{print $2}' |cut -c21-)
+	TIMEZONE=$(find /usr/share/zoneinfo -type f -print0 | xargs -0 md5 -r | grep "$TZ" | awk '{print $2}' |cut -c21-)
 
 	if [ -z "$TIMEZONE" ]; then
 		TIMEZONE="America\/Los_Angeles"


### PR DESCRIPTION
### Changes proposed in this pull request:
- Some unrelated commit changed `find ... -print` to `find ... -print0`, ignoring `xargs` in the pipe. Add `-0` to `xargs`. Otherwise timezone is always set to America/LA 
