### PR TITLE
dovecot: Fix `jail -m jid=NAME` on 13.2

### DIFF
--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -8,9 +8,10 @@ export JAIL_CONF_EXTRA="
 
 mt6-include vpopmail
 
-allow_sysvipc_stage(){
+allow_sysvipc_stage()
+{
     tell_status "allow sysvipc for the staged jail"
-    jail -m jid=stage allow.sysvipc=1
+    jail -m name=stage allow.sysvipc=1
 }
 
 install_dovecot()


### PR DESCRIPTION
On FreeBSD 13.2, passing a non-numeric value for `jid` results in error:

```
# jail -m jid=stage allow.sysvipc=1
jail: jid: non-integer value "stage"
```

### Changes proposed in this pull request:
- Use `jail -m name=NAME`

Checklist:
- [ ] docs up-to-date
