### PR TITLE
always mount data dir at /data, new data/etc/fstab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ node_modules
 *.tar.gz
 *.txt
 *.php
+*.mt6

--- a/contrib/exorcise_maildrop.sh
+++ b/contrib/exorcise_maildrop.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# shellcheck disable=SC2044
 for _f in $(find /data/vpopmail/ -type f -name .qmail); do
 
 	# ignore files that don't specify maildrop

--- a/contrib/exorcise_maildrop.sh
+++ b/contrib/exorcise_maildrop.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+for _f in $(find /data/vpopmail/ -type f -name .qmail); do
+
+	# ignore files that don't specify maildrop
+	if ! grep -q maildrop "$_f"; then continue; fi
+
+	_lines=$(wc -l < "$_f" | bc)
+	if [ "$_lines" = 1 ]; then
+		# files with only a mailfilter rule can be deleted
+		echo "$_lines: rm $_f"
+		rm "$_f"
+		continue
+	fi
+
+	# multiple delivery rules are in the file (see 'man dot-qmail')
+
+	# extract all that isn't a maildrop invocation
+	_contents=$(grep -v maildrop "$_f")
+
+	# replace the maildrop rule with fully qualified path to Maildir
+	_maildir="$(dirname "$_f" | sed -e 's|/data/vpopmail/home|/usr/local/vpopmail|')/Maildir/"
+
+	echo "$_lines"
+	echo "$_f"
+	echo
+
+	#echo "$_contents"
+	#echo
+
+	# write a new .qmail with the FQ Maildir + other delivery rules
+	echo "$_contents" > "$_f.new" || exit 1
+	echo "$_maildir" >> "$_f.new" || exit 1
+	chown 89:89 "$_f.new" || exit 1
+	chmod 600 "$_f.new" || exit 1
+
+	# atomically replace the existing .qmail
+	#echo "mv $_f.new $_f"
+	#mv "$_f.new" "$_f"
+done

--- a/include/vpopmail.sh
+++ b/include/vpopmail.sh
@@ -67,7 +67,7 @@ install_qmail()
 
 	for _cdir in control users
 	do
-		local _vmdir="$ZFS_DATA_MNT/vpopmail/qmail-${_cdir}"
+		local _vmdir="$ZFS_DATA_MNT/vpopmail/home/qmail-${_cdir}"
 		if [ ! -d "$_vmdir" ]; then
 			tell_status "creating $_vmdir"
 			mkdir -p "$_vmdir" || exit
@@ -87,7 +87,7 @@ install_qmail()
 	mkdir -p "$STAGE_MNT/usr/local/etc/rc.d"
 
 	tell_status "setting qmail hostname to $TOASTER_HOSTNAME"
-	echo "$TOASTER_HOSTNAME" > "$ZFS_DATA_MNT/vpopmail/qmail-control/me"
+	echo "$TOASTER_HOSTNAME" > "$ZFS_DATA_MNT/vpopmail/home/qmail-control/me"
 
 	if grep -qs ^mail_qmail_ "$ZFS_JAIL_MNT/vpopmail/etc/make.conf"; then
 		tell_status "copying qmail port options from existing vpopmail jail"

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -228,8 +228,8 @@ if [ "$(uname)" = 'FreeBSD' ]; then
 fi
 
 # the 'base' jail that other jails are cloned from. This will be named as the
-# host OS version, eg: base-13.0-RELEASE and the snapshot name will be the OS
-# patch level, eg: base-13.0-RELEASE@p3
+# host OS version, eg: base-13.2-RELEASE and the snapshot name will be the OS
+# patch level, eg: base-13.2-RELEASE@p3
 export BASE_NAME="base-$FBSD_REL_VER"
 export BASE_VOL="$ZFS_JAIL_VOL/$BASE_NAME"
 export BASE_SNAP="${BASE_VOL}@${FBSD_PATCH_VER}"
@@ -600,6 +600,7 @@ install_fstab()
 	echo "/usr/ports         $STAGE_MNT/usr/ports       nullfs rw  0  0" | tee -a "$_fstab.stage"
 	echo "/var/cache/pkg     $STAGE_MNT/var/cache/pkg   nullfs rw  0  0" | tee -a "$_fstab.stage"
 
+	# copy staged fstab into place for jail shutdown
 	if [ ! -d "$ZFS_DATA_MNT/stage/etc" ]; then
 		mkdir -p "$ZFS_DATA_MNT/stage/etc" || exit 1
 	fi

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -228,8 +228,8 @@ if [ "$(uname)" = 'FreeBSD' ]; then
 fi
 
 # the 'base' jail that other jails are cloned from. This will be named as the
-# host OS version, ex: base-13.0-RELEASE and the snapshot name will be the OS
-# patch level, ex: base-13.0-RELEASE@p3
+# host OS version, eg: base-13.0-RELEASE and the snapshot name will be the OS
+# patch level, eg: base-13.0-RELEASE@p3
 export BASE_NAME="base-$FBSD_REL_VER"
 export BASE_VOL="$ZFS_JAIL_VOL/$BASE_NAME"
 export BASE_SNAP="${BASE_VOL}@${FBSD_PATCH_VER}"
@@ -855,7 +855,7 @@ stage_pkg_install()
 
 stage_port_install()
 {
-	# $1 is the port directory (ex: mail/dovecot)
+	# $1 is the port directory (eg: mail/dovecot)
 	echo "jexec $SAFE_NAME make -C /usr/ports/$1 build deinstall install clean"
 	jexec "$SAFE_NAME" make -C "/usr/ports/$1" build deinstall install clean || return 1
 
@@ -1005,6 +1005,8 @@ mount_data()
 
 unmount_data()
 {
+	# $1 is ZFS fs (eg: /data/mysql)
+	# $2 is FS mountpoint (eg: /jails/mysql/data)
 	local _data_vol; _data_vol="$ZFS_DATA_VOL/$1"
 
 	if ! zfs_filesystem_exists "$_data_vol"; then return; fi
@@ -1026,7 +1028,6 @@ data_mountpoint()
 
 	case "$1" in
 		avg )       echo "$_base_dir/data/avg"; return ;;
-		mysql )     echo "$_base_dir/var/db/mysql"; return ;;
 		vpopmail )  echo "$_base_dir/usr/local/vpopmail"; return ;;
 	esac
 

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1026,7 +1026,6 @@ data_mountpoint()
 
 	case "$1" in
 		avg )       echo "$_base_dir/data/avg"; return ;;
-		clamav )	echo "$_base_dir/var/db/clamav"; return ;;
 		geoip )     echo "$_base_dir/usr/local/share/GeoIP"; return ;;
 		mysql )     echo "$_base_dir/var/db/mysql"; return ;;
 		vpopmail )  echo "$_base_dir/usr/local/vpopmail"; return ;;

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -601,7 +601,7 @@ install_fstab()
 	echo "/var/cache/pkg     $STAGE_MNT/var/cache/pkg   nullfs rw  0  0" | tee -a "$_fstab.stage"
 
 	if [ ! -d "$ZFS_DATA_MNT/stage/etc" ]; then
-		mkdir "$ZFS_DATA_MNT/stage/etc" || exit 1
+		mkdir -p "$ZFS_DATA_MNT/stage/etc" || exit 1
 	fi
 	cp "$_fstab.stage" "$ZFS_DATA_MNT/stage/etc/fstab" || exit 1
 }
@@ -674,9 +674,12 @@ start_staged_jail()
 {
 	local _name="$1"
 	local _path="$2"
+	local _fstab="$ZFS_DATA_MNT/$_name/etc/fstab.stage"
 
 	if [ -z "$_name" ]; then _name="$SAFE_NAME"; fi
 	if [ -z "$_path" ]; then _path="$STAGE_MNT"; fi
+
+	if [ "$_name" = "base" ]; then _fstab="$BASE_MNT/data/etc/fstab"; fi
 
 	tell_status "stage jail $_name startup"
 
@@ -690,7 +693,7 @@ start_staged_jail()
 		ip6.addr="$(get_jail_ip6 stage)" \
 		exec.start="/bin/sh /etc/rc" \
 		exec.stop="/bin/sh /etc/rc.shutdown" \
-		mount.fstab="$ZFS_DATA_MNT/$_name/etc/fstab.stage" \
+		mount.fstab="$_fstab" \
 		devfs_ruleset=5 \
 		$JAIL_START_EXTRA \
 		|| exit

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1026,7 +1026,6 @@ data_mountpoint()
 
 	case "$1" in
 		avg )       echo "$_base_dir/data/avg"; return ;;
-		geoip )     echo "$_base_dir/usr/local/share/GeoIP"; return ;;
 		mysql )     echo "$_base_dir/var/db/mysql"; return ;;
 		vpopmail )  echo "$_base_dir/usr/local/vpopmail"; return ;;
 	esac

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -615,6 +615,11 @@ create_staged_fs()
 	echo "zfs clone $BASE_SNAP $ZFS_JAIL_VOL/stage"
 	zfs clone "$BASE_SNAP" "$ZFS_JAIL_VOL/stage" || exit
 
+	if [ ! -d "$ZFS_JAIL_MNT/stage/data" ]; then
+		tell_status "creating $ZFS_JAIL_MNT/stage/data"
+		mkdir "$ZFS_JAIL_MNT/stage/data" || exit 1
+	fi
+
 	stage_sysrc hostname="$1"
 	sed -i '' -e "/^hostname=/ s/_HOSTNAME_/$1/" \
 		"$STAGE_MNT/usr/local/etc/ssmtp/ssmtp.conf" || exit

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -149,7 +149,7 @@ enable_security_periodic()
 	tee "$_daily/auto_security_upgrades" <<'EO_PKG_SECURITY'
 #!/bin/sh
 
-auto_remove="vim-console"
+auto_remove="vim-console vim-lite"
 for _pkg in $auto_remove;
 do
   /usr/sbin/pkg delete "$_pkg"
@@ -327,6 +327,12 @@ install_vimrc()
 	fi
 
 	fetch -m -o "$_vimdir/vimrc" https://raw.githubusercontent.com/nandalopes/vim-for-server/main/vimrc
+	sed -i '' \
+		-e 's/^syntax on/" syntax on/' \
+		-e 's/^colorscheme/" colorscheme/' \
+		-e 's/^set number/" set number/' \
+		-e 's/^set relativenumber/" set relativenumber/' \
+		"$_vimdir/vimrc"
 }
 
 install_base()

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -2,9 +2,6 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
-
 ifconfig ${JAIL_NET_INTERFACE} 2>&1 | grep -q 'does not exist' && {
 	echo; echo "ERROR: did you run 'provision host' yet?"; echo;
 	exit 1
@@ -53,6 +50,8 @@ install_freebsd()
 	else
 		stage_fbsd_package base "$BASE_MNT"
 	fi
+
+	touch "$BASE_MNT/etc/fstab"
 }
 
 install_ssmtp()
@@ -211,6 +210,13 @@ WRKDIRPREFIX?=/tmp/portbuild
 EO_MAKE_CONF
 }
 
+configure_fstab() {
+	if [ ! -d "$BASE_MNT/data/etc" ]; then
+		mkdir -p "$BASE_MNT/data/etc" || exit 1
+	fi
+	touch "$BASE_MNT/data/etc/fstab"
+}
+
 configure_base()
 {
 	if [ ! -d "$BASE_MNT/usr/ports" ]; then
@@ -242,6 +248,7 @@ configure_base()
 	configure_syslog
 	configure_bourne_shell "$BASE_MNT"
 	configure_csh_shell "$BASE_MNT"
+	configure_fstab
 }
 
 install_periodic_conf()

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -270,7 +270,7 @@ migrate_clamav_dbs()
 
 	Proceed?
 	"
-	dialog --yesno "$_confirm_msg" 13 70 || return
+	dialog --yesno "$_confirm_msg" 13 70 || exit
 
 	service jail stop clamav
 

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -200,7 +200,6 @@ configure_clamd()
 
 	echo "done"
 
-	stage_sysrc	clamav_clamd_flags="-c /data/etc/clamd.conf"
 	sed -i '' \
 		-e 's/\/usr\/local\/etc/\/data\/etc/g' \
 		-e 's/\/var\/db\/clamav/\/data\/db/g' \
@@ -226,7 +225,6 @@ configure_freshclam()
 		"$_conf" || exit
 
 	echo "done"
-	stage_sysrc clamav_freshclam_flags="--config-file=/data/etc/freshclam.conf --datadir=/data/db"
 	sed -i '' \
 		-e 's/\/usr\/local\/etc/\/data\/etc/g' \
 		-e 's/\/var\/db\/clamav/\/data\/db/g' \
@@ -246,9 +244,11 @@ start_clamav()
 
 	tell_status "starting ClamAV daemons"
 	stage_sysrc clamav_clamd_enable=YES
+	stage_sysrc clamav_clamd_flags="-c /data/etc/clamd.conf"
 	stage_exec service clamav-clamd start
 
 	stage_sysrc clamav_freshclam_enable=YES
+	stage_sysrc clamav_freshclam_flags="--config-file=/data/etc/freshclam.conf --datadir=/data/db"
 	stage_exec service clamav-freshclam start
 }
 

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -254,7 +254,7 @@ start_clamav()
 migrate_clamav_dbs()
 {
 	for _suffix in cvd dat; do
-		for _db in $STAGE_MNT/data/*.$_suffix; do
+		for _db in "$STAGE_MNT"/data/*."$_suffix"; do
 			echo "mv $_db $STAGE_MNT/data/db/"
 			mv "$_db" "$STAGE_MNT/data/db/"
 		done

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -158,6 +158,7 @@ install_clamav()
 		_path="$STAGE_MNT/data/$_d"
 		[ -d "$_path" ] || mkdir "$_path"
 	done
+
 	stage_exec chown clamav:clamav /data/log /data/db
 
 	install_clamav_nrpe
@@ -250,6 +251,16 @@ start_clamav()
 	stage_exec service clamav-freshclam start
 }
 
+migrate_clamav_dbs()
+{
+	for _suffix in cvd dat; do
+		for _db in $STAGE_MNT/data/*.$_suffix; do
+			echo "mv $_db $STAGE_MNT/data/db/"
+			mv "$_db" "$STAGE_MNT/data/db/"
+		done
+	done
+}
+
 test_clamav()
 {
 	echo "testing ClamAV clamd"
@@ -264,4 +275,5 @@ install_clamav
 configure_clamav
 start_clamav
 test_clamav
+migrate_clamav_dbs
 promote_staged_jail clamav

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -2,9 +2,6 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
-
 install_clamav_fangfrisch()
 {
 	if [ "$CLAMAV_FANGFRISCH" = "0" ]; then return; fi

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -253,7 +253,23 @@ start_clamav()
 
 migrate_clamav_dbs()
 {
-	for _suffix in cvd dat; do
+	if [ ! -f "$ZFS_DATA_MNT/clamav/daily.cld" ]; then
+		# no clamav dbs or already migrated
+		return
+	fi
+
+	local _confirm_msg="
+	clamav db migration required. Choosing yes will:
+
+	1. stop the running clamav jail
+	2. move the clamav dbs into 'data/db'
+	3. promote this newly build clamav jail
+
+	Proceed?
+	"
+	dialog --yesno "$_confirm_msg" 13 70 || return
+
+	for _suffix in cdb cld cvd dat fp ftm hsb ldb ndb yara; do
 		for _db in "$STAGE_MNT"/data/*."$_suffix"; do
 			echo "mv $_db $STAGE_MNT/data/db/"
 			mv "$_db" "$STAGE_MNT/data/db/"

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -208,21 +208,22 @@ configure_clamd()
 
 configure_freshclam()
 {
-	tell_status "configuring freshclam"
-
 	local _conf="$STAGE_MNT/data/etc/freshclam.conf"
-	if [ ! -f "$_conf" ]; then
+	if [ -f "$_conf" ]; then
+		tell_status "freshclam already configured"
+	else
+		tell_status "configuring freshclam"
 		cp "$STAGE_MNT/usr/local/etc/freshclam.conf" "$_conf"
-	fi
 
-	sed -i.bak \
-		-e 's/DatabaseDirectory \/var\/db\/clamav/DatabaseDirectory \/data\/db/' \
-		-e 's/^UpdateLogFile \/var\/log\/clamav/UpdateLogFile \/data\/log/' \
-		-e 's/^#LogSyslog/LogSyslog/' \
-		-e 's/^#LogFacility/LogFacility/' \
-		-e 's/^#SafeBrowsing/SafeBrowsing/' \
-		-e 's/^#DatabaseMirror/DatabaseMirror/; s/XY/us/' \
-		"$_conf" || exit
+		sed -i.bak \
+			-e 's/DatabaseDirectory \/var\/db\/clamav/DatabaseDirectory \/data\/db/' \
+			-e 's/^UpdateLogFile \/var\/log\/clamav/UpdateLogFile \/data\/log/' \
+			-e 's/^#LogSyslog/LogSyslog/' \
+			-e 's/^#LogFacility/LogFacility/' \
+			-e 's/^#SafeBrowsing/SafeBrowsing/' \
+			-e 's/^#DatabaseMirror/DatabaseMirror/; s/XY/us/' \
+			"$_conf" || exit
+	fi
 
 	echo "done"
 	sed -i '' \

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -105,7 +105,7 @@ enable_control()
 		mkdir "$ZFS_DATA_MNT/dns/control" || exit
 	fi
 
-	tee -a "$ZFS_DATA_MNT/dns/control.conf" <<EO_CONTROL_CONF
+	tee "$ZFS_DATA_MNT/dns/control.conf" <<EO_CONTROL_CONF
 		control-enable: yes
 		control-interface: 0.0.0.0
 

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -2,16 +2,14 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
+export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/dovecot/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail
 
 allow_sysvipc_stage()
 {
     tell_status "allow sysvipc for the staged jail"
-    jail -m name=stage allow.sysvipc=1
+    jail -m name=stage allow.sysvipc=1 || exit 1
 }
 
 install_dovecot()
@@ -26,9 +24,6 @@ install_dovecot()
 	tell_status "creating vpopmail user & group"
 	stage_exec pw groupadd -n vpopmail -g 89
 	stage_exec pw useradd -n vpopmail -s /nonexistent -d /usr/local/vpopmail -u 89 -g 89 -m -h-
-
-	tell_status "mounting shared vpopmail fs"
-	mount_data vpopmail
 
 	if [ "$TLS_LIBRARY" = "libressl" ]; then
 		echo 'DEFAULT_VERSIONS+=ssl=libressl' >> "$STAGE_MNT/etc/make.conf"
@@ -642,6 +637,7 @@ test_dovecot()
 
 base_snapshot_exists || exit
 create_staged_fs dovecot
+mkdir -p "$STAGE_MNT/usr/local/vpopmail"
 start_staged_jail dovecot
 allow_sysvipc_stage
 install_dovecot
@@ -649,5 +645,4 @@ configure_dovecot
 stage_resolv_conf
 start_dovecot
 test_dovecot
-unmount_data vpopmail
 promote_staged_jail dovecot

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -4,7 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
+		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include vpopmail
 
@@ -227,7 +227,7 @@ configure_dovecot_sql_conf()
 		local _sqlconf="$ZFS_DATA_MNT/dovecot/etc/dovecot-sql.conf.ext"
 
 		# shellcheck disable=SC2034
-		_vpass=$(grep -v ^# "$ZFS_DATA_MNT/vpopmail/etc/vpopmail.mysql" | head -n1 | cut -f4 -d'|')
+		_vpass=$(grep -v ^# "$ZFS_DATA_MNT/vpopmail/home/etc/vpopmail.mysql" | head -n1 | cut -f4 -d'|')
 
 		store_config "$_sqlconf" "overwrite" <<EO_DOVECOT_SQL
   driver = mysql

--- a/provision/dspam.sh
+++ b/provision/dspam.sh
@@ -43,10 +43,8 @@ configure_dspam_mysql()
 	for _jail in dspam stage; do
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
-			echo "CREATE USER dspam@'${_ip}' IDENTIFIED BY '${_dpass}';" \
-				| mysql_query || exit
-			echo "GRANT ALL PRIVILEGES ON dspam.* to dspam@'${_ip}';" \
-				| mysql_query || exit
+			echo "CREATE USER IF NOT EXISTS 'dspam'@'${_ip}' IDENTIFIED BY '${_dpass}';" | mysql_query || exit 1
+			echo "GRANT ALL PRIVILEGES ON dspam.* to 'dspam'@'${_ip}';" | mysql_query || exit 1
 		done
 	done
 }

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -116,11 +116,13 @@ migrate_geoip_dbs()
 
 	Proceed?
 	"
-	dialog --yesno "$_confirm_msg" 13 70 || return
+	dialog --yesno "$_confirm_msg" 13 70 || exit
+
+	service jail stop geoip spamassassin haraka
 
 	for _suffix in mmdb dat; do
-		for _db in "$DATA_MNT"/geoip/*."$_suffix"; do
-			mv "$_db" "$DATA_MNT/geoip/db"
+		for _db in "$ZFS_DATA_MNT"/geoip/*."$_suffix"; do
+			mv "$_db" "$ZFS_DATA_MNT/geoip/db"
 		done
 	done
 }

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -112,7 +112,10 @@ migrate_geoip_dbs()
 	2. move the geoip data into a 'db' subdirectory
 	3. promote the newly build geoip jail
 
-	You will need to provision new spamassassin and haraka jails.
+	Then, for the spamassassin and haraka jails, you will need to do one of:
+
+		- update the mountpoint for the geoip db directory in jail.conf
+		- provision new jails
 
 	Proceed?
 	"
@@ -129,11 +132,11 @@ migrate_geoip_dbs()
 
 preflight_check
 base_snapshot_exists || exit
+migrate_geoip_dbs
 create_staged_fs geoip
 start_staged_jail geoip
 install_geoip
 configure_geoip
 start_geoip
 test_geoip
-migrate_geoip_dbs
 promote_staged_jail geoip

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -119,7 +119,7 @@ migrate_geoip_dbs()
 
 	Proceed?
 	"
-	dialog --yesno "$_confirm_msg" 18 70 || exit
+	dialog --yesno "$_confirm_msg" 19 70 || exit
 
 	service jail stop geoip spamassassin haraka
 

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -2,9 +2,6 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
-
 preflight_check() {
 	if [ -z "$MAXMIND_LICENSE_KEY" ]; then
 		echo "ERROR: edit mail-toaster.conf and set MAXMIND_LICENSE_KEY"

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -119,13 +119,18 @@ migrate_geoip_dbs()
 
 	Proceed?
 	"
-	dialog --yesno "$_confirm_msg" 13 70 || exit
+	dialog --yesno "$_confirm_msg" 18 70 || exit
 
 	service jail stop geoip spamassassin haraka
 
+	for _d in etc db; do
+		_path="$ZFS_DATA_MNT/geoip/$_d"
+		[ -d "$_path" ] || mkdir "$_path"
+	done
+
 	for _suffix in mmdb dat; do
 		for _db in "$ZFS_DATA_MNT"/geoip/*."$_suffix"; do
-			mv "$_db" "$ZFS_DATA_MNT/geoip/db"
+			mv "$_db" "$ZFS_DATA_MNT/geoip/db/"
 		done
 	done
 }

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -31,6 +31,12 @@ install_geoip()
 		[ -d "$_path" ] || mkdir "$_path"
 	done
 
+	for _suffix in mmdb dat; do
+		for _db in "$STAGE_MNT"/data/*."$_suffix"; do
+			mv "$_db" "$STAGE_MNT/data/db"
+		done
+	done
+
 	if [ "$GEOIP_UPDATER" = "geoipupdate" ]; then
 		install_geoip_geoipupdate
 	else

--- a/provision/ghost.sh
+++ b/provision/ghost.sh
@@ -9,10 +9,10 @@ install_ghost()
 {
 	tell_status "install ghost"
 
-	stage_pkg_install python27
-	stage_exec ln -s /usr/local/bin/python2.7 /usr/local/bin/python
+	#stage_pkg_install python27
+	#stage_exec ln -s /usr/local/bin/python2.7 /usr/local/bin/python
 
-	stage_pkg_install npm-node10 || exit
+	stage_pkg_install npm-node18 || exit
 	stage_exec npm install -g ghost-cli@latest
 }
 
@@ -28,7 +28,7 @@ configure_ghost()
 start_ghost()
 {
 	tell_status "starting up ghost"
-	stage_exec bash -c 'cd /data/www/ghost && ghost start'
+	stage_exec bash -c 'cd /data/www/ghost && ghost start || exit 1'
 }
 
 test_ghost()

--- a/provision/haproxy.sh
+++ b/provision/haproxy.sh
@@ -2,9 +2,6 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
-
 install_haproxy()
 {
 	case "$TLS_LIBRARY" in

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -5,6 +5,7 @@
 export JAIL_START_EXTRA="devfs_ruleset=7"
 export JAIL_CONF_EXTRA="
 		devfs_ruleset = 7;"
+export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP nullfs rw 0 0"
 
 HARAKA_CONF="$ZFS_DATA_MNT/haraka/config"
 
@@ -46,10 +47,6 @@ install_geoip_dbs()
 		tell_status "enabling Haraka geoip plugin"
 		sed -i.bak -e '/^# geoip/ s/# //' "$HARAKA_CONF/plugins"
 	fi
-
-	mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
-	JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
-		mount += \"$ZFS_DATA_MNT/geoip/db \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
 }
 
 add_devfs_rule()
@@ -641,8 +638,7 @@ EO_DCC
 
 configure_haraka_spf()
 {
-	if grep -qv '^;' "$HARAKA_CONF/spf.ini";
-	then
+	if grep -qs '^;' "$HARAKA_CONF/spf.ini"; then
 		tell_status "spf.ini already configured"
 	else
 		tell_status "configuring SPF [relay]context=myself"
@@ -756,6 +752,7 @@ preinstall_checks() {
 
 preinstall_checks
 create_staged_fs haraka
+mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
 add_devfs_rule
 start_staged_jail haraka
 install_haraka

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -49,7 +49,7 @@ install_geoip_dbs()
 
 	mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
 	JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
-		mount += \"$ZFS_DATA_MNT/geoip \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
+		mount += \"$ZFS_DATA_MNT/geoip/db \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
 }
 
 add_devfs_rule()

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -230,8 +230,8 @@ tmpdir=/data/avg/spool
 
 	if zfs_filesystem_exists "$ZFS_DATA_VOL/avg"; then
 		tell_status "adding avg data FS to Haraka jail"
-		JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
-		mount += \"$ZFS_DATA_MNT/avg \$path/data/avg nullfs rw 0 0\";"
+		JAIL_FSTAB="$JAIL_FSTAB
+$ZFS_DATA_MNT/avg   $ZFS_JAIL_MNT/haraka/data/avg nullfs rw 0 0"
 
 		if ! grep -qs spool "$HARAKA_CONF/avg.ini"; then
 			tell_status "update tmpdir in avg.ini"

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -245,12 +245,7 @@ $ZFS_DATA_MNT/avg   $ZFS_JAIL_MNT/haraka/data/avg nullfs rw 0 0"
 	fi
 
 	if ! grep -q ^avg "$HARAKA_CONF/plugins"; then
-		if ! jls | grep -qs avg; then
-			echo "AVG not running, not enabling"
-			return
-		fi
-
-		if ! jls | grep -qs avg; then
+		if ! jls -j avg | grep -qs avg; then
 			echo "AVG not running, not enabling"
 			return
 		fi

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -5,7 +5,7 @@
 export JAIL_START_EXTRA=""
 # shellcheck disable=2016
 export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
+		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include php
 mt6-include nginx

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -229,8 +229,8 @@ EO_HORDE_PREFS
 		for _jail in horde stage; do
 			for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 			do
-				echo "GRANT ALL PRIVILEGES ON horde.* to 'horde'@'${_ip}' IDENTIFIED BY '${_hordepass}';" \
-					| mysql_query || exit
+				echo "CREATE USER IF NOT EXISTS 'horde'@'${_ip}' IDENTIFIED BY '${_hordepass}';" | mysql_query || exit 1
+				echo "GRANT ALL PRIVILEGES ON horde.* to 'horde'@'${_ip}';" | mysql_query || exit 1
 			done
 		done
 	fi

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -2,10 +2,7 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-# shellcheck disable=2016
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
+export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/horde/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include php
 mt6-include nginx

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -173,7 +173,7 @@ constrain_sshd_to_host()
 
 sshd_reorder()
 {
-	_file="/usr/local/etc/rc.d/sshd_recorder"
+	_file="/usr/local/etc/rc.d/sshd_reorder"
 	if [ -x "$_file" ]; then return; fi
 
 	tell_status "starting sshd earlier"
@@ -184,6 +184,8 @@ sshd_reorder()
 
 # PROVIDE: sshd_reorder
 # REQUIRE: LOGIN sshd
+# BEFORE: jail
+
 EO_SSHD_REORDER
 	chmod 755 "$_file"
 }

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -118,7 +118,6 @@ EO_MY_CNF
 
 start_mysql()
 {
-
 	tell_status "starting mysql"
 
 	if [ -d "$ZFS_JAIL_MNT/mysql/data/db/mysql" ]; then
@@ -148,9 +147,26 @@ migrate_mysql_dbs()
 	HALT: mysql data migration required.
 
 	See https://github.com/msimerson/Mail-Toaster-6/wiki/Updating
-
 		"
 		exit 1
+	fi
+
+	if jls -j mysql | grep -qs mysql; then
+		echo "mysql jail is running"
+
+		_my_ver=$(pkg -j mysql info | grep mysql | grep server | cut -f1 -d' ' | cut -d- -f3)
+		if [ -n "$_my_ver" ]; then
+			_major=$(echo "$_my_ver" | cut -f1 -d'.')
+			if [ "$_major" -lt "8" ]; then
+				echo "
+	HALT: mysql upgrade to version 8 required.
+
+	See https://github.com/msimerson/Mail-Toaster-6/wiki/Updating
+				"
+				exit 1
+
+			fi
+		fi
 	fi
 }
 

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -3,11 +3,18 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/mysql \$path/var/db/mysql nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA=""
 
 install_db_server()
 {
+	for _d in etc db; do
+		_path="$STAGE_MNT/data/$_d"
+		if [ ! -d "$_path" ]; then
+			mkdir "$_path" || exit 1
+			chown 88:88 "$_path"
+		fi
+	done
+
 	# Check if MariaDB needs to be installed
 	if [ "$TOASTER_MARIADB" = "1" ]; then
 		install_mariadb
@@ -49,6 +56,8 @@ EO_MY_CNF
 
 configure_mysql_keys()
 {
+	local _dbdir="$ZFS_DATA_MNT/mysql/db"
+
 	if [ ! -f "$_dbdir/private_key.pem" ]; then
 		tell_status "enabling sha256_password support"
 		openssl genrsa -out "$_dbdir/private_key.pem" 2048
@@ -82,7 +91,6 @@ configure_mysql_root_password()
 configure_mysql()
 {
 	tell_status "configuring mysql"
-	stage_sysrc mysql_optfile="/var/db/mysql/my.cnf"
 	if [ ! -f "$STAGE_MNT/data/etc/my.cnf" ]; then
 		sed -i '' \
 			-e 's/= \/var\/db\/mysql$/= \/data\/db/g' \
@@ -91,39 +99,41 @@ configure_mysql()
 		# cp "$STAGE_MNT/usr/local/etc/mysql/my.cnf" "$STAGE_MNT/data/etc/my.cnf"
 	fi
 
-	preserve_file /etc/my.cnf
+	stage_sysrc mysql_enable=YES
+	stage_sysrc mysql_dbdir="/data/db"
+	stage_sysrc mysql_optfile="/data/etc/extra.cnf"
 
-	local _dbdir="$ZFS_DATA_MNT/mysql"
-	if [ ! -d "$_dbdir" ]; then mkdir "$_dbdir" || exit 1; fi
+	local _dbdir="$ZFS_DATA_MNT/mysql/db"
 
-	local _my_cnf="$_dbdir/my.cnf"
-	if [ ! -f "$_my_cnf" ]; then
-		tell_status "installing $_my_cnf"
-		tee -a "$_my_cnf" <<EO_MY_CNF
+	local _my_cnf="$STAGE_MNT/data/etc/extra.cnf"
+	store_config "$_my_cnf" <<EO_MY_CNF
 [mysqld]
+datadir                         = /data/db
+innodb_data_home_dir            = /data/db
+innodb_log_group_home_dir       = /data/db
+
 innodb_doublewrite = off
 innodb_file_per_table = 1
 innodb_checksum_algorithm = none
 innodb_flush_neighbors = 0
 EO_MY_CNF
-	fi
-
-	configure_mysql_keys
-	configure_mysql_root_password
 }
 
 start_mysql()
 {
-	tell_status "starting mysql"
-	stage_sysrc mysql_enable=YES
 
-	if [ -d "$ZFS_JAIL_MNT/mysql/var/db/mysql" ]; then
-		# update, mysql jail exists, unmount the data dir, two mysql's
+	tell_status "starting mysql"
+
+	if [ -d "$ZFS_JAIL_MNT/mysql/data/db/mysql" ]; then
+		# mysql jail exists, unmount the data dir as two mysql's
 		# cannot access the data concurrently
+		tell_status "unmounting live mysql data FS"
 		unmount_data mysql
 	fi
 
 	stage_exec service mysql-server start || exit
+	configure_mysql_root_password
+	configure_mysql_keys
 }
 
 test_mysql()
@@ -145,7 +155,7 @@ base_snapshot_exists || exit
 create_staged_fs mysql
 start_staged_jail mysql
 install_db_server
-start_mysql
 configure_mysql
+start_mysql
 test_mysql
 promote_staged_jail mysql

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -2,9 +2,6 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
-
 install_db_server()
 {
 	for _d in etc db; do

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -141,6 +141,19 @@ test_mysql()
 	echo "it worked"
 }
 
+migrate_mysql_dbs()
+{
+	if [ -f "$ZFS_DATA_MNT/mysql/mysql.err" ]; then
+		echo "
+	HALT: mysql data migration required.
+
+	See https://github.com/msimerson/Mail-Toaster-6/wiki/Updating
+
+		"
+		exit 1
+	fi
+}
+
 if [ "$TOASTER_MYSQL" = "1" ] || [ "$SQUIRREL_SQL" = "1" ] || [ "$ROUNDCUBE_SQL" = "1" ]; then
 	tell_status "installing MySQL"
 else
@@ -155,4 +168,5 @@ install_db_server
 configure_mysql
 start_mysql
 test_mysql
+migrate_mysql_dbs
 promote_staged_jail mysql

--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -57,8 +57,8 @@ install_roundcube_mysql()
 		for _jail in roundcube stage; do
 			for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 			do
-				echo "GRANT ALL PRIVILEGES ON roundcubemail.* to 'roundcube'@'${_ip}' IDENTIFIED BY '${_rcpass}';" \
-					| mysql_query || exit
+				echo "CREATE USER IF NOT EXISTS 'roundcube'@'${_ip}' IDENTIFIED BY '${_rcpass}';" | mysql_query || exit 1
+				echo "GRANT ALL PRIVILEGES ON roundcubemail.* to 'roundcube'@'${_ip}';" | mysql_query || exit 1
 			done
 		done
 

--- a/provision/snappymail.sh
+++ b/provision/snappymail.sh
@@ -12,7 +12,7 @@ PHP_VER="82"
 
 install_snappymail()
 {
-	local _php_modules="curl dom gd iconv intl mbstring pdo_sqlite pecl-APCu pecl-gnupg pecl-uuid phar session simplexml sodium tidy xml zip zlib"
+	local _php_modules="ctype curl dom gd iconv intl mbstring pdo_sqlite pecl-APCu pecl-gnupg pecl-uuid phar session simplexml sodium tidy xml zip zlib"
 
 	if [ "$TOASTER_MYSQL" != "1" ]; then
 		tell_status "using sqlite DB backend"

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -2,8 +2,7 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0"
 
 mt6-include mysql
 
@@ -168,9 +167,6 @@ configure_geoip()
 		tell_status "GeoIP jail not present, SKIPPING geoip plugin"
 		return
 	fi
-
-	JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
-		mount += \"$ZFS_DATA_MNT/geoip/db \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
 }
 
 configure_spamassassin()
@@ -323,6 +319,7 @@ test_spamassassin()
 
 base_snapshot_exists || exit
 create_staged_fs spamassassin
+mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
 start_staged_jail spamassassin
 install_spamassassin
 configure_spamassassin

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -170,7 +170,7 @@ configure_geoip()
 	fi
 
 	JAIL_CONF_EXTRA="$JAIL_CONF_EXTRA
-		mount += \"$ZFS_DATA_MNT/geoip \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
+		mount += \"$ZFS_DATA_MNT/geoip/db \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
 }
 
 configure_spamassassin()

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -285,11 +285,8 @@ EO_MYSQL_CONF
 	do
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
-			mysql_user_exists spamassassin $_ip \
-                                || echo "CREATE USER 'spamassassin'@'$_ip' IDENTIFIED BY '$_my_pass'; FLUSH PRIVILEGES;" | mysql_query \
-                                || exit 1
-			echo "GRANT ALL PRIVILEGES ON spamassassin.* to 'spamassassin'@'$_ip'" \
-				| mysql_query || exit 1
+			echo "CREATE USER IF NOT EXISTS 'spamassassin'@'$_ip' IDENTIFIED BY '$_my_pass'; FLUSH PRIVILEGES;" | mysql_query || exit 1
+			echo "GRANT ALL PRIVILEGES ON spamassassin.* to 'spamassassin'@'$_ip'" | mysql_query || exit 1
 		done
 	done
 }

--- a/provision/squirrelmail.sh
+++ b/provision/squirrelmail.sh
@@ -65,8 +65,8 @@ EO_SQUIRREL_SQL
 	for _jail in squirrelmail stage; do
 		for _ip in $(get_jail_ip "$_jail") $(get_jail_ip6 "$_jail");
 		do
-			echo "GRANT ALL PRIVILEGES ON squirrelmail.* to 'squirrelmail'@'${_ip}' IDENTIFIED BY '${sqpass}';" \
-				| mysql_query || exit
+			echo "CREATE USER IF NOT EXISTS 'squirrelmail'@'${_ip}' IDENTIFIED BY '${sqpass}';" | mysql_query || exit 1
+			echo "GRANT ALL PRIVILEGES ON squirrelmail.* to 'squirrelmail'@'${_ip}';" | mysql_query || exit 1
 		done
 	done
 }

--- a/provision/sqwebmail.sh
+++ b/provision/sqwebmail.sh
@@ -2,10 +2,7 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/sqwebmail \$path/data nullfs rw 0 0\";
-		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
+export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/sqwebmail/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail
 

--- a/provision/sqwebmail.sh
+++ b/provision/sqwebmail.sh
@@ -5,7 +5,7 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		mount += \"$ZFS_DATA_MNT/sqwebmail \$path/data nullfs rw 0 0\";
-		mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
+		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include vpopmail
 

--- a/provision/unifi.sh
+++ b/provision/unifi.sh
@@ -2,10 +2,12 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
                 mount.fdescfs;
                 mount.procfs;"
+# TODO: test
+# export JAIL_FSTAB="fdescfs /jails/unifi/dev/fd fdescfs rw 0 0
+# proc     /jails/unifi/proc   procfs  rw 0 0"
 
 install_unifi()
 {

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -315,23 +315,23 @@ migrate_vpopmail_home()
 	"
 	exit
 
-	service jail stop dovecot vpopmail
+	# service jail stop dovecot vpopmail
 
-	for _d in bin domains include qmail-control doc etc lib qmail-users; do
-		echo "mv $ZFS_DATA_MNT/vpopmail/$_d $ZFS_DATA_MNT/vpopmail/home/"
-		mv "$ZFS_DATA_MNT/vpopmail/$_d" "$ZFS_DATA_MNT/vpopmail/home/"
-	done
+	# for _d in bin domains include qmail-control doc etc lib qmail-users; do
+	# 	echo "mv $ZFS_DATA_MNT/vpopmail/$_d $ZFS_DATA_MNT/vpopmail/home/"
+	# 	mv "$ZFS_DATA_MNT/vpopmail/$_d" "$ZFS_DATA_MNT/vpopmail/home/"
+	# done
 
-	if [ ! -d "$ZFS_DATA_MNT/vpopmail/etc" ]; then
-		mkdir "$ZFS_DATA_MNT/vpopmail/etc"
-	fi
+	# if [ ! -d "$ZFS_DATA_MNT/vpopmail/etc" ]; then
+	# 	mkdir "$ZFS_DATA_MNT/vpopmail/etc"
+	# fi
 
-	if [ -d "$ZFS_DATA_MNT/vpopmail/home/etc/pf.conf.d" ]; then
-		mv "$ZFS_DATA_MNT/vpopmail/home/etc/pf.conf.d" "$ZFS_DATA_MNT/vpopmail/etc/"
-	fi
+	# if [ -d "$ZFS_DATA_MNT/vpopmail/home/etc/pf.conf.d" ]; then
+	# 	mv "$ZFS_DATA_MNT/vpopmail/home/etc/pf.conf.d" "$ZFS_DATA_MNT/vpopmail/etc/"
+	# fi
 
-	# TODO: patch fstab mounts in /etc/jail.conf
-	service jail stop dovecot vpopmail
+	# # TODO: patch fstab mounts in /etc/jail.conf
+	# service jail stop dovecot vpopmail
 }
 
 migrate_vpopmail_home

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -6,6 +6,7 @@ export VPOPMAIL_OPTIONS_SET="CLEAR_PASSWD"
 export VPOPMAIL_OPTIONS_UNSET="ROAMING"
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
+		mount += \"$ZFS_DATA_MNT/vpopmail \$path/data nullfs rw 0 0\";
 		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include vpopmail

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -78,8 +78,8 @@ install_qmailadmin()
 	tell_status "installing qmailadmin"
 	stage_pkg_install autorespond ezmlm-idx autoconf automake help2man
 	stage_make_conf mail_qmailadmin_ '
-mail_qmailadmin_SET=HELP IDX MODIFY_QUOTA SPAM_DETECTION TRIVIAL_PASSWORD USER_INDEX
-mail_qmailadmin_UNSET=CATCHALL CRACKLIB IDX_SQL
+mail_qmailadmin_SET=HELP IDX MODIFY_QUOTA TRIVIAL_PASSWORD USER_INDEX
+mail_qmailadmin_UNSET=CATCHALL CRACKLIB IDX_SQL SPAM_DETECTION SPAM_NEEDS_EMAIL
 '
 
 	if [ -f "$ZFS_JAIL_MNT/vpopmail/var/db/ports/mail_qmailadmin/options" ]; then
@@ -280,7 +280,7 @@ migrate_vpopmail_home()
 
 	Proceed?
 	"
-	dialog --yesno "$_confirm_msg" 13 70 || return
+	dialog --yesno "$_confirm_msg" 13 70 || exit
 
 	service jail stop dovecot vpopmail
 

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -6,7 +6,7 @@ export VPOPMAIL_OPTIONS_SET="CLEAR_PASSWD"
 export VPOPMAIL_OPTIONS_UNSET="ROAMING"
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/vpopmail \$path/usr/local/vpopmail nullfs rw 0 0\";"
+		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
 
 mt6-include vpopmail
 mt6-include mysql
@@ -95,9 +95,6 @@ mail_qmailadmin_UNSET=CATCHALL CRACKLIB IDX_SQL
 
 	export WEBDATADIR=www/data CGIBINDIR=www/cgi-bin CGIBINSUBDIR=qmailadmin SPAM_COMMAND="| /usr/local/bin/maildrop /usr/local/etc/mail/mailfilter"
 
-	if [ -x "$STAGE_MNT/usr/local/bin/perl5.26.2" ]; then
-		stage_exec ln /usr/local/bin/perl5.26.2 /usr/local/bin/perl5.26.1
-	fi
 	stage_port_install mail/qmailadmin || exit
 
 	install_lighttpd
@@ -202,6 +199,13 @@ install_quota_report()
 
 install_vpopmail()
 {
+	for _d in etc home; do
+		_path="$STAGE_MNT/data/$_d"
+		if [ ! -d "$_path" ]; then
+			mkdir "$_path" || exit 1
+		fi
+	done
+
 	install_qmail
 	configure_qmail
 	install_maildrop
@@ -242,7 +246,7 @@ configure_vpopmail()
 	stage_pkg_install p5-Package-Constants
 	fetch -o - "$TOASTER_SRC_URL/qmail/run.sh" | stage_exec sh
 
-	if [ ! -d "$ZFS_DATA_MNT/vpopmail/domains/$TOASTER_MAIL_DOMAIN" ]; then
+	if [ ! -d "$STAGE_MNT/usr/local/vpopmail/domains/$TOASTER_MAIL_DOMAIN" ]; then
 		tell_status "ATTN: Your postmaster password is..."
 		stage_exec /usr/local/vpopmail/bin/vadddomain -r14 "$TOASTER_MAIL_DOMAIN"
 	fi

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -4,10 +4,7 @@
 
 export VPOPMAIL_OPTIONS_SET="CLEAR_PASSWD"
 export VPOPMAIL_OPTIONS_UNSET="ROAMING"
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/vpopmail \$path/data nullfs rw 0 0\";
-		mount += \"$ZFS_DATA_MNT/vpopmail/home \$path/usr/local/vpopmail nullfs rw 0 0\";"
+export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/vpopmail/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail
 mt6-include mysql
@@ -200,13 +197,6 @@ install_quota_report()
 
 install_vpopmail()
 {
-	for _d in etc home; do
-		_path="$STAGE_MNT/data/$_d"
-		if [ ! -d "$_path" ]; then
-			mkdir "$_path" || exit 1
-		fi
-	done
-
 	install_qmail
 	configure_qmail
 	install_maildrop
@@ -274,6 +264,11 @@ test_vpopmail()
 
 base_snapshot_exists || exit
 create_staged_fs vpopmail
+
+mkdir -p "$STAGE_MNT/usr/local/vpopmail" \
+	"$ZFS_DATA_MNT/vpopmail/home" \
+	"$ZFS_DATA_MNT/vpopmail/etc"
+
 start_staged_jail vpopmail
 install_vpopmail
 configure_vpopmail

--- a/provision/whmcs.sh
+++ b/provision/whmcs.sh
@@ -2,9 +2,7 @@
 
 . mail-toaster.sh || exit
 
-export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-	   mount += \"$ZFS_DATA_MNT/geoip/db \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
+export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP nullfs rw 0 0"
 
 mt6-include php
 mt6-include nginx
@@ -72,7 +70,6 @@ configure_whmcs()
 	configure_nginx whmcs
 
 	mkdir -p "$STAGE_MNT/vendor/whmcs/whmcs"
-	mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
 	chown -R www:www "$STAGE_MNT/vendor"
 
 	tee -a "$STAGE_MNT/etc/crontab" <<'EO_CRONTAB'
@@ -98,6 +95,7 @@ test_whmcs()
 
 base_snapshot_exists || exit
 create_staged_fs whmcs
+mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
 start_staged_jail
 install_whmcs
 configure_whmcs

--- a/provision/whmcs.sh
+++ b/provision/whmcs.sh
@@ -4,8 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
-	   mount += \"$ZFS_DATA_MNT/whmcs \$path/data nullfs rw 0 0\";
-	   mount += \"$ZFS_DATA_MNT/geoip \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
+	   mount += \"$ZFS_DATA_MNT/geoip/db \$path/usr/local/share/GeoIP nullfs ro 0 0\";"
 
 mt6-include php
 mt6-include nginx

--- a/qmail/run.sh
+++ b/qmail/run.sh
@@ -217,6 +217,7 @@ case "$1" in
     then
       if [ -x /var/qmail/bin/qmail-newu ]
       then
+        /var/qmail/users/assign
         echo "Reloaded /var/qmail/users/assign."
       fi
     fi


### PR DESCRIPTION
- to be more consistent with how other jails works
- to store persistent /data/etc and /data/log directories
- fix: overly broad sed scripts on clamd.conf
- rework filesystem mounts
    - goals: simplify, make more explicit, make more flexible
    - instead of `mount +=` lines in jail.conf, a single `mount.fstab=$data/etc/fstab` setting
    - previously: information about "special" fstab mounts was embedded in functions in mail-toaster.sh and in the provision scripts.
    - now: a custom `$data/etc/fstab` file is generated for each jail. The data fs is mounted automatically, any extra filesystems must be added as fstab entries within the provision script as JAIL_FSTAB.
    - for staging, a sed script rewrites `$data/etc/fstab` to `$data/etc/fstab.stage`

### TODO

- [x] write migration scripts
- [x] document migration scripts