### PR TITLE
host: jail ipv6 nat

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1079,11 +1079,9 @@ get_public_ip()
 	if [ "$_ver" = "ipv6" ]; then
 		export PUBLIC_IP6
 		PUBLIC_IP6=$(ifconfig "$PUBLIC_NIC" inet6 | grep inet | grep -v fe80 | awk '{print $2}' | head -n1)
-		echo "$PUBLIC_IP6"
 	else
 		export PUBLIC_IP4
 		PUBLIC_IP4=$(ifconfig "$PUBLIC_NIC" inet | grep inet | awk '{print $2}' | head -n1)
-		echo "$PUBLIC_IP4"
 	fi
 }
 

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -234,7 +234,6 @@ if [ -z "$JAIL_NET6" ]; then
 	echo "export JAIL_NET6=\"$JAIL_NET6\"" >> mail-toaster.conf
 	export JAIL_NET6
 fi
-echo "IPv6 jail network: $JAIL_NET6"
 
 # little below here should need customizing. If so, consider opening
 # an issue or PR at https://github.com/msimerson/Mail-Toaster-6
@@ -269,7 +268,6 @@ safe_jailname()
 
 export SAFE_NAME; SAFE_NAME=$(safe_jailname stage)
 if [ -z "$SAFE_NAME" ]; then echo "unset SAFE_NAME"; exit; fi
-echo "safe name: $SAFE_NAME"
 
 zfs_filesystem_exists()
 {
@@ -1076,8 +1074,6 @@ get_public_facing_nic()
 		echo "public NIC detection failed"
 		exit 1
 	fi
-
-	echo "$PUBLIC_NIC"
 }
 
 get_public_ip()

--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -34,7 +34,7 @@ install_dcc_port_options()
 
 	get_public_ip ipv6
 	if [ -z "$PUBLIC_IP6" ]; then
-		UNSET="$UNSET IPv6"
+		UNSET="$UNSET IPV6"
 	else
 		SET="$SET IPV6"
 	fi

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -185,7 +185,8 @@ switch_host_resolver()
 	if grep "^nameserver $(get_jail_ip dns)" /etc/resolv.conf; then return; fi
 
 	echo "switching host resolver to local"
-	local _NSLIST="nameserver $(get_jail_ip dns)"
+	local _NSLIST
+	_NSLIST="nameserver $(get_jail_ip dns)"
 
 	sysrc -f /etc/resolvconf.conf name_servers="$(get_jail_ip dns)"
 	if [ -n "$PUBLIC_IP6" ]; then

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -20,9 +20,9 @@ get_mt6_data()
 	local _spf_ips
 
 	if [ -z "$PUBLIC_IP6" ]; then
-		_spf_ips="ip4:${JAIL_NET_PREFIX}.0/24 ip4:$PUBLIC_IP4 ip6:$JAIL_NET6::/64"
+		_spf_ips="ip4:${JAIL_NET_PREFIX}.0/24 ip4:$PUBLIC_IP4 ip6:$JAIL_NET6::/112"
 	else
-		_spf_ips="ip4:${JAIL_NET_PREFIX}.0/24 ip4:$PUBLIC_IP4 ip6:$JAIL_NET6::/64 ip6:$PUBLIC_IP6"
+		_spf_ips="ip4:${JAIL_NET_PREFIX}.0/24 ip4:$PUBLIC_IP4 ip6:$JAIL_NET6::/112 ip6:$PUBLIC_IP6"
 	fi
 
 	echo "
@@ -60,7 +60,7 @@ install_access_conf()
 	   access-control: 127.0.0.0/8 allow
 	   access-control: ${JAIL_NET_PREFIX}.0${JAIL_NET_MASK} allow
 	   access-control: $PUBLIC_IP4 allow
-	   access-control: $JAIL_NET6::/64 allow
+	   access-control: $JAIL_NET6::/112 allow
 
 EO_UNBOUND_ACCESS
 }

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -67,8 +67,6 @@ EO_UNBOUND_ACCESS
 
 install_local_conf()
 {
-	get_public_ip
-
 	store_config "$ZFS_DATA_MNT/dns/mt6-local.conf" "overwrite" <<EO_UNBOUND
 	   $UNBOUND_LOCAL
 
@@ -151,7 +149,9 @@ configure_unbound()
 
 	enable_control
 	tweak_unbound_conf
+
 	get_public_ip
+	get_public_ip ipv6
 
 	install_access_conf
 	install_local_conf

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -173,13 +173,18 @@ constrain_sshd_to_host()
 	get_public_ip
 	get_public_ip ipv6
 
+	local IP_MSG="	Your public IP(s) are detected as $PUBLIC_IP4"
+	if [ -n "$PUBLIC_IP6" ]; then
+		IP_MSG="$IP_MSG
+		and $PUBLIC_IP6"
+	fi
+
 	if [ -t 0 ]; then
 		local _confirm_msg="
 	To not interfere with the jails, sshd should be constrained to
 	listening on your hosts public facing IP(s).
 
-	Your public IPs are detected as $PUBLIC_IP4
-		and $PUBLIC_IP6
+	$IP_MSG
 
 	May I update your sshd config?
 	"

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -350,7 +350,7 @@ configure_ipv6()
 {
 	get_public_ip ipv6
 
-	if [ -n "$PUBLIC_IP4" ] && [ -n "$PUBLIC_NIC" ]; then
+	if [ -n "$PUBLIC_IP6" ] && [ -n "$PUBLIC_NIC" ]; then
 		sysrc ipv6_activate_all_interfaces="YES"
 		sysrc ipv6_cpe_wanif="$PUBLIC_NIC"
 		sysrc ipv6_gateway_enable="YES"

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -349,6 +349,7 @@ configure_ipv6()
 		sysrc ipv6_activate_all_interfaces="YES"
 		sysrc ipv6_cpe_wanif="$PUBLIC_NIC"
 		sysrc ipv6_gateway_enable="YES"
+		sysctl net.inet6.ip6.forwarding=1
 	fi
 }
 
@@ -368,7 +369,7 @@ ext_ip4="$PUBLIC_IP4"
 ext_ip6="$PUBLIC_IP6"
 
 jail_ip4="$JAIL_NET_PREFIX.0${JAIL_NET_MASK}"
-jail_ip6="$JAIL_NET6:1/112"
+jail_ip6="$JAIL_NET6:0/112"
 
 table <ext_ip>  { \$ext_ip4, \$ext_ip6 } persist
 table <ext_ip4> { \$ext_ip4 } persist
@@ -563,7 +564,7 @@ assign_syslog_ip()
 
 	if ! ifconfig lo1 2>&1 | grep -q "$JAIL_NET6:1 "; then
 		echo "assigning $JAIL_NET6:1 to lo1"
-		ifconfig inet6 lo1 "$JAIL_NET6:1/112"
+		ifconfig lo1 inet6 "$JAIL_NET6:1/112"
 	fi
 }
 

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -67,13 +67,21 @@ install_lighttpd()
 		tell_status "installing lighttpd.conf"
 		cat <<EO_LIGHTTPD >> "$_conf"
 
-include "/usr/local/etc/lighttpd/lighttpd*annotated.conf"
-include "/usr/local/etc/lighttpd/conf-enabled/*.conf"
+#include "/usr/local/etc/lighttpd/lighttpd*annotated.conf"
+#include "/usr/local/etc/lighttpd/conf-enabled/*.conf"
+
+# server.modules += ( "mod_access" ) # for IP filtering
 
 server.document-root = "/data/htdocs"
+server.pid-file      = "/var/run/lighttpd/lighttpd.pid"
 
-server.modules += ( "mod_alias", "mod_auth", "mod_authn_file" )
+var.log_root         = "/var/log/lighttpd"
+server.errorlog      = log_root + "/error.log"
 
+#server.modules     += ( "mod_accesslog" )
+#accesslog.filename  = log_root + "/access.log"
+
+server.modules += ( "mod_alias" )
 alias.url = ( "/cgi-bin/"     => "/data/cgi-bin/",
               "/qmailadmin/"  => "/data/htdocs/qmailadmin/",
             )
@@ -89,6 +97,7 @@ extforward.forwarder = (
      "$(get_jail_ip6 haproxy)"  => "trust",
 )
 
+server.modules += ( "mod_auth", "mod_authn_file" )
 #auth.backend                   = "plain"
 auth.backend                   = "htdigest"
 auth.backend.plain.userfile    = "/data/etc/WebUsers.plain"
@@ -149,7 +158,7 @@ install_vqadmin()
 	if [ "$TOASTER_VQADMIN" != "1" ]; then return; fi
 
 	tell_status "installing vqadmin"
-	export WEBDATADIR=../../htdocs CGIBINDIR=../../cgi-bin
+	export WEBDATADIR=../../data/htdocs CGIBINDIR=../../data/cgi-bin
 	stage_port_install mail/vqadmin
 	stage_exec ln /data/cgi-bin/vqadmin/html/en-us /data/cgi-bin/vqadmin/html/en-US
 }

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -216,6 +216,7 @@ install_index()
   const adminPaths = {
     'admin'     : '',
     'qmailadmin': '/cgi-bin/qmailadmin/qmailadmin/',
+    # 'vqadmin'   : '/cgi-bin/vqadmin/vqadmin.cgi',
     'rspamd'    : '/rspamd/',
     'watch'     : '/watch/',
     'snappymail': '/snappymail/?admin',


### PR DESCRIPTION
### Changes proposed in this pull request:
- vpopmail: improve lighttpd config
- host: in pf rule, declare IPv6 network (instead of `(lo1)` syntax)
- host: add ipv6 settings
- mt: only ipv6 in jails when host has public IPv6
- mt: consolidate all jail settings into host block

Fixes #610 

Checklist:
- [ ] docs up-to-date
