### PR TITLE
Fix timezone detection for php.ini

### DIFF
--- a/include/php.sh
+++ b/include/php.sh
@@ -50,7 +50,7 @@ configure_php_ini()
 
 	tell_status "getting the timezone"
 	TZ=$(md5 -q /etc/localtime)
-	TIMEZONE=$(find /usr/share/zoneinfo -type f -print0 | xargs -0 md5 -r | grep "$TZ" | awk '{print $2}' |cut -c21-)
+	TIMEZONE=$(find /usr/share/zoneinfo -type f -print0 | xargs -0 md5 -r | grep "$TZ" | awk '{print $2; exit}' |cut -c21-)
 
 	if [ -z "$TIMEZONE" ]; then
 		TIMEZONE="America\/Los_Angeles"


### PR DESCRIPTION
For some timezones, timezone detection in configure_php_ini() is broken, e.g. here this code returns multiple timezone names for a single MD5 hash:
```
(TZ=$(md5 -q /etc/localtime); find /usr/share/zoneinfo -type f -print0 | xargs -0 md5 -r | grep "$TZ" )
4790e83465681cefbf852aed265354bf /usr/share/zoneinfo/Europe/Berlin
4790e83465681cefbf852aed265354bf /usr/share/zoneinfo/Europe/Copenhagen
4790e83465681cefbf852aed265354bf /usr/share/zoneinfo/Europe/Oslo
4790e83465681cefbf852aed265354bf /usr/share/zoneinfo/Europe/Stockholm
4790e83465681cefbf852aed265354bf /usr/share/zoneinfo/Arctic/Longyearbyen
4790e83465681cefbf852aed265354bf /usr/share/zoneinfo/Atlantic/Jan_Mayen
```
The patch skips all entries except the first one.

### Changes proposed in this pull request:
-
-
-

Fixes # .

Checklist:
- [ ] docs up-to-date
