### PR TITLE
Fixed roundcube php.ini customizations

### DIFF
--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -199,8 +199,8 @@ EO_RC_ADD
 
 	# apply roundcube customizations to php.ini
 	sed -i.bak \
-		-e "/'session.gc_maxlifetime'/ s/=\d+/=21600/" \
-		-e "/upload_max_filesize/ s/=\dM/=5M/" \
+		-e "/'session.gc_maxlifetime'/ s/=[1-9][0-9]*/=21600/" \
+		-e "/upload_max_filesize/ s/=[1-9][0-9]*M/=5M/" \
 		"$STAGE_MNT/usr/local/etc/php.ini"
 }
 


### PR DESCRIPTION
Apparently this had never been tested, we're on BSD `sed`, but even with GNU sed the regexes were wrong.

### Changes proposed in this pull request:
- Fix `sed` regexes in Roundcube php.ini customization script.