### PR TITLE
PF anchors - load PF rules as jails start/stop

### DIFF
--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -2,11 +2,15 @@
 
 . mail-toaster.sh || exit
 
+_pf_etc="$ZFS_DATA_MNT/dhcp/etc/pf.conf.d"
+
 export JAIL_START_EXTRA="devfs_ruleset=7
 		allow.raw_sockets=1"
 export JAIL_CONF_EXTRA="
 		devfs_ruleset = 7;
-		allow.raw_sockets = 1;"
+		allow.raw_sockets = 1;
+		exec.created = 'pfctl -a rdr/dhcp -f $_pf_etc/rdr.conf';
+		exec.poststop = 'pfctl -a rdr/dhcp -F all';"
 
 install_dhcpd()
 {
@@ -27,7 +31,10 @@ configure_dhcpd()
 	stage_sysrc dhcpd_rootdir="/data/db"	# directory to run in
 	echo "configured"
 
-	add_pf_portmap "67 68" dhcp
+	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
+rdr inet  proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip  dhcp)
+rdr inet6 proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip6 dhcp)
+EO_PF_RDR
 
 	if [ ! -d "$ZFS_DATA_MNT/dhcp/etc" ]; then
 		mkdir -p "$ZFS_DATA_MNT/dhcp/etc" || exit

--- a/provision/haproxy.sh
+++ b/provision/haproxy.sh
@@ -2,8 +2,12 @@
 
 . mail-toaster.sh || exit
 
+_pf_etc="$ZFS_DATA_MNT/haproxy/etc/pf.conf.d"
+
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
+export JAIL_CONF_EXTRA="
+		exec.created = 'pfctl -a rdr/haproxy -f $_pf_etc/rdr.conf';
+		exec.poststop = 'pfctl -a rdr/haproxy -F all';"
 
 install_haproxy()
 {
@@ -337,6 +341,11 @@ configure_haproxy()
 		# useful for stats socket
 		mkdir "$STAGE_MNT/var/run/haproxy"
 	fi
+
+	store_config "$_pf_etc/rdr.conf" <<EO_PF
+rdr inet  proto tcp from any to <ext_ip4> port { 80 443 } -> $(get_jail_ip  haproxy)
+rdr inet6 proto tcp from any to <ext_ip6> port { 80 443 } -> $(get_jail_ip6 haproxy)
+EO_PF
 
 	configure_haproxy_tls
 }

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -2,8 +2,12 @@
 
 . mail-toaster.sh || exit
 
+_pf_etc="$ZFS_DATA_MNT/haraka/etc/pf.conf.d"
+
 export JAIL_START_EXTRA="devfs_ruleset=7"
 export JAIL_CONF_EXTRA="
+		exec.created = 'pfctl -a rdr/haraka -f $_pf_etc/rdr.conf';
+		exec.poststop = 'pfctl -a rdr/haraka -F all';
 		devfs_ruleset = 7;"
 
 HARAKA_CONF="$ZFS_DATA_MNT/haraka/config"
@@ -713,6 +717,11 @@ configure_haraka()
 	configure_haraka_access
 	configure_haraka_dcc
 	configure_haraka_spf
+
+	store_config "$_pf_etc/rdr.conf" <<EO_PF
+rdr inet  proto tcp from any to <ext_ip4> port { 25 465 587 } -> $(get_jail_ip  haraka)
+rdr inet6 proto tcp from any to <ext_ip6> port { 25 465 587 } -> $(get_jail_ip6 haraka)
+EO_PF
 
 	install_geoip_dbs
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
- mt: tighten up detection of data fs mount
- mt.stop_jail: if jail isn't running, don't attempt to stop it
- mt.store_config(), new function.
- dhcp,dovecot,haraka,haproxy: PF port mappings moved to jails config

Previously, PF rules for port 80 & 443 were in /etc/pf.conf and pointed to haproxy. After this PR, those same PF redirect rules are located at `$data/haproxy/etc/pf.conf.d/rdr.conf`. Same goes for MUA, MSA, and MTA ports which moved to `$data/dovecot/etc/pf.conf.d/rdr.conf` and similarly haraka and dhcp.

### Motivations

- encapsulation: keep all the jail needs contained within its jail.conf and data partition.
- flexibility: as an example, one could replace haproxy with nginx, haraka with postfix/opensmtpd/other, etc.
- upon boot, some PF rules may not be ready due to dependencies.
- store_config: when writing out configs, write them always as $filePath.dist, and then if $filePath doesn't exist, install it. The provides a reference for comparing after upgrades.

Checklist:
- [ ] docs up-to-date
