### PR TITLE
rspamd needs to recreate /var/run/rspamd when /var/run is ephemeral

### DIFF
--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -11,6 +11,14 @@ install_rspamd()
 {
 	tell_status "installing rspamd"
 	stage_pkg_install rspamd || exit
+
+	if [ "$TOASTER_USE_TMPFS" = 1 ]; then
+		tee -a $STAGE_MNT/etc/rc.local <<'EO_RC_LOCAL'
+mkdir -p /var/run/rspamd
+chown rspamd:rspamd /var/run/rspamd
+EO_RC_LOCAL
+		stage_exec service local start
+	fi
 }
 
 configure_redis()


### PR DESCRIPTION
### Changes proposed in this pull request:
- When TOASTER_USE_TMPFS is defined, rspamd can't find expected /var/run/rspamd directory, so we need to recreate it on jail start. In my installation, it's the only app which needed this workaround, but my setup is far from standard, e.g. I don't run haproxy and haraka.
