### PR TITLE
Fix check if jail is already enabled in enable_jail

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -667,10 +667,10 @@ seed_pkg_audit()
 
 enable_jail()
 {
-	if sysrc -e jail_list | grep -q "$1"; then
+	case " $(sysrc -n jail_list) " in *" $1 "*)
 		#echo "jail $1 already enabled at startup"
-		return
-	fi
+		return ;;
+	esac
 
 	tell_status "enabling jail $1 at startup"
 	sysrc jail_list+=" $1"


### PR DESCRIPTION
When JAIL_ORDERED_LIST contains a jail name which is a substring of another jail name, the former can't be enabled.

### Changes proposed in this pull request:
-  Use whole word comparison in enable_jail().
