### PR TITLE
host: avoid showing "error" when loading pf.ko

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -433,7 +433,7 @@ add_jail_conf_d()
 
 	local _path; _path="$(get_safe_jail_path $1)"
 
-	jail_conf_extra
+	jail_conf_extra $1
 
 	tell_status "creating /etc/jail.conf.d/$1.conf"
 	echo "$(jail_conf_header)
@@ -466,7 +466,7 @@ add_jail_conf()
 	fi
 
 	local _path; _path="$(get_safe_jail_path $1)"
-	jail_conf_extra
+	jail_conf_extra $1
 
 	local _conf; _conf="$1	{${_path}
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -5,6 +5,11 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
+ifconfig ${JAIL_NET_INTERFACE} 2>&1 | grep -q 'does not exist' && {
+	echo; echo "ERROR: did you run 'provision host' yet?"; echo;
+	exit 1
+}
+
 mt6-include shell
 
 create_base_filesystem()

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -6,8 +6,7 @@ export JAIL_START_EXTRA="devfs_ruleset=7
 		allow.raw_sockets=1"
 export JAIL_CONF_EXTRA="
 		devfs_ruleset = 7;
-		allow.raw_sockets = 1;
-		mount += \"$ZFS_DATA_MNT/dhcp \$path/data nullfs rw 0 0\";"
+		allow.raw_sockets = 1;"
 
 install_dhcpd()
 {

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -3,7 +3,8 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
+export JAIL_CONF_EXTRA="
+		allow.raw_sockets;"
 
 install_unbound()
 {

--- a/provision/dspam.sh
+++ b/provision/dspam.sh
@@ -43,7 +43,9 @@ configure_dspam_mysql()
 	for _jail in dspam stage; do
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
-			echo "GRANT ALL PRIVILEGES ON dspam.* to 'dspam'@'${_ip}' IDENTIFIED BY '${_dpass}';" \
+			echo "CREATE USER dspam@'${_ip}' IDENTIFIED BY '${_dpass}';" \
+				| mysql_query || exit
+			echo "GRANT ALL PRIVILEGES ON dspam.* to dspam@'${_ip}';" \
 				| mysql_query || exit
 		done
 	done

--- a/provision/elasticsearch.sh
+++ b/provision/elasticsearch.sh
@@ -7,8 +7,7 @@ export JAIL_START_EXTRA="enforce_statfs=1"
 export JAIL_CONF_EXTRA="
 		mount.fdescfs;
 		mount.procfs;
-		enforce_statfs = 1;
-		mount += \"$ZFS_DATA_MNT/elasticsearch \$path/data nullfs rw 0 0\";"
+		enforce_statfs = 1;"
 
 create_data_dirs()
 {

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -4,8 +4,7 @@
 
 export JAIL_START_EXTRA="devfs_ruleset=7"
 export JAIL_CONF_EXTRA="
-		devfs_ruleset = 7;
-		mount += \"$ZFS_DATA_MNT/haraka \$path/data nullfs rw 0 0\";"
+		devfs_ruleset = 7;"
 
 HARAKA_CONF="$ZFS_DATA_MNT/haraka/config"
 

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -5,8 +5,8 @@
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA="
-mount += \"$ZFS_DATA_MNT/horde \$path/data nullfs rw 0 0\";
-mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
+		mount += \"$ZFS_DATA_MNT/horde \$path/data nullfs rw 0 0\";
+		mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include php
 mt6-include nginx

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -350,7 +350,7 @@ haproxy_lo6  = "{ $(get_jail_ip6 haproxy) }"
 
 # default route to the internet for jails
 nat on \$ext_if inet  from $JAIL_NET_PREFIX.0${JAIL_NET_MASK} to any -> (\$ext_if)
-nat on \$ext_if inet6 from ! \$ext_if to any -> \$PUBLIC_IP6
+nat on \$ext_if inet6 from ! \$ext_if to any -> <ext_ip6>
 
 nat-anchor "nat/*"
 
@@ -385,9 +385,9 @@ EO_PF_RULES
 	kldstat -q -m pf || kldload pf || exit 1
 
 	grep -q ^pf_enable /etc/rc.conf || sysrc pf_enable=YES
-	/etc/rc.d/pf restart 2>/dev/null || exit 1
+	/etc/rc.d/pf restart || exit 1
 
-	pfctl -f /etc/pf.conf 2>/dev/null || exit 1
+	pfctl -f /etc/pf.conf || exit 1
 }
 
 install_jailmanage()
@@ -461,11 +461,12 @@ enable_jails()
 	jail_reverse_shutdown
 	set_jail_start_order
 
-	if grep -sq 'exec' /etc/jail.conf; then
+	if [ -d /etc/jail.conf.d ]; then
+		add_jail_conf stage
 		return
 	fi
 
-	jail_conf_header
+	grep -sq 'exec' /etc/jail.conf || jail_conf_header
 }
 
 update_ports_tree()

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -350,7 +350,7 @@ haproxy_lo6  = "{ $(get_jail_ip6 haproxy) }"
 
 # default route to the internet for jails
 nat on \$ext_if inet  from $JAIL_NET_PREFIX.0${JAIL_NET_MASK} to any -> (\$ext_if)
-nat on \$ext_if inet6 from ! \$ext_if to any -> \$ext_if
+nat on \$ext_if inet6 from ! \$ext_if to any -> \$PUBLIC_IP6
 
 nat-anchor "nat/*"
 

--- a/provision/mailtest.sh
+++ b/provision/mailtest.sh
@@ -3,7 +3,9 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
+export JAIL_CONF_EXTRA="
+		allow.raw_sockets;"
+
 
 install_mailtest()
 {

--- a/provision/mongodb.sh
+++ b/provision/mongodb.sh
@@ -5,8 +5,7 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		allow.sysvipc;
-		allow.mlock;
-		mount += \"$ZFS_DATA_MNT/mongodb \$path/data nullfs rw 0 0\";"
+		allow.mlock;"
 
 install_mongodb()
 {

--- a/provision/prometheus.sh
+++ b/provision/prometheus.sh
@@ -3,8 +3,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/prometheus \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_prometheus()
 {

--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -162,12 +162,10 @@ EO_WORKER
 
 configure_controller()
 {
-	_email="postmaster@$TOASTER_MAIL_DOMAIN"
-	_pass=$(jexec vpopmail /usr/local/vpopmail/bin/vuserinfo -C "$_email")
-	_hash=$(jexec stage rspamadm pw -p "$_pass")
+	_pass=$(jexec vpopmail /usr/local/vpopmail/bin/vuserinfo -C "postmaster@${TOASTER_MAIL_DOMAIN}")
 
 	tee "$RSPAMD_ETC/local.d/worker-controller.inc" <<EO_CONTROLLER
-password = "$_hash";
+password = "$(jexec stage rspamadm pw -p "$_pass")";
 secure_ip = $(get_jail_ip dovecot);
 secure_ip = $(get_jail_ip6 dovecot);
 EO_CONTROLLER

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -3,8 +3,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/spamassassin \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 mt6-include mysql
 

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -3,8 +3,7 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/wildduck \$path/data nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 
 install_wildduck()

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -6,25 +6,49 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 
 
+install_webmail()
+{
+	stage_exec bash -c "cd /data && git clone https://github.com/nodemailer/wildduck-webmail.git webmail" || exit 1
+	stage_exec bash -c "cd /data/webmail && npm install"
+	stage_exec bash -c "cd /data/webmail && npm run bowerdeps"
+}
+
 install_wildduck()
 {
 	tell_status "installing node.js"
 	stage_pkg_install npm-node16 git-lite || exit
 
 	tell_status "installing wildduck"
-	stage_pkg_install dialog4ports
-	stage_exec bash -c "cd /data && git clone git://github.com/nodemailer/wildduck.git && cd wildduck && npm install --production"
+	# stage_pkg_install dialog4ports
+	stage_exec bash -c "cd /data && git clone https://github.com/nodemailer/wildduck.git" || exit 1
+	stage_exec bash -c "cd /data/wildduck && npm install --production"
+
+	install_webmail
 }
 
 configure_wildduck()
 {
-	echo "nothing, yet"
+	sed -i '' \
+		-e "/^mongo/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
+		-e "/^#redis/ s/127.0.0.1/$(get_jail_ip redis)/; s/\/3/\/8/" \
+		-e "/^host=/ s/127.0.0.1/$(get_jail_ip redis)/" \
+		-e "/^db=3/ s/3/8/" \
+		"$STAGE_MNT/data/wildduck/config/dbs.toml" || exit 1
+
+	stage_exec npm install -g pm2
+	stage_exec pm2 startup
 }
 
 start_wildduck()
 {
 	tell_status "starting wildduck"
-	stage_exec service wildduck start || exit
+	stage_exec service pm2_toor start
+
+	stage_exec bash -c 'cd /data/wildduck && NODE_ENV=production pm2 start "node server.js" -n wildduck'
+
+	stage_exec bash -c 'cd /data/webmail && NODE_ENV=production pm2 start "node server.js" -n webmail'
+
+	stage_exec pm2 save
 }
 
 test_imap()
@@ -80,8 +104,9 @@ test_wildduck()
 	tell_status "testing wildduck"
 	stage_listening 9993 3
 	stage_listening 9995 3
-	test_imap
-	test_pop3
+	stage_listening 3000 3
+	# test_imap
+	# test_pop3
 	echo "it worked"
 }
 

--- a/provision/zonemta.sh
+++ b/provision/zonemta.sh
@@ -29,6 +29,7 @@ install_zonemta()
 	stage_exec bash -c "cd /data/zone-mta && npm install eslint --save-dev"
 	stage_exec bash -c "cd /data/zone-mta && npm init"
 	stage_exec bash -c "cd /data/zone-mta && npm install --production"
+	stage_exec bash -c "cd /data/zone-mta && npm install zonemta-wildduck --save"
 
 	sed -i '' \
 		-e "/^mongo/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
@@ -51,6 +52,9 @@ configure_zonemta()
 	stage_exec pm2 startup
 	stage_sysrc pm2_toor_enable=YES
 	service pm2_toor start
+
+	tell_status "TODO: configure zonemta-wildduck"
+	echo "https://github.com/nodemailer/zonemta-wildduck"
 }
 
 start_zonemta()

--- a/provision/zonemta.sh
+++ b/provision/zonemta.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+. mail-toaster.sh || exit
+
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+
+
+install_zonemta_webadmin()
+{
+	tell_status "installing ZoneMTA webadmin"
+	stage_exec bash -c "cd /data && git clone https://github.com/zone-eu/zmta-webadmin.git admin"
+	stage_exec bash -c "cd /data/admin && npm install --production"
+
+	sed -i '' \
+		-e "/^mongo/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
+		-e "/^host/  s/localhost/$(get_jail_ip redis)/; s/\/2/\/7/" \
+		-e "/^db = / s/2/7/" \
+		"$STAGE_MNT/data/admin/config/default.toml"
+}
+
+install_zonemta()
+{
+	tell_status "installing node.js"
+	stage_pkg_install npm-node16 git-lite || exit
+
+	tell_status "installing ZoneMTA"
+	stage_exec bash -c "cd /data && git clone https://github.com/zone-eu/zone-mta-template.git zone-mta"
+	stage_exec bash -c "cd /data/zone-mta && npm install eslint --save-dev"
+	stage_exec bash -c "cd /data/zone-mta && npm init"
+	stage_exec bash -c "cd /data/zone-mta && npm install --production"
+
+	sed -i '' \
+		-e "/^mongo/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
+		-e "/^redis/ s/localhost/$(get_jail_ip redis)/; s/\/2/\/7/" \
+		"$STAGE_MNT/data/zone-mta/config/dbs-production.toml"
+
+	sed -i '' \
+		-e "/^mongo/   s/127.0.0.1/$(get_jail_ip mongodb)/" \
+		-e "/^host = / s/localhost/$(get_jail_ip redis)/" \
+		"$STAGE_MNT/data/zone-mta/config/dbs-development.toml"
+
+	# stage_exec bash -c "cd /data/zone-mta && npm install zonemta-delivery-counters --save"
+
+	install_zonemta_webadmin
+}
+
+configure_zonemta()
+{
+	echo "nothing, yet"
+}
+
+start_zonemta()
+{
+	tell_status "starting zonemta"
+	stage_exec bash -c "cd /data/zone-mta && npm start &"
+
+	tell_status "starting zonemta webadmin"
+	stage_exec bash -c "cd /data/admin && npm start &"
+}
+
+test_zonemta()
+{
+	tell_status "testing zonemta"
+	stage_listening 2525 3
+	echo "it worked"
+	stage_listening 8082 3
+	echo "it worked"
+}
+
+base_snapshot_exists || exit
+create_staged_fs zonemta
+start_staged_jail zonemta
+install_zonemta
+configure_zonemta
+start_zonemta
+test_zonemta
+promote_staged_jail zonemta

--- a/provision/zonemta.sh
+++ b/provision/zonemta.sh
@@ -47,16 +47,21 @@ install_zonemta()
 
 configure_zonemta()
 {
-	echo "nothing, yet"
+	stage_exec npm install -g pm2
+	stage_exec pm2 startup
+	stage_sysrc pm2_toor_enable=YES
+	service pm2_toor start
 }
 
 start_zonemta()
 {
 	tell_status "starting zonemta"
-	stage_exec bash -c "cd /data/zone-mta && npm start &"
+	stage_exec bash -c 'cd /data/zone-mta && NODE_ENV=production pm2 start "npm run start" -n zone-mta'
 
 	tell_status "starting zonemta webadmin"
-	stage_exec bash -c "cd /data/admin && npm start &"
+	stage_exec bash -c 'cd /data/admin    && NODE_ENV=production pm2 start "npm run start" -n admin'
+
+	stage_exec pm2 save
 }
 
 test_zonemta()


### PR DESCRIPTION
### Changes proposed in this pull request:

- host: avoid showing "error" when loading pf.ko
- host: update pf rule so IPv6 NAT works
- dns/mailtest: allow raw sockets in jails
- mt: use /etc/jail.conf.d if exists
- mt: remove jail.conf.d during unprovision
- base: add check for host setup
- mt: smarter JAIL_CONF_EXTRA handling, if $ZFS_DATA_MNT is not found, then add it
- dspam: update for mysql 8
- zonemta: added
- wildduck: added, webmail

Checklist:
- [ ] docs up-to-date
