### PR TITLE
mt: update pfrule.sh, improve table handling

### DIFF
--- a/contrib/pfrule.sh
+++ b/contrib/pfrule.sh
@@ -2,40 +2,78 @@
 
 # pfrule.sh
 #
-# Use pfctl to load and unload PF config files into named PF anchors.
-# Config files are named for the anchor they'll be inserted
-# at. See https://github.com/msimerson/Mail-Toaster-6/wiki/PF
+# Matt Simerson, matt@tnpi.net, 2024-11
 #
-# Matt Simerson, matt@tnpi.net, 2023-06
+# Use pfctl to load and unload PF rules into named anchors from config
+# files. See https://github.com/msimerson/Mail-Toaster-6/wiki/PF
 
-_etcpath="$(dirname -- "$( readlink -f -- "$0"; )";)"
+ETC_PATH="$(dirname -- "$( readlink -f -- "$0"; )";)"
+JAIL_NAME=$(basename "$(dirname "$(dirname $ETC_PATH)")")
+PREVIEW="$2"
 
 usage() {
-    echo "   usage: $0 [ load | unload ]"
+    echo "   usage: $0 [ load | unload ] [-n]"
     echo " "
     exit 1
 }
 
-for _f in "$_etcpath"/*.conf; do
+cleanup() {
+    if [ -f allow.conf ] && [ ! -f filter.conf ]; then
+        echo "mv allow.conf filter.conf"
+        mv allow.conf filter.conf
+    fi
+}
+
+load_tables() {
+    for _f in "$ETC_PATH"/*.table; do
+        [ -f "$_f" ] || continue
+        _table_name=$(basename $_f .table)
+        do_cmd "pfctl -t "$_table_name" -T replace -f "$_f""
+    done
+}
+
+flush_tables() {
+    for _f in "$ETC_PATH"/*.table; do
+        [ -f "$_f" ] || continue
+        _table_name=$(basename $_f .table)
+        do_cmd "pfctl -t "$_table_name" -T flush"
+    done
+}
+
+do_cmd() {
+    if [ "$PREVIEW" = "-n" ]; then
+        echo "$1"
+    else
+        $1 || exit 1
+    fi
+}
+
+flush() {
+    case "$1" in
+        "nat"   ) do_cmd "$2 -F nat"   ;;
+        "rdr"   ) do_cmd "$2 -F nat"   ;;
+        "filter") do_cmd "$2 -F rules" ;;
+    esac
+}
+
+cleanup
+
+# load tables first, they may be referenced in anchored files
+if [ "$1" = "load" ]; then load_tables; fi
+
+for _anchor in binat nat rdr filter; do
+    _f="$ETC_PATH/$_anchor.conf"
     [ -f "$_f" ] || continue
 
-    _anchor=$(basename $_f .conf)  # nat, rdr, allow
-    _jailname=$(basename "$(dirname "$(dirname $_etcpath)")")
+    _pfctl="pfctl -a $_anchor/$JAIL_NAME"
 
     case "$1" in
-        "load" )
-            _cmd="pfctl -a $_anchor/$_jailname -f $_f"
-        ;;
-        "unload" )
-            _cmd="pfctl -a $_anchor/$_jailname -F all"
-        ;;
-        *) 
-            usage
-        ;;
+        "load"   ) do_cmd "$_pfctl -f $_f" ;;
+        "unload" ) flush "$_anchor" "$_pfctl" ;;
+        *        ) usage                 ;;
     esac
-
-    echo "$_cmd"
-    $_cmd || exit 1
 done
+
+if [ "$1" = "unload" ]; then flush_tables; fi
 
 exit

--- a/contrib/pfrule.sh
+++ b/contrib/pfrule.sh
@@ -28,7 +28,7 @@ load_tables() {
     for _f in "$ETC_PATH"/*.table; do
         [ -f "$_f" ] || continue
         _table_name=$(basename $_f .table)
-        do_cmd "pfctl -t "$_table_name" -T replace -f "$_f""
+        do_cmd "pfctl -t $_table_name -T replace -f $_f"
     done
 }
 
@@ -36,7 +36,7 @@ flush_tables() {
     for _f in "$ETC_PATH"/*.table; do
         [ -f "$_f" ] || continue
         _table_name=$(basename $_f .table)
-        do_cmd "pfctl -t "$_table_name" -T flush"
+        do_cmd "pfctl -t $_table_name -T flush"
     done
 }
 

--- a/include/shell.sh
+++ b/include/shell.sh
@@ -28,6 +28,13 @@ install_zsh()
 	stage_exec chpass -s /usr/local/bin/zsh
 }
 
+install_fish()
+{
+	tell_status "installing fish"
+	stage_pkg_install fish
+	stage_exec chpass -s /usr/local/bin/fish
+}
+
 configure_bash()
 {
 	if ! grep -q profile "$1/root/.profile"; then

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -353,12 +353,15 @@ base_snapshot_exists()
 
 jail_conf_header()
 {
+	local _path="$ZFS_JAIL_MNT/$1"
+	if [ "$1" = "base" ]; then _path="$BASE_MNT" fi
+
 	cat <<EO_JAIL_CONF_HEAD
 exec.start = "/bin/sh /etc/rc";
 exec.stop = "/bin/sh /etc/rc.shutdown";
 exec.clean;
 devfs_ruleset=5;
-path = "$(get_jail_data $1)";
+path = "$_path";
 interface = $JAIL_NET_INTERFACE;
 host.hostname = \$name;
 

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -504,19 +504,13 @@ get_jail_data()
 	fi
 }
 
-get_jail_fstab()
-{
-	local _suffix=${2:-""}
-	echo "$(get_jail_data $1)/etc/fstab$_suffix"
-}
-
 add_jail_conf_d()
 {
 	store_config "/etc/jail.conf.d/$(safe_jailname $1).conf" <<EO_JAIL_RC
 $(jail_conf_header $1)
 
 $(safe_jailname $1)	{$(get_safe_jail_path $1)
-		mount.fstab = "$(get_jail_fstab $1)";
+		mount.fstab = "$(get_jail_data $1)/etc/fstab";
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
 		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 $1);${JAIL_CONF_EXTRA}
 		exec.created = "$(get_jail_data $1)/etc/pf.conf.d/pfrule.sh load";
@@ -730,9 +724,8 @@ start_staged_jail()
 	local _path=${2:-"$STAGE_MNT"}
 	local _fstab
 
-	_fstab="$(get_jail_fstab $_name .stage)"
-
-	if [ "$_name" = "base" ]; then _fstab=$(get_jail_fstab base); fi
+	_fstab="$(get_jail_data $_name)/etc/fstab"
+	if [ "$_name" != "base" ]; then _fstab="$_fstab.stage"; fi
 
 	tell_status "stage jail $_name startup"
 

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -355,7 +355,7 @@ jail_conf_header()
 {
 	local _path="$ZFS_JAIL_MNT/\$name"
 	if [ "$1" = "base" ]; then
-		_path="$ZFS_JAIL_MNT/$(uname -r | cut -f1,2 -d'-')"
+		_path="base-$ZFS_JAIL_MNT/$(uname -r | cut -f1,2 -d'-')"
 	fi
 
 	cat <<EO_JAIL_CONF_HEAD

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -512,7 +512,7 @@ get_jail_fstab()
 add_jail_conf_d()
 {
 	store_config "/etc/jail.conf.d/$(safe_jailname $1).conf" <<EO_JAIL_RC
-$(jail_conf_header $1)
+$(jail_conf_header)
 
 $(safe_jailname $1)	{$(get_safe_jail_path $1)
 		mount.fstab = "$(get_jail_fstab $1)";

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -502,10 +502,12 @@ get_safe_jail_path()
 
 get_jail_fstab()
 {
+	local _suffix=${2:-""}
+
 	if [ "$1" = "base" ]; then
-		echo "mount.fstab = \"$BASE_MNT/data/etc/fstab\";"
+		echo "$BASE_MNT/data/etc/fstab$_suffix"
 	else
-		echo "mount.fstab = \"$ZFS_DATA_MNT/$1/etc/fstab\";"
+		echo "$ZFS_DATA_MNT/$1/etc/fstab$_suffix"
 	fi
 }
 
@@ -525,7 +527,7 @@ add_jail_conf_d()
 $(jail_conf_header $1)
 
 $(safe_jailname $1)	{$(get_safe_jail_path $1)
-		$_fstab
+		mount.fstab = "$_fstab";
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
 		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 $1);${JAIL_CONF_EXTRA}$_pfrule
 	}
@@ -801,9 +803,11 @@ start_staged_jail()
 {
 	local _name=${1:-"$SAFE_NAME"}
 	local _path=${2:-"$STAGE_MNT"}
-	local _fstab="$ZFS_DATA_MNT/$_name/etc/fstab.stage"
+	local _fstab
 
-	if [ "$_name" = "base" ]; then _fstab="$BASE_MNT/data/etc/fstab"; fi
+	_fstab="$(get_jail_fstab $_name .stage)"
+
+	if [ "$_name" = "base" ]; then _fstab=$(get_jail_fstab base); fi
 
 	tell_status "stage jail $_name startup"
 

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -628,6 +628,13 @@ usage() {
     exit 1
 }
 
+cleanup() {
+    if [ -f allow.conf ] && [ ! -f filter.conf ]; then
+        echo "mv allow.conf filter.conf"
+        mv allow.conf filter.conf
+    fi
+}
+
 load_tables() {
     for _f in "$ETC_PATH"/*.table; do
         [ -f "$_f" ] || continue
@@ -659,6 +666,8 @@ flush() {
         "filter") do_cmd "$2 -F rules" ;;
     esac
 }
+
+cleanup
 
 # load tables first, they may be referenced in anchored files
 if [ "$1" = "load" ]; then load_tables; fi

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -500,20 +500,32 @@ get_safe_jail_path()
 	fi
 }
 
+get_jail_fstab()
+{
+	if [ "$1" = "base" ]; then
+		echo "mount.fstab = \"$BASE_MNT/data/etc/fstab\";"
+	else
+		echo "mount.fstab = \"$ZFS_DATA_MNT/$1/etc/fstab\";"
+	fi
+}
+
 add_jail_conf_d()
 {
 	local _pfrule=''
+	local _fstab=
+	_fstab=$(get_jail_fstab $1)
+
 	if [ "$1" != "base" ]; then
 		_pfrule="
-		exec.created = "$ZFS_DATA_MNT/$1/etc/pf.conf.d/pfrule.sh load";
-		exec.poststop = "$ZFS_DATA_MNT/$1/etc/pf.conf.d/pfrule.sh unload";"
+		exec.created = \"$ZFS_DATA_MNT/$1/etc/pf.conf.d/pfrule.sh load\";
+		exec.poststop = \"$ZFS_DATA_MNT/$1/etc/pf.conf.d/pfrule.sh unload\";"
 	fi
 
 	store_config "/etc/jail.conf.d/$(safe_jailname $1).conf" <<EO_JAIL_RC
 $(jail_conf_header $1)
 
 $(safe_jailname $1)	{$(get_safe_jail_path $1)
-		mount.fstab = "$ZFS_DATA_MNT/$1/etc/fstab";
+		$_fstab
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
 		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 $1);${JAIL_CONF_EXTRA}$_pfrule
 	}

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -358,7 +358,7 @@ exec.start = "/bin/sh /etc/rc";
 exec.stop = "/bin/sh /etc/rc.shutdown";
 exec.clean;
 devfs_ruleset=5;
-path = "$(get_jail_base $1)";
+path = "$(get_jail_data $1)";
 interface = $JAIL_NET_INTERFACE;
 host.hostname = \$name;
 

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -183,7 +183,7 @@ export TOASTER_EDITOR_PORT=${TOASTER_EDITOR_PORT:="vim-tiny"}
 # See https://github.com/msimerson/Mail-Toaster-6/wiki/MySQL
 export TOASTER_MYSQL=${TOASTER_MYSQL:="1"}
 export TOASTER_MARIADB=${TOASTER_MARIADB:="0"}
-export TOASTER_NTP=${TOASTER_NTP:="ntp"}
+export TOASTER_NTP=${TOASTER_NTP:="openntpd"}
 export TOASTER_MSA=${TOASTER_MSA:="haraka"}
 export TOASTER_PKG_AUDIT=${TOASTER_PKG_AUDIT:="0"}
 export TOASTER_PKG_BRANCH=${TOASTER_PKG_BRANCH:="latest"}
@@ -589,35 +589,69 @@ install_pfrule()
 
 # pfrule.sh
 #
-# Matt Simerson, matt@tnpi.net, 2023-06
+# Matt Simerson, matt@tnpi.net, 2024-11
 #
 # Use pfctl to load and unload PF rules into named anchors from config
 # files. See https://github.com/msimerson/Mail-Toaster-6/wiki/PF
 
-_etcpath="$(dirname -- "$( readlink -f -- "$0"; )";)"
+ETC_PATH="$(dirname -- "$( readlink -f -- "$0"; )";)"
+JAIL_NAME=$(basename "$(dirname "$(dirname $ETC_PATH)")")
+PREVIEW="$2"
 
 usage() {
-    echo "   usage: $0 [ load | unload ]"
+    echo "   usage: $0 [ load | unload ] [-n]"
     echo " "
     exit 1
 }
 
-for _f in "$_etcpath"/*.conf; do
+load_tables() {
+    for _f in "$ETC_PATH"/*.table; do
+        [ -f "$_f" ] || continue
+        _table_name=$(basename $_f .table)
+        do_cmd "pfctl -t "$_table_name" -T replace -f "$_f""
+    done
+}
+
+flush_tables() {
+    for _f in "$ETC_PATH"/*.table; do
+        [ -f "$_f" ] || continue
+        _table_name=$(basename $_f .table)
+        do_cmd "pfctl -t "$_table_name" -T flush"
+    done
+}
+
+do_cmd() {
+    if [ "$PREVIEW" = "-n" ]; then
+        echo "$1"
+    else
+        $1 || exit 1
+    fi
+}
+
+flush() {
+    case "$1" in
+        "nat"   ) do_cmd "$2 -F nat"   ;;
+        "filter") do_cmd "$2 -F rules" ;;
+    esac
+}
+
+# load tables first, they may be referenced in anchored files
+if [ "$1" = "load" ]; then load_tables; fi
+
+for _anchor in binat nat rdr filter; do
+    _f="$ETC_PATH/$_anchor.conf"
     [ -f "$_f" ] || continue
 
-    _anchor=$(basename $_f .conf)  # nat, rdr, allow
-    _jailname=$(basename "$(dirname "$(dirname $_etcpath)")")
-    _pfctl="pfctl -a $_anchor/$_jailname"
+    _pfctl="pfctl -a $_anchor/$JAIL_NAME"
 
     case "$1" in
-        "load"   ) _cmd="$_pfctl -f $_f" ;;
-        "unload" ) _cmd="$_pfctl -F all" ;;
+        "load"   ) do_cmd "$_pfctl -f $_f" ;;
+        "unload" ) flush "$_anchor" "$_pfctl" ;;
         *        ) usage                 ;;
     esac
-
-    echo "$_cmd"
-    $_cmd || exit 1
 done
+
+if [ "$1" = "unload" ]; then flush_tables; fi
 
 exit
 EO_PF_RULE

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -354,7 +354,7 @@ base_snapshot_exists()
 jail_conf_header()
 {
 	local _path="$ZFS_JAIL_MNT/$1"
-	if [ "$1" = "base" ]; then _path="$BASE_MNT" fi
+	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
 
 	cat <<EO_JAIL_CONF_HEAD
 exec.start = "/bin/sh /etc/rc";

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -598,8 +598,12 @@ cleanup_staged_fs()
 
 install_pfrule()
 {
+	local _pfdir
+	_pfdir="$(get_jail_etc $1)/pf.conf.d"
+
 	mt6-fetch contrib pfrule.sh
-	install -C -m 0755 contrib/pfrule.sh "$(get_jail_etc $1)/pf.conf.d/pfrule.sh"
+	install -d "$_pfdir"
+	install -C -m 0755 contrib/pfrule.sh "$_pfdir/pfrule.sh"
 }
 
 install_fstab()

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -631,6 +631,7 @@ do_cmd() {
 flush() {
     case "$1" in
         "nat"   ) do_cmd "$2 -F nat"   ;;
+        "rdr"   ) do_cmd "$2 -F nat"   ;;
         "filter") do_cmd "$2 -F rules" ;;
     esac
 }

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -180,9 +180,7 @@ EO_MAKE_CONF
 configure_fstab() {
 	local _sub_dir=${1:-""}
 	local _etc_path="$BASE_MNT/${_sub_dir}etc"
-	if [ ! -d "$_etc_path" ]; then
-		mkdir -p "$_etc_path"
-	fi
+	if [ ! -d "$_etc_path" ]; then mkdir -p "$_etc_path"; fi
 
 	tee "$_etc_path/fstab" <<EO_FSTAB
 # Device                Mountpoint      FStype  Options         Dump    Pass#
@@ -192,9 +190,7 @@ EO_FSTAB
 
 configure_base()
 {
-	if [ ! -d "$BASE_MNT/usr/ports" ]; then
-		mkdir "$BASE_MNT/usr/ports"
-	fi
+	if [ ! -d "$BASE_MNT/usr/ports" ]; then mkdir "$BASE_MNT/usr/ports"; fi
 
 	tell_status "adding base jail resolv.conf"
 	cp /etc/resolv.conf "$BASE_MNT/etc"
@@ -204,6 +200,8 @@ configure_base()
 
 	tell_status "installing $BASE_MNT/etc/hosts"
 	cp /etc/hosts "$BASE_MNT/etc"
+
+	install_pfrule
 
 	configure_make_conf
 

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -201,7 +201,7 @@ configure_base()
 	tell_status "installing $BASE_MNT/etc/hosts"
 	cp /etc/hosts "$BASE_MNT/etc"
 
-	install_pfrule
+	install_pfrule base
 
 	configure_make_conf
 

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -201,8 +201,6 @@ configure_base()
 	tell_status "installing $BASE_MNT/etc/hosts"
 	cp /etc/hosts "$BASE_MNT/etc"
 
-	install_pfrule base
-
 	configure_make_conf
 
 	tell_status "adding base rc.conf settings"
@@ -222,6 +220,7 @@ configure_base()
 	configure_bourne_shell "$BASE_MNT"
 	configure_csh_shell "$BASE_MNT"
 	configure_fstab "data/"
+	install_pfrule base
 }
 
 install_periodic_conf()

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -202,6 +202,9 @@ configure_base()
 	tell_status "setting base jail timezone (to hosts)"
 	cp /etc/localtime "$BASE_MNT/etc"
 
+	tell_status "installing $BASE_MNT/etc/hosts"
+	cp /etc/hosts "$BASE_MNT/etc"
+
 	configure_make_conf
 
 	tell_status "adding base rc.conf settings"

--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -54,11 +54,20 @@ configure_dcc()
 		"$STAGE_MNT/var/db/dcc/dcc_conf"
 
 	_pf_etc="$ZFS_DATA_MNT/dcc/etc/pf.conf.d"
-	store_config "$_pf_etc/allow.conf" <<EO_PF_ALLOW
-table <dcc_server> { $(get_jail_ip dcc), $(get_jail_ip6 dcc) }
-pass in quick proto udp from any port 6277 to <ext_ip>
-pass in quick proto udp from any port 6277 to <dcc_server>
-EO_PF_ALLOW
+
+	get_public_ip
+	get_public_ip ipv6
+
+	store_config "$_pf_etc/dcc.table" <<EO_DCC_TABLE
+$PUBLIC_IP4
+$PUBLIC_IP6
+$(get_jail_ip dcc)
+$(get_jail_ip6 dcc)
+EO_DCC_TABLE
+
+	store_config "$_pf_etc/filter.conf" <<EO_PF_FILTER
+pass in quick proto udp from any port 6277 to <dcc>
+EO_PF_FILTER
 
 	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
 rdr inet  proto tcp from any to <ext_ip4> port 6277 -> $(get_jail_ip  dcc)

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -532,15 +532,15 @@ $(get_jail_ip6 dovecot)
 EO_PF_INSECURE
 
 	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
-dovecot_lo4 = "$(get_jail_ip dovecot)"
-dovecot_lo6 = "$(get_jail_ip6 dovecot)"
+int_ip4 = "$(get_jail_ip dovecot)"
+int_ip6 = "$(get_jail_ip6 dovecot)"
 
-rdr inet  proto tcp from any to <ext_ip4> port { 993 995 } -> \$dovecot_lo4
-rdr inet6 proto tcp from any to <ext_ip6> port { 993 995 } -> \$dovecot_lo6
+rdr inet  proto tcp from any to <ext_ip4> port { 993 995 } -> \$int_ip4
+rdr inet6 proto tcp from any to <ext_ip6> port { 993 995 } -> \$int_ip6
 
 # to permit legacy users to access insecure POP3 & IMAP, add their IPs/masks
-rdr inet  proto tcp from <insecure_mua> to <ext_ip4> port { 110 143 } -> \$dovecot_lo4
-rdr inet6 proto tcp from <insecure_mua> to <ext_ip6> port { 110 143 } -> \$dovecot_lo6
+rdr inet  proto tcp from <insecure_mua> to <ext_ip4> port { 110 143 } -> \$int_ip4
+rdr inet6 proto tcp from <insecure_mua> to <ext_ip6> port { 110 143 } -> \$int_ip6
 EO_PF_RDR
 
 	store_config "$_pf_etc/filter.conf" <<EO_PF_FILTER

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -67,7 +67,7 @@ disable_ntpd()
 {
 	if grep -q ^ntpd_enable /etc/rc.conf; then
 		tell_status "disabling NTPd"
-		service ntpd stop
+		service ntpd onestop
 		sysrc ntpd_enable=NO
 	fi
 

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -67,7 +67,7 @@ disable_ntpd()
 {
 	if grep -q ^ntpd_enable /etc/rc.conf; then
 		tell_status "disabling NTPd"
-		service ntpd onestop
+		service ntpd onestop || echo -n
 		sysrc ntpd_enable=NO
 	fi
 

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -365,6 +365,8 @@ table <sshguard> persist
 
 ## NAT / Network Address Translation
 
+binat-anchor "binat/*"
+
 # default route to the internet for jails
 nat on \$ext_if inet  from $JAIL_NET_PREFIX.0${JAIL_NET_MASK} to any -> (\$ext_if)
 nat on \$ext_if inet6 from (lo1) to any -> <ext_ip6>
@@ -396,11 +398,13 @@ pass in inet6 proto ipv6-icmp icmp6-type 136
 # NTP
 pass out quick on \$ext_if proto udp to any port ntp keep state
 
-pass  in quick on \$ext_if proto tcp to port ssh \
+pass in quick on \$ext_if proto tcp to port ssh \
         flags S/SA synproxy state \
         (max-src-conn 10, max-src-conn-rate 8/15, overload <bruteforce> flush global)
 
+# allow anchor is deprecated, use filter instead
 anchor "allow/*"
+anchor "filter/*"
 EO_PF_RULES
 
 	if [ -z "$PUBLIC_IP6" ]; then

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -51,7 +51,7 @@ configure_openntpd()
 
 	pkg install -y openntpd
 	sysrc openntpd_enable=YES
-	service openntpd start
+	service openntpd restart
 }
 
 configure_chrony()

--- a/test/run.sh
+++ b/test/run.sh
@@ -3,6 +3,9 @@
 echo "shellcheck *.sh"
 shellcheck ./*.sh
 
+echo "shellcheck contrib/*.sh"
+shellcheck contrib/*.sh
+
 echo "shellcheck include/*.sh"
 shellcheck include/*.sh
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- mt: default NTPd is now openntpd
- mt: install pfrule from GH repo (vs inline)
  - add mt6-fetch, get_jail_data
- pfrule.sh:
  - adds a -n option
  - adds binat loading support
  - loads tables in pf.conf.d
  - unload is smarter now
- host: ntpd stop -> onestop
- base: fix jail config so `service jail start base` works

Fixes #600 

Checklist:
- [ ] docs up-to-date
