### PR TITLE
Fix jail.conf updating for common-prefixed jail names

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -409,7 +409,7 @@ add_jail_conf()
 
 	jail_conf_header
 
-	if grep -q "^$1" /etc/jail.conf; then
+	if grep -q "^$1\\>" /etc/jail.conf; then
 		tell_status "$1 already in /etc/jail.conf"
 		return;
 	fi


### PR DESCRIPTION
E.g. `add_jail_conf gitlab` won't work when `jail.conf` contains a `gitlab_runner` entry.
