### PR TITLE
Change replace command, since max_unrecognized_commands doesn't exist…

### DIFF
--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -437,9 +437,7 @@ configure_haraka_limit()
 {
 	if ! grep -qs ^limit "$HARAKA_CONF/plugins"; then
 		tell_status "adding limit plugin"
-		sed -i.bak \
-			-e 's/^max_unrecognized_commands/# limit/' \
-			"$HARAKA_CONF/plugins"
+        echo 'limit' | tee -a "$HARAKA_CONF/plugins"
 	fi
 
 	if [ ! -f "$HARAKA_CONF/limit.ini" ]; then

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -437,7 +437,7 @@ configure_haraka_limit()
 {
 	if ! grep -qs ^limit "$HARAKA_CONF/plugins"; then
 		tell_status "adding limit plugin"
-        echo 'limit' | tee -a "$HARAKA_CONF/plugins"
+		echo 'limit' | tee -a "$HARAKA_CONF/plugins"
 	fi
 
 	if [ ! -f "$HARAKA_CONF/limit.ini" ]; then


### PR DESCRIPTION
… in plugins

### Changes proposed in this pull request:
- Just add limit instead of replace, since max doesn't exist 

See here: https://github.com/haraka/Haraka/pull/2755

