### PR TITLE
Vpopmail

### DIFF
--- a/include/mua.sh
+++ b/include/mua.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+test_imap_empty()
+{
+	pkg info | grep -q ^empty || pkg install -y empty
+
+	if [ -f in ]; then rm -f in; fi
+	if [ -f out ]; then rm -f out; fi
+
+	# empty -v -f -i in -o out telnet "$MUA_TEST_HOST" 143
+	empty -v -f -i in -o out openssl s_client -quiet -verify_quiet -crlf -connect "$MUA_TEST_HOST:993"
+	if [ ! -e out ]; then exit; fi
+	empty -v -w -i out -o in "ready"             ". LOGIN $MUA_TEST_USER $MUA_TEST_PASS"$'\n'
+	empty -v -w -i out -o in "Logged in"         $'. LIST \"\" \"*\"\n'
+	empty -v -w -i out -o in "List completed"    $'. SELECT INBOX\n'
+	# shellcheck disable=SC2050
+	if [ "has" = "some messages" ]; then
+		empty -v -w -i out -o in "Select completed"  $'. FETCH 1 BODY\n'
+		empty -v -w -i out -o in "OK Fetch completed" $'. LOGOUT\n'
+	else
+		empty -v -w -i out -o in "Select completed" $'. LOGOUT\n'
+	fi
+	echo "Logout completed"
+	if [ -e out ]; then
+		sleep 1
+		if [ -e out ]; then exit; fi
+	fi
+}
+
+test_imap_openssl()
+{
+	openssl s_client -quiet -verify_quiet -crlf -connect "$MUA_TEST_HOST:993" <<EOF
+. login $MUA_TEST_USER $MUA_TEST_PASS
+. LIST "" "*"
+. SELECT INBOX
+. LOGOUT
+EOF
+}
+
+test_imap_curl()
+{
+	# shellcheck disable=SC2001
+	curl -k -v --login-options 'AUTH=PLAIN' "imaps://$(echo $MUA_TEST_USER | sed -e 's/@/%40/'):${MUA_TEST_PASS}@${MUA_TEST_HOST}/"
+}
+
+test_imap()
+{
+	echo "testing IMAP AUTH as $MUA_TEST_USER"
+	test_imap_curl
+	# test_imap_openssl
+	# test_imap_empty
+}
+
+test_pop3_empty()
+{
+	pkg info | grep -q ^empty || pkg install -y empty
+
+	if [ -f in ]; then rm -f in; fi
+	if [ -f out ]; then rm -f out; fi
+
+	echo "testing POP3 AUTH as $MUA_TEST_USER"
+
+	# empty -v -f -i in -o out telnet "$MUA_TEST_HOST" 110
+	empty -v -f -i in -o out openssl s_client -quiet -crlf -connect "$MUA_TEST_HOST:995"
+	if [ ! -e out ]; then exit; fi
+	empty -v -w -i out -o in "\+OK." "user $MUA_TEST_USER"$'\n'
+	empty -v -w -i out -o in "\+OK" "pass $MUA_TEST_PASS"$'\n'
+	empty -v -w -i out -o in "OK Logged in" $'list\n'
+	empty -v -w -i out -o in "." $'quit\n'
+
+	if [ -e out ]; then
+		sleep 1
+		if [ -e out ]; then exit; fi
+	fi
+}
+
+test_pop3()
+{
+	# shellcheck disable=SC2001
+	curl -k -v --login-options 'AUTH=PLAIN' "pop3s://$(echo $MUA_TEST_USER | sed -e 's/@/%40/'):${MUA_TEST_PASS}@${MUA_TEST_HOST}/"
+}

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -33,6 +33,9 @@ freebsd_update()
 	tell_status "apply FreeBSD security updates to base jail"
 	sed -i.bak -e 's/^Components.*/Components world/' "$BASE_MNT/etc/freebsd-update.conf"
 	freebsd-update -b "$BASE_MNT" -f "$BASE_MNT/etc/freebsd-update.conf" fetch install
+
+	echo "clearing freebsd-update cache"
+	rm -rf $BASE_MNT/var/db/freebsd-update/*
 }
 
 install_freebsd()

--- a/provision/borg.sh
+++ b/provision/borg.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_borg()
 {

--- a/provision/bsd_cache.sh
+++ b/provision/bsd_cache.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include nginx
 

--- a/provision/certbot.sh
+++ b/provision/certbot.sh
@@ -2,6 +2,10 @@
 
 . mail-toaster.sh || exit
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 install_certbot()
 {
 	tell_status "installing certbot"

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -4,6 +4,10 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 install_clamav_fangfrisch()
 {
 	if [ "$CLAMAV_FANGFRISCH" = "0" ]; then return; fi

--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -6,6 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_dcc_cleanup()
 {

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e -u
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA="devfs_ruleset=7
 		allow.raw_sockets=1"
 export JAIL_CONF_EXTRA="
 		devfs_ruleset = 7;
 		allow.raw_sockets = 1;"
+export JAIL_FSTAB=""
 
 install_dhcpd()
 {
 	tell_status "installing dhcpd"
-	stage_pkg_install isc-dhcp44-server || exit
+	stage_pkg_install isc-dhcp44-server
 }
 
 configure_dhcpd()
@@ -34,11 +37,11 @@ rdr inet6 proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip6 dhcp)
 EO_PF_RDR
 
 	if [ ! -d "$ZFS_DATA_MNT/dhcp/etc" ]; then
-		mkdir -p "$ZFS_DATA_MNT/dhcp/etc" || exit
+		mkdir -p "$ZFS_DATA_MNT/dhcp/etc"
 	fi
 
 	if [ ! -d "$ZFS_DATA_MNT/dhcp/db" ]; then
-		mkdir -p "$ZFS_DATA_MNT/dhcp/db" || exit
+		mkdir -p "$ZFS_DATA_MNT/dhcp/db"
 	fi
 
 	get_public_ip
@@ -79,7 +82,7 @@ EO_DHCP
 start_dhcpd()
 {
 	tell_status "starting dhcpd"
-	stage_exec service isc-dhcpd start || exit
+	stage_exec service isc-dhcpd start
 }
 
 test_dhcpd()

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -7,6 +7,7 @@ set -e
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		allow.raw_sockets;"
+export JAIL_FSTAB=""
 
 install_unbound()
 {

--- a/provision/dspam.sh
+++ b/provision/dspam.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include mysql
 

--- a/provision/elasticsearch.sh
+++ b/provision/elasticsearch.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -e -u
 
 . mail-toaster.sh
 

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -4,6 +4,10 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 preflight_check() {
 	if [ -z "$MAXMIND_LICENSE_KEY" ]; then
 		echo "ERROR: edit mail-toaster.conf and set MAXMIND_LICENSE_KEY"

--- a/provision/ghost.sh
+++ b/provision/ghost.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_ghost()
 {

--- a/provision/gitlab.sh
+++ b/provision/gitlab.sh
@@ -6,6 +6,7 @@ export JAIL_START_EXTRA="allow.sysvipc=1"
 export JAIL_CONF_EXTRA="
 		allow.sysvipc;
 "
+export JAIL_FSTAB=""
 
 # https://docs.gitlab.com/ee/install/relative_url.html
 # https://gitlab.fechner.net/mfechner/Gitlab-docu/blob/master/install/15.10-freebsd.md

--- a/provision/gitlab_runner.sh
+++ b/provision/gitlab_runner.sh
@@ -2,6 +2,10 @@
 
 . mail-toaster.sh || exit
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 # https://wiki.freebsd.org/Docker
 # https://docs.gitlab.com/runner/install/freebsd.html
 

--- a/provision/grafana.sh
+++ b/provision/grafana.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_grafana()
 {

--- a/provision/haproxy.sh
+++ b/provision/haproxy.sh
@@ -4,6 +4,10 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 install_haproxy()
 {
 	case "$TLS_LIBRARY" in

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -396,6 +396,21 @@ configure_haraka_smtp_ini()
 		"$HARAKA_CONF/smtp.ini"
 }
 
+configure_haraka_outbound_ini
+{
+	if [ ! -f "$HARAKA_CONF/outbound.ini" ]; then
+		configure_install_default outbound.ini
+	fi
+
+	if grep -q ^local_mx_ok "$HARAKA_CONF/outbound.ini"
+	then
+		tell_status "preserving local_mx_ok in outbound.ini"
+	else
+		tell_status "setting local_mx_ok in outbound.ini"
+		echo 'local_mx_ok=true' >> "$HARAKA_CONF/outbound.ini"
+	fi
+}
+
 configure_haraka_plugins()
 {
 	if [ ! -f "$HARAKA_CONF/plugins" ]; then
@@ -684,6 +699,7 @@ configure_haraka()
 	fi
 
 	configure_haraka_smtp_ini
+	configure_haraka_outbound_ini
 	configure_haraka_plugins
 	configure_haraka_limit
 	configure_haraka_syslog

--- a/provision/horde.sh
+++ b/provision/horde.sh
@@ -2,6 +2,8 @@
 
 . mail-toaster.sh || exit
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/horde/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include php

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -6,6 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include shell
 mt6-include mta
@@ -491,6 +492,9 @@ update_freebsd()
 
 	tell_status "updating FreeBSD with security patches"
 	freebsd-update fetch install
+
+	tell_status "clearing freebsd-update cache"
+	rm -rf /var/db/freebsd-update/*
 
 	tell_status "updating FreeBSD pkg collection"
 	pkg update

--- a/provision/influxdb.sh
+++ b/provision/influxdb.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_influxdb()
 {

--- a/provision/jekyll.sh
+++ b/provision/jekyll.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_jekyll()
 {

--- a/provision/joomla.sh
+++ b/provision/joomla.sh
@@ -3,8 +3,8 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-# shellcheck disable=2016
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/knot.sh
+++ b/provision/knot.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include user
 

--- a/provision/letsencrypt.sh
+++ b/provision/letsencrypt.sh
@@ -4,6 +4,10 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 install_letsencrypt()
 {
 	tell_status "installing ACME.sh & Let's Encrypt"

--- a/provision/mail_dmarc.sh
+++ b/provision/mail_dmarc.sh
@@ -1,21 +1,26 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e -u
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA=""
-# shellcheck disable=2016
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_dmarc()
 {
 	tell_status "installing Mail::DMARC deps"
-	stage_pkg_install perl5 p5-HTTP-Date p5-File-ShareDir p5-Module-Build p5-CGI p5-HTTP-Tiny || exit
-	stage_pkg_install p5-Config-Tiny p5-DBIx-Simple p5-Email-Simple p5-JSON p5-Mail-DKIM p5-Net-DNS p5-Net-IP p5-Net-SMTPS p5-URI || exit
-	stage_pkg_install p5-Email-MIME p5-Net-IDN-Encode p5-Regexp-Common p5-XML-LibXML p5-HTTP-Message p5-libwww p5-Net-Server || exit
-	stage_pkg_install p5-Test-Output p5-Net-IMAP-Simple p5-Test-File-ShareDir p5-Test-Exception p5-DBD-mysql || exit
+	stage_pkg_install perl5 p5-File-ShareDir p5-Module-Build p5-XML-LibXML p5-Regexp-Common
+	stage_pkg_install p5-Net-DNS p5-Net-IP p5-Net-Server p5-Net-SMTPS p5-Net-IDN-Encode p5-Mail-DKIM
+	stage_pkg_install p5-Email-MIME p5-Email-Simple p5-Net-IMAP-Simple p5-Email-Sender
+	stage_pkg_install p5-CGI p5-HTTP-Tiny p5-libwww p5-HTTP-Date p5-JSON p5-HTTP-Message p5-URI
+	stage_pkg_install p5-Test-Output p5-Test-File-ShareDir p5-Test-Exception p5-Net-DNS-Resolver-Mock
+	stage_pkg_install p5-Config-Tiny p5-DBIx-Simple p5-DBD-mysql
+	stage_pkg_install p5-Mail-DMARC
 
-	tell_status "installing Mail::DMARC"
-	stage_exec perl -MCPAN -e 'install Mail::DMARC' || exit
+	tell_status "installing Mail::DMARC from CPAN"
+	stage_exec perl -MCPAN -e 'install Mail::DMARC'
 
 	tell_status "Mail::DMARC installed"
 

--- a/provision/mailtest.sh
+++ b/provision/mailtest.sh
@@ -7,7 +7,7 @@ set -e
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		allow.raw_sockets;"
-
+export JAIL_FSTAB=""
 
 install_mailtest()
 {

--- a/provision/mediawiki.sh
+++ b/provision/mediawiki.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/memcached.sh
+++ b/provision/memcached.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_memcached()
 {

--- a/provision/minecraft.sh
+++ b/provision/minecraft.sh
@@ -6,6 +6,7 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		mount += \"$ZFS_DATA_MNT/minecraft/etc \$path/usr/local/etc/minecraft-server nullfs rw 0 0\";
 		mount += \"$ZFS_DATA_MNT/minecraft/db \$path/var/db/minecraft-server nullfs rw 0 0\";"
+export JAIL_FSTAB=""
 
 install_minecraft()
 {

--- a/provision/mongodb.sh
+++ b/provision/mongodb.sh
@@ -9,6 +9,7 @@ export JAIL_CONF_EXTRA="
 		allow.raw_sockets;
 		allow.sysvipc;
 		allow.mlock;"
+export JAIL_FSTAB=""
 
 install_mongodb()
 {

--- a/provision/munin.sh
+++ b/provision/munin.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_lighttpd()
 {

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -4,6 +4,10 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
+
 install_db_server()
 {
 	for _d in etc db; do

--- a/provision/nagios.sh
+++ b/provision/nagios.sh
@@ -5,6 +5,7 @@
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA="
 		allow.raw_sockets;"
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/nginx.sh
+++ b/provision/nginx.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_nginx()
 {

--- a/provision/nictool.sh
+++ b/provision/nictool.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 export NICTOOL_VER=${NICTOOL_VER:="2.33"}
 export NICTOOL_UPGRADE=""

--- a/provision/nsd.sh
+++ b/provision/nsd.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include user
 

--- a/provision/php7.sh
+++ b/provision/php7.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 

--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -1,22 +1,23 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e -u
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 _dkim_private_key="$ZFS_DATA_MNT/postfix/dkim/$TOASTER_MAIL_DOMAIN.private"
-_has_dkim=""
-if [ -f "$_dkim_private_key" ]; then _has_dkim=1; fi
 
 install_postfix()
 {
 	tell_status "installing postfix"
-	stage_pkg_install postfix-sasl opendkim || exit
+	stage_pkg_install postfix-sasl opendkim
 
 	if [ -n "$TOASTER_NRPE" ]; then
 		tell_status "installing nagios-plugins"
-		stage_pkg_install nrpe nagios-plugins || exit
+		stage_pkg_install nrpe nagios-plugins
 	fi
 }
 
@@ -31,26 +32,34 @@ configure_opendkim()
 	if [ ! -d "$STAGE_MNT/data/dkim" ]; then mkdir "$STAGE_MNT/data/dkim"; fi
 
 	if [ -f "$STAGE_MNT/data/etc/opendkim.conf" ]; then
-		echo "opendkim config retained"
+		tell_status "preserving opendkim config"
+	else
+		tell_status "configuring opendkim"
+		sed \
+			-e "/^Domain/ s/example.com/$TOASTER_MAIL_DOMAIN/"  \
+			-e "/^KeyFile/ s/\/.*$/\/data\/dkim\/$TOASTER_MAIL_DOMAIN.private/"  \
+			-e '/^Socket/ s/inet:port@localhost/inet:8891/' \
+			-e "/^Selector/ s/my-selector-name/$(date '+%b%Y' | tr '[:upper:]' '[:lower:]')/" \
+			"$STAGE_MNT/usr/local/etc/mail/opendkim.conf.sample" \
+			> "$STAGE_MNT/data/etc/opendkim.conf"
+	fi
+}
+
+configure_postfix_main_cf()
+{
+	local _main_cf="$ZFS_DATA_MNT/postfix/etc/main.cf"
+	if [ -f "$_main_cf" ]; then
+		tell_status "preserving $_main_cf"
 		return
 	fi
 
-	sed \
-		-e "/^Domain/ s/example.com/$TOASTER_MAIL_DOMAIN/"  \
-		-e "/^KeyFile/ s/\/.*$/\/data\/dkim\/$TOASTER_MAIL_DOMAIN.private/"  \
-		-e '/^Socket/ s/inet:port@localhost/inet:2016/' \
-		-e "/^Selector/ s/my-selector-name/$(date '+%b%Y' | tr '[:upper:]' '[:lower:]')/" \
-		"$STAGE_MNT/usr/local/etc/mail/opendkim.conf.sample" \
-		> "$STAGE_MNT/data/etc/opendkim.conf"
-}
-
-configure_postfix()
-{
-	stage_sysrc postfix_enable=YES
+	stage_exec install -m 0644 /usr/local/etc/postfix/main.cf /data/etc/main.cf
 	stage_exec postconf -e "myhostname = postfix.$TOASTER_HOSTNAME"
-	stage_exec postconf -e 'smtp_use_tls=yes'
-	stage_exec postconf -e 'smtp_tls_security_level = encrypt'
-	stage_exec postconf -e 'smtp_tls_wrappermode = yes'
+	stage_exec postconf -e 'smtp_tls_security_level = may'
+	stage_exec postconf -e 'smtpd_tls_security_level = may'
+	stage_exec postconf -e 'smtpd_tls_auth_only = yes'
+	stage_exec postconf -e 'lmtp_tls_security_level = may'
+	stage_exec postconf -e 'lmtpd_tls_security_level = may'
 	stage_exec postconf -e "mynetworks = ${JAIL_NET_PREFIX}.0${JAIL_NET_MASK}"
 
 	if [ -f "$ZFS_DATA_MNT/postfix/etc/sasl_passwd" ]; then
@@ -59,58 +68,70 @@ configure_postfix()
 		stage_exec postconf -e 'smtp_sasl_password_maps = hash:/data/etc/sasl_passwd'
 	fi
 
-	if [ -n "$TOASTER_NRPE" ]; then
-		stage_sysrc nrpe_enable=YES
-		stage_sysrc nrpe_configfile="/data/etc/nrpe.cfg"
-	fi
-
 	if [ -f "$ZFS_DATA_MNT/postfix/etc/transport" ]; then
 		stage_exec postmap /data/etc/transport
 		stage_exec postconf -e 'transport_maps = hash:/data/etc/transport'
 	fi
 
-	for _f in master main
-	do
-		if [ -f "$ZFS_DATA_MNT/postfix/etc/$_f.cf" ]; then
-			tell_status "preserving /usr/local/etc/postfix/$_f.cf"
-			cp "$ZFS_DATA_MNT/postfix/etc/$_f.cf" "$STAGE_MNT/usr/local/etc/postfix/" || exit 1
-		fi
-	done
-
-	if [ -f "$ZFS_JAIL_MNT/postfix/etc/aliases" ]; then
-		tell_status "preserving /etc/aliases"
-		cp "$ZFS_JAIL_MNT/postfix/etc/aliases" "$STAGE_MNT/etc/aliases"
-		stage_exec /usr/local/bin/newaliases
-	elif [ -f "$ZFS_DATA_MNT/postfix/etc/aliases" ]; then
-		cp "$ZFS_DATA_MNT/postfix/etc/aliases" "$STAGE_MNT/etc/aliases"
-		stage_exec /usr/local/bin/newaliases
+	if [ -f "$_dkim_private_key" ]; then
+		postconf -e 'smtpd_milters = inet:localhost:8891'
+		postconf -e 'non_smtpd_milters = $smtpd_milters'
 	fi
+}
 
-	if [ ! -f "$STAGE_MNT/usr/local/etc/mail/mailer.conf" ]; then
-		if [ ! -d "$STAGE_MNT/usr/local/etc/mail" ]; then
-			mkdir -p "$STAGE_MNT/usr/local/etc/mail"
-		fi
-		stage_exec install -m 0644 /usr/local/share/postfix/mailer.conf.postfix /usr/local/etc/mail/mailer.conf
+configure_postfix_master_cf()
+{
+	local _master_cf="$ZFS_DATA_MNT/postfix/etc/master.cf"
+	if [ -f "$_master_cf" ]; then
+		tell_status "preserving $_master_cf"
+	else
+		tell_status "installing $_master_cf"
+		stage_exec install -m 0644 /usr/local/etc/postfix/master.cf /data/etc/master.cf
+	fi
+}
+
+configure_postfix()
+{
+	stage_sysrc sendmail_enable=NONE
+	stage_sysrc postfix_enable=YES
+	stage_sysrc postfix_flags="-c /data/etc"
+
+	configure_postfix_main_cf
+	configure_postfix_master_cf
+
+	# postconf will break symlinks to files. To get all of postfix to always
+	# look at /data/etc for config, symlink the config dir
+	stage_exec mv /usr/local/etc/postfix /usr/local/etc/postfix.dist
+	stage_exec ln -s /data/etc /usr/local/etc/postfix
+
+	if [ -n "$TOASTER_NRPE" ]; then
+		stage_sysrc nrpe_enable=YES
+		stage_sysrc nrpe_configfile="/data/etc/nrpe.cfg"
 	fi
 
 	configure_opendkim
+
+	preserve_file postfix '/etc/mail/aliases'
+	stage_exec /usr/local/bin/newaliases
+
+	stage_exec install -m 0644 /usr/local/share/postfix/mailer.conf.postfix /data/etc/mailer.conf
 }
 
 start_postfix()
 {
 	tell_status "starting postfix"
-	if [ -n "$_has_dkim" ]; then
+	if [ -f "$_dkim_private_key" ]; then
 		stage_exec service milter-opendkim start
 	fi
-	stage_exec service postfix start || exit
+	stage_exec service postfix start
 }
 
 test_postfix()
 {
-	if [ -n "$_has_dkim" ]; then
+	if [ -f "$_dkim_private_key" ]; then
 		tell_status "testing opendkim"
 		stage_test_running opendkim
-		stage_listening 2016
+		stage_listening 8891
 	fi
 
 	tell_status "testing postfix"
@@ -119,7 +140,7 @@ test_postfix()
 	echo "it worked."
 }
 
-base_snapshot_exists || exit
+base_snapshot_exists || exit 1
 create_staged_fs postfix
 start_staged_jail postfix
 install_postfix

--- a/provision/prometheus.sh
+++ b/provision/prometheus.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_prometheus()
 {

--- a/provision/puppeteer.sh
+++ b/provision/puppeteer.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_puppeteer()
 {

--- a/provision/rainloop.sh
+++ b/provision/rainloop.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/redis.sh
+++ b/provision/redis.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_redis()
 {

--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -6,12 +6,13 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx
 mt6-include mysql
 
-PHP_VER="81"
+PHP_VER="83"
 
 mysql_error_warning()
 {

--- a/provision/rsnapshot.sh
+++ b/provision/rsnapshot.sh
@@ -6,6 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_rsnapshot()
 {

--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -6,6 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 RSPAMD_ETC="$STAGE_MNT/usr/local/etc/rspamd"
 

--- a/provision/smf.sh
+++ b/provision/smf.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/snappymail.sh
+++ b/provision/snappymail.sh
@@ -6,6 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -4,6 +4,8 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
 
 mt6-include mysql
@@ -58,17 +60,6 @@ install_spamassassin_port()
 	stage_port_install mail/spamassassin
 }
 
-install_spamassassin_nrpe()
-{
-	if [ -z "$TOASTER_NRPE" ]; then
-		echo "TOASTER_NRPE unset, skipping nrpe plugin"
-		return
-	fi
-
-	tell_status "installing nrpe spamd plugin"
-	stage_pkg_install nagios-spamd-plugin
-}
-
 install_spamassassin_data_fs()
 {
 	for _d in $ZFS_DATA_MNT/spamassassin/etc $ZFS_DATA_MNT/spamassassin/var $STAGE_MNT/usr/local/etc/mail; do
@@ -121,7 +112,6 @@ install_spamassassin()
 	fi
 
 	install_spamassassin_data_fs
-	install_spamassassin_nrpe
 	install_spamassassin_port
 }
 

--- a/provision/sphinxsearch.sh
+++ b/provision/sphinxsearch.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_sphinxsearch()
 {

--- a/provision/squirrelcart.sh
+++ b/provision/squirrelcart.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx

--- a/provision/squirrelmail.sh
+++ b/provision/squirrelmail.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx
@@ -73,14 +74,14 @@ EO_SQUIRREL_SQL
 
 install_squirrelmail()
 {
-	install_php 80 "fileinfo pecl-mcrypt exif"
+	install_php 81 "fileinfo pecl-mcrypt exif"
 	install_nginx || exit
 
 	tell_status "installing squirrelmail"
-	stage_pkg_install squirrelmail-php80 \
-		squirrelmail-sasql-plugin-php80 \
-		squirrelmail-quota_usage-plugin-php80 \
-		squirrelmail-abook_import_export-plugin-php80 || exit
+	stage_pkg_install squirrelmail-php81 \
+		squirrelmail-sasql-plugin-php81 \
+		squirrelmail-quota_usage-plugin-php81 \
+		squirrelmail-abook_import_export-plugin-php81 || exit
 
 	configure_squirrelmail_local
 

--- a/provision/sqwebmail.sh
+++ b/provision/sqwebmail.sh
@@ -2,6 +2,8 @@
 
 . mail-toaster.sh || exit
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/sqwebmail/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail

--- a/provision/statsd.sh
+++ b/provision/statsd.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_statsd()
 {

--- a/provision/telegraf.sh
+++ b/provision/telegraf.sh
@@ -4,6 +4,7 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 install_telegraf()
 {

--- a/provision/tinydns.sh
+++ b/provision/tinydns.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
-. include/djb.sh || exit
+set -e
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
+
+mt6-include djb
 
 configure_tinydns()
 {
@@ -48,16 +51,16 @@ test_tinydns()
 	fi
 
 	tell_status "testing UDP DNS query"
-	drill    "$_fqdn" @"$(get_jail_ip stage)" || exit
+	drill    "$_fqdn" @"$(get_jail_ip stage)"
 
 	tell_status "testing TCP DNS query"
-	drill -t "$_fqdn" @"$(get_jail_ip stage)" || exit
+	drill -t "$_fqdn" @"$(get_jail_ip stage)"
 
 	tell_status "switching tinydns IP to deployment IP"
 	get_jail_ip tinydns | tee "$STAGE_MNT/var/service/tinydns/env/IP" "$STAGE_MNT/var/service/axfrdns/env/IP"
 	get_jail_ip6 tinydns | tee "$STAGE_MNT/var/service/tinydns-v6/env/IP" "$STAGE_MNT/var/service/axfrdns-v6/env/IP"
 
-	stage_exec service svscan stop || exit
+	stage_exec service svscan stop
 	for d in tinydns axfrdns tinydns-v6 axfrdns-v6
 	do
 		if [ -d "$ZFS_DATA_MNT/tinydns/service/$d" ]; then
@@ -70,7 +73,7 @@ test_tinydns()
 	stage_sysrc svscan_servicedir="/data/service"
 }
 
-base_snapshot_exists || exit
+base_snapshot_exists || exit 1
 create_staged_fs tinydns
 start_staged_jail tinydns
 install_daemontools

--- a/provision/unifi.sh
+++ b/provision/unifi.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e
 
+. mail-toaster.sh
+
+export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB="fdescfs $ZFS_JAIL_MNT/unifi/dev/fd fdescfs rw 0 0
 proc     $ZFS_JAIL_MNT/unifi/proc   procfs  rw 0 0"
@@ -9,10 +12,10 @@ proc     $ZFS_JAIL_MNT/unifi/proc   procfs  rw 0 0"
 install_unifi()
 {
 	tell_status "installing Unifi deps"
-	stage_pkg_install mongodb44 openjdk17 snappyjava gmake || exit
+	stage_pkg_install mongodb44 openjdk17 snappyjava gmake
 
 	tell_status "installing Unifi"
-	stage_port_install net-mgmt/unifi8 || exit
+	stage_port_install net-mgmt/unifi8
 
 	tell_status "Enable UniFi"
 	stage_sysrc unifi_enable=YES

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -4,9 +4,12 @@ set -e
 
 . mail-toaster.sh
 
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/vpopmail/usr/local/vpopmail nullfs rw 0 0"
+
 export VPOPMAIL_OPTIONS_SET=""
 export VPOPMAIL_OPTIONS_UNSET="ROAMING"
-export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/vpopmail/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail
 mt6-include mysql

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -6,6 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include nginx
 

--- a/provision/whmcs.sh
+++ b/provision/whmcs.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e
 
+. mail-toaster.sh
+
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP nullfs rw 0 0"
 
 mt6-include php
@@ -13,7 +17,7 @@ install_whmcs()
 	install_php 81 "ctype curl filter gd iconv imap mbstring session soap xml zip zlib"
 	install_nginx whmcs
 
-	stage_port_install devel/ioncube || exit
+	stage_port_install devel/ioncube
 }
 
 configure_whmcs_nginx()
@@ -93,7 +97,7 @@ test_whmcs()
 	echo "it worked"
 }
 
-base_snapshot_exists || exit
+base_snapshot_exists || exit 1
 create_staged_fs whmcs
 mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
 start_staged_jail

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -1,41 +1,88 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
+mt6-include mua
+
+preflight_check()
+{
+	for _j in dns redis mongodb
+	do
+		if ! jail_is_running "$_j"; then
+			fatal_err "jail $_j is required"
+		fi
+	done
+}
 
 install_webmail()
 {
-	stage_exec bash -c "cd /data && git clone https://github.com/nodemailer/wildduck-webmail.git webmail" || exit 1
-	stage_exec bash -c "cd /data/webmail && npm install"
-	stage_exec bash -c "cd /data/webmail && npm run bowerdeps"
+	if [ ! -e "$STAGE_MNT/data/webmail" ]; then
+		tell_status "installing wildduck webmail"
+		stage_exec bash -c "cd /data && git clone https://github.com/nodemailer/wildduck-webmail.git webmail" || exit 1
+		stage_exec bash -c "cd /data/webmail && npm install"
+		stage_exec bash -c "cd /data/webmail && npm run bowerdeps"
+	else
+		tell_status "updating wildduck webmail"
+		stage_exec bash -c "cd /data/webmail && git pull && npm install && npm run bowerdeps"
+		stage_exec bash -c "cd /data/webmail && mkdir -p public/components && bower install --allow-root"
+	fi
 }
 
 install_wildduck()
 {
-	tell_status "installing node.js"
-	stage_pkg_install npm-node16 git-tiny || exit
+	tell_status "installing wildduck dependencies"
+	stage_pkg_install npm-node20 git-tiny || exit
 
-	tell_status "installing wildduck"
-	stage_exec bash -c "cd /data && git clone https://github.com/nodemailer/wildduck.git" || exit 1
-	stage_exec bash -c "cd /data/wildduck && npm install --production"
+	if [ ! -e "$STAGE_MNT/data/webmail" ]; then
+		tell_status "installing wildduck"
+		stage_exec bash -c "cd /data && git clone https://github.com/nodemailer/wildduck.git" || exit 1
+		stage_exec bash -c "cd /data/wildduck && npm install --production"
+	else
+		tell_status "updating wildduck"
+		stage_exec bash -c "cd /data/wildduck && git pull && npm install --production"
+	fi
 
 	install_webmail
 }
 
+configure_pf()
+{
+	_pf_etc="$ZFS_DATA_MNT/wildduck/etc/pf.conf.d"
+
+	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
+rdr proto tcp from any to <ext_ip4> port 993 -> $(get_jail_ip  wildduck) port 9993
+rdr proto tcp from any to <ext_ip4> port 995 -> $(get_jail_ip  wildduck) port 9995
+EO_PF_RDR
+
+	store_config "$_pf_etc/allow.conf" <<EO_PF_ALLOW
+mua_ports = "{ 993 995 9993 9995 }"
+table <mua_servers> persist { $(get_jail_ip wildduck), $(get_jail_ip6 wildduck) }
+pass in quick proto tcp from any to <mua_servers> port \$mua_ports
+EO_PF_ALLOW
+}
+
 configure_wildduck()
 {
-	sed -i '' \
-		-e "/^mongo/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
-		-e "/^#redis/ s/127.0.0.1/$(get_jail_ip redis)/; s/\/3/\/8/" \
-		-e "/^host=/ s/127.0.0.1/$(get_jail_ip redis)/" \
-		-e "/^db=3/ s/3/8/" \
-		"$STAGE_MNT/data/wildduck/config/dbs.toml" || exit 1
+	_db_cfg="$STAGE_MNT/data/wildduck/config/dbs.toml"
+	if grep -qE '^mongo.*127' "$_db_cfg"; then
+		sed -i '' \
+			-e "/^mongo/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
+			-e "/^#redis/ s/127.0.0.1/$(get_jail_ip redis)/; s/\/3/\/8/" \
+			-e "/^host=/ s/127.0.0.1/$(get_jail_ip redis)/" \
+			-e "/^db=3/ s/3/8/" \
+			"$_db_cfg"
+	fi
 
 	stage_exec npm install -g pm2
 	stage_exec pm2 startup
+
+	configure_pf
 }
 
 start_wildduck()
@@ -50,66 +97,24 @@ start_wildduck()
 	stage_exec pm2 save
 }
 
-test_imap()
-{
-	pkg install -y empty
-
-	POST_USER="postmaster@${TOASTER_MAIL_DOMAIN}"
-	POST_PASS=$(jexec vpopmail /usr/local/vpopmail/bin/vuserinfo -C "${POST_USER}")
-	rm -f in out
-
-	echo "testing IMAP AUTH as $POST_USER"
-
-	# empty -v -f -i in -o out telnet "$(get_jail_ip stage)" 143
-	empty -v -f -i in -o out openssl s_client -quiet -crlf -connect "$(get_jail_ip stage):9993"
-	if [ ! -e out ]; then exit; fi
-	empty -v -w -i out -o in "ready"             ". LOGIN $POST_USER $POST_PASS\n"
-	empty -v -w -i out -o in "Logged in"         ". LIST \"\" \"*\"\n"
-	empty -v -w -i out -o in "List completed"    ". SELECT INBOX\n"
-	# shellcheck disable=SC2050
-	if [ "has" = "some messages" ]; then
-		empty -v -w -i out -o in "Select completed"  ". FETCH 1 BODY\n"
-		empty -v -w -i out -o in "OK Fetch completed" ". LOGOUT\n"
-	else
-		empty -v -w -i out -o in "Select completed" ". LOGOUT\n"
-	fi
-	echo "Logout completed"
-	if [ -e out ]; then exit; fi
-}
-
-test_pop3()
-{
-	pkg install -y empty
-
-	POST_USER="postmaster@${TOASTER_MAIL_DOMAIN}"
-	POST_PASS=$(jexec vpopmail /usr/local/vpopmail/bin/vuserinfo -C "${POST_USER}")
-	rm -f in out
-
-	echo "testing POP3 AUTH as $POST_USER"
-
-	# empty -v -f -i in -o out telnet "$(get_jail_ip stage)" 110
-	empty -v -f -i in -o out openssl s_client -quiet -crlf -connect "$(get_jail_ip stage):9995"
-	if [ ! -e out ]; then exit; fi
-	empty -v -w -i out -o in "\+OK." "user $POST_USER\n"
-	empty -v -w -i out -o in "\+OK" "pass $POST_PASS\n"
-	empty -v -w -i out -o in "OK Logged in" "list\n"
-	empty -v -w -i out -o in "." "quit\n"
-
-	if [ -e out ]; then exit; fi
-}
-
 test_wildduck()
 {
 	tell_status "testing wildduck"
 	stage_listening 9993 3
 	stage_listening 9995 3
 	stage_listening 3000 3
+
+	# MUA_TEST_USER="postmaster@${TOASTER_MAIL_DOMAIN}"
+	# MUA_TEST_PASS=$(jexec vpopmail /usr/local/vpopmail/bin/vuserinfo -C "${MUA_TEST_USER}")
+	# MUA_TEST_HOST=$(get_jail_ip stage)
+
 	# test_imap
 	# test_pop3
 	echo "it worked"
 }
 
-base_snapshot_exists || exit
+base_snapshot_exists || exit 1
+preflight_check
 create_staged_fs wildduck
 start_staged_jail wildduck
 install_wildduck

--- a/provision/wordpress.sh
+++ b/provision/wordpress.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
+export JAIL_FSTAB=""
 
 mt6-include php
 mt6-include nginx
@@ -16,7 +19,7 @@ install_wordpress()
 	install_php 81 "ctype curl dom exif fileinfo filter ftp gd iconv intl mbstring mysqli pecl-imagick-im7 session tokenizer xml zip zlib"
 
 	# stage_pkg_install wordpress
-	stage_port_install www/wordpress || exit
+	stage_port_install www/wordpress
 }
 
 configure_nginx_server()
@@ -136,7 +139,7 @@ configure_wp_config()
 	local _installed_config="$_wp_install/wp-config.php"
 	if [ -f "$_installed_config" ]; then
 		tell_status "preserving wp-config.php"
-		cp "$_installed_config" "$STAGE_MNT/usr/local/www/wordpress/" || exit
+		cp "$_installed_config" "$STAGE_MNT/usr/local/www/wordpress/"
 		return
 	else
 		tell_status "post-install configuration will be required"

--- a/provision/zonemta.sh
+++ b/provision/zonemta.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-. mail-toaster.sh || exit
+set -e
+
+. mail-toaster.sh
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-
+export JAIL_FSTAB=""
 
 install_zonemta_webadmin()
 {
@@ -22,7 +24,7 @@ install_zonemta_webadmin()
 install_zonemta()
 {
 	tell_status "installing node.js"
-	stage_pkg_install npm-node16 git-tiny || exit
+	stage_pkg_install npm-node20 git-tiny
 
 	tell_status "installing ZoneMTA"
 	stage_exec bash -c "cd /data && git clone https://github.com/zone-eu/zone-mta-template.git zone-mta"

--- a/qmail/run.sh
+++ b/qmail/run.sh
@@ -384,7 +384,7 @@ EO_DELIVERABLED_RUN
 	pkg install -y p5-Package-Constants
 
 	echo "installing Qmail::Deliverable"
-	pkg install -y p5-Log-Message p5-Archive-Extract p5-Object-Accessor p5-Module-Pluggable p5-App-Cpanminus
+	pkg install -y p5-Log-Message p5-Archive-Extract p5-Object-Accessor p5-Module-Pluggable p5-App-Cpanminus p5-libwww
 	cpanm Qmail::Deliverable
 
 	if [ "$TOASTER_VPOPMAIL_EXT" = "1" ]; then


### PR DESCRIPTION
- dmarc: install two more dependencies from ports 
- haraka: set local_mx_ok in outbound.ini
- host,base: improve cache emptying
- i/mta: also disable sendmail periodic tasks
- i/mua: move pop3 & imap tests into it (shared by dovecot & wildduck)
- include/vpopmail: add SQL queries needed by vpopmail 5.6.1 source
- qmail/run: also install p5-libwww port
- mt: declare TLS_LIBRARY & TOASTER_BUILD_DEBUG
- mt: change TOASTER_PKG_AUDIT 0 -> 1
- provision/*: always declare JAIL_START_EXTRA, JAIL_CONF_EXTRA, JAIL_FSTAB
- postfix: preserve main.cf (vs apply scripted settings every time)
- roundcube: bump php 8.1 -> 8.3
- spamassassin: no longer install nagios-spamd-plugin (port deleted)
- squirrelmail: bump php 8.0 -> 8.1
- vpopmail: update source build
- wildduck: add update support, PF rules, preflight check
- zonemta: bump node version to 20

Checklist:
- [x] docs up-to-date
