### PR TITLE
Puppeteer: new jail

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -130,7 +130,7 @@ export BOURNE_SHELL=${BOURNE_SHELL:="bash"}
 export JAIL_NET_PREFIX=${JAIL_NET_PREFIX:="172.16.15"}
 export JAIL_NET_MASK=${JAIL_NET_MASK:="/12"}
 export JAIL_NET_INTERFACE=${JAIL_NET_INTERFACE:="lo1"}
-export JAIL_ORDERED_LIST="syslog base dns mysql clamav spamassassin dspam vpopmail haraka webmail monitor haproxy rspamd avg dovecot redis geoip nginx lighttpd apache postgres minecraft joomla php7 memcached sphinxsearch elasticsearch nictool sqwebmail dhcp letsencrypt tinydns roundcube squirrelmail rainloop rsnapshot mediawiki smf wordpress whmcs squirrelcart horde grafana unifi mongodb gitlab gitlab_runner dcc prometheus influxdb telegraf statsd mail_dmarc ghost jekyll borg nagios postfix"
+export JAIL_ORDERED_LIST="syslog base dns mysql clamav spamassassin dspam vpopmail haraka webmail monitor haproxy rspamd avg dovecot redis geoip nginx lighttpd apache postgres minecraft joomla php7 memcached sphinxsearch elasticsearch nictool sqwebmail dhcp letsencrypt tinydns roundcube squirrelmail rainloop rsnapshot mediawiki smf wordpress whmcs squirrelcart horde grafana unifi mongodb gitlab gitlab_runner dcc prometheus influxdb telegraf statsd mail_dmarc ghost jekyll borg nagios postfix puppeteer"
 
 export ZFS_VOL=${ZFS_VOL:="zroot"}
 export ZFS_JAIL_MNT=${ZFS_JAIL_MNT:="/jails"}

--- a/provision/puppeteer.sh
+++ b/provision/puppeteer.sh
@@ -10,7 +10,7 @@ install_puppeteer()
 	tell_status "install puppeteer"
 	stage_pkg_install npm-node16 chromium
 
-	stage_exec npm install -g puppeteer
+	stage_exec PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g puppeteer
 }
 
 configure_puppeteer()
@@ -27,13 +27,13 @@ configure_puppeteer()
 start_puppeteer()
 {
 	tell_status "starting up puppeteer"
-	stage_exec bash -c "cd /data/test && puppeteer serve &"
+	#stage_exec bash -c "cd /data/test && puppeteer serve &"
 }
 
 test_puppeteer()
 {
 	tell_status "testing puppeteer"
-	stage_listening 4000 3
+	#stage_listening 4000 3
 }
 
 base_snapshot_exists || exit

--- a/provision/puppeteer.sh
+++ b/provision/puppeteer.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+. mail-toaster.sh || exit
+
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+
+install_puppeteer()
+{
+	tell_status "install puppeteer"
+	stage_pkg_install npm-node16 chromium
+
+	stage_exec npm install -g puppeteer
+}
+
+configure_puppeteer()
+{
+	if [ -d "$STAGE_MNT/data/test" ]; then
+		tell_status "puppeteer site exists"
+		return;
+	fi
+
+	tell_status "configuring puppeteer"
+	stage_exec bash -c "cd /data && puppeteer new test"
+}
+
+start_puppeteer()
+{
+	tell_status "starting up puppeteer"
+	stage_exec bash -c "cd /data/test && puppeteer serve &"
+}
+
+test_puppeteer()
+{
+	tell_status "testing puppeteer"
+	stage_listening 4000 3
+}
+
+base_snapshot_exists || exit
+create_staged_fs puppeteer
+start_staged_jail puppeteer
+install_puppeteer
+configure_puppeteer
+start_puppeteer
+test_puppeteer
+promote_staged_jail puppeteer

--- a/provision/puppeteer.sh
+++ b/provision/puppeteer.sh
@@ -11,6 +11,7 @@ install_puppeteer()
 	stage_pkg_install npm-node16 chromium
 
 	stage_exec PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g puppeteer
+	stage_exec npm install -g https://github.com/msimerson/google-charts-node.git
 }
 
 configure_puppeteer()


### PR DESCRIPTION
- install requires PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
- also install google-charts-node
- used by beadedstream/db#392