### PR TITLE
webmail: disable squirrelmail, rainloop, and sqwebmail

### DIFF
--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -178,7 +178,7 @@ switch_host_resolver()
 {
 	if grep "^nameserver $(get_jail_ip dns)" /etc/resolv.conf; then return; fi
 
-	echo "switching host resolver to dns jail"
+	echo "switching host resolver to local"
 	sysrc -f /etc/resolvconf.conf name_servers="$(get_jail_ip dns) $(get_jail_ip6 dns)"
 	echo "nameserver $(get_jail_ip dns)
 nameserver $(get_jail_ip6 dns)" | resolvconf -a "$PUBLIC_NIC"

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -112,7 +112,7 @@ install_index()
     'snappymail'  : '/snappymail/',
     // 'rainloop'    : '/rainloop/',
     // 'sqwebmail'   : '/cgi-bin/sqwebmail?index=1',
-    'squirrelmail': '/squirrelmail/src/webmail.php',
+    // 'squirrelmail': '/squirrelmail/src/webmail.php',
   }
   const adminPaths = {
     'admin'     : '',

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -110,8 +110,8 @@ install_index()
     'webmail'     : '',
     'roundcube'   : '/roundcube/',
     'snappymail'  : '/snappymail/',
-    'rainloop'    : '/rainloop/',
-    'sqwebmail'   : '/cgi-bin/sqwebmail?index=1',
+    // 'rainloop'    : '/rainloop/',
+    // 'sqwebmail'   : '/cgi-bin/sqwebmail?index=1',
     'squirrelmail': '/squirrelmail/src/webmail.php',
   }
   const adminPaths = {
@@ -120,7 +120,7 @@ install_index()
     'rspamd'    : '/rspamd/',
     'watch'     : '/watch/',
     'snappymail': '/snappymail/?admin',
-    'rainloop'  : '/rainloop/?admin',
+    // 'rainloop'  : '/rainloop/?admin',
   }
   const statsPaths = {
     'statistics': '',
@@ -215,9 +215,9 @@ body {
                <option value=webmail>Webmail</option>
                <option value=roundcube>Roundcube</option>
                <option value=snappymail>Snappymail</option>
-               <option value=squirrelmail>Squirrelmail</option>
-               <option value=rainloop>Rainloop</option>
-               <option value=sqwebmail>Sqwebmail</option>
+               <!--<option value=squirrelmail>Squirrelmail</option>-->
+               <!--<option value=rainloop>Rainloop</option>-->
+               <!--<option value=sqwebmail>Sqwebmail</option>-->
            </select>
        </a>
        </li>
@@ -228,7 +228,7 @@ body {
                <option value=rspamd>Rspamd</option>
                <option value=watch>Haraka Watch</option>
                <option value=snappymail>Snappymail Admin</option>
-               <option value=rainloop>Rainloop Admin</option>
+               <!--<option value=rainloop>Rainloop Admin</option>-->
            </select>
        </a>
        </li>


### PR DESCRIPTION
- all 3 are effectively unmaintained. Don't encourage their use, but keep it easy to manually enable them. 