### PR TITLE
clamav: fall back to port build if pkg install fails

### DIFF
--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -179,9 +179,15 @@ PATH="$PATH:/usr/local/bin"|' \
  	fi
 }
 
+install_clamav_port()
+{
+	stage_pkg_install curl cmake expat gmake gettext curl libpsl ninja perl5 portconfig python3
+	stage_port_install security/clamav
+}
+
 install_clamav()
 {
-	stage_pkg_install clamav
+	stage_pkg_install clamav || install_clamav_port
 	echo "done"
 
 	for _d in etc db log; do

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -181,6 +181,10 @@ test_unbound()
 	# set it back to production value
 	echo "nameserver $(get_jail_ip dns)" | tee "$STAGE_MNT/etc/resolv.conf"
 	echo "it worked."
+
+	if [ -f "$ZFS_DATA_MNT/dns/unbound.conf" ]; then
+		stage_sysrc unbound_conf=/data/unbound.conf
+	fi
 }
 
 switch_host_resolver()

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -624,7 +624,7 @@ update_host() {
 	configure_etc_hosts
 	configure_csh_shell ""
 	configure_bourne_shell ""
-	if [ ! -e "/etc/localtime" ]; then tzsetup; fi
+	test -e "/etc/localtime" || tzsetup
 	check_global_listeners
 	echo; echo "Success! Your host is ready to install Mail Toaster 6!"; echo
 }


### PR DESCRIPTION
- dns: set rc to use /data/unbound.conf if exists
