### PR TITLE
bats: added mysql, shell, and vpopmail tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ node_modules
 *.txt
 *.php
 *.mt6
+
+.gemini/
+gha-creds-*.json

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,9 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-03
 
+- feat(haraka): enable LMTP to dovecot for new installs
 - feat(fstab_add_mount): added
+- fix(mailfilter): remove most of it, so maildrop sometimes works
 - feat(test/run.sh): run a single script
 - change(NTP): switch default server to chrony
 - change(spamassassin): updated TxRep/AWL/userpref SQL

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,21 @@
 
 refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://github.com/msimerson/Mail-Toaster-6/commits/master)
 
+
+## 2026-03
+
+- feat(fstab_add_mount): added
+- feat(test/run.sh): run a single script
+- change(NTP): switch default server to chrony
+- change(spamassassin): updated TxRep/AWL/userpref SQL
+  - enable build options for DMARC & RELAY_COUNTRY
+  - inline SQL for tables, no longer installed
+- change(snappymail): php8.2 -> 8.3
+- maildrop: install from package (TODO: test)
+- change: refactored mail-toaster.sh into test covered modules
+  - config, jail, network, util, zfs
+- test: added more tests to other modules
+
 ## 2022-05
 
 ### Feature

--- a/include/config.sh
+++ b/include/config.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+mt6_defaults()
+{
+	# export these in your environment to customize
+	export BOURNE_SHELL=${BOURNE_SHELL:="bash"}
+	export JAIL_NET_PREFIX=${JAIL_NET_PREFIX:="172.16.15"}
+	export JAIL_NET_MASK=${JAIL_NET_MASK:="/19"}
+	export JAIL_NET_INTERFACE=${JAIL_NET_INTERFACE:="lo1"}
+	export JAIL_ORDERED_LIST="syslog base dns mysql clamav spamassassin foundationdb vpopmail haraka webmail munin haproxy rspamd stalwart dovecot redis geoip nginx mailtest apache postgres minecraft joomla php7 memcached sphinxsearch elasticsearch nictool sqwebmail dhcp letsencrypt tinydns roundcube squirrelmail rainloop rsnapshot mediawiki smf wordpress whmcs squirrelcart horde grafana unifi mongodb gitlab gitlab_runner dcc prometheus influxdb telegraf statsd mail_dmarc ghost jekyll borg nagios postfix puppeteer snappymail knot nsd bsd_cache wildduck zonemta centos ubuntu bhyve-ubuntu mailman"
+
+	export ZFS_VOL=${ZFS_VOL:="zroot"}
+	export ZFS_BHYVE_VOL="${ZFS_BHYVE_VOL:=$ZFS_VOL}"
+	export ZFS_JAIL_MNT=${ZFS_JAIL_MNT:="/jails"}
+	export ZFS_DATA_MNT=${ZFS_DATA_MNT:="/data"}
+	export FBSD_MIRROR=${FBSD_MIRROR:="ftp://ftp.freebsd.org"}
+
+	export TLS_LIBRARY=${TLS_LIBRARY:=""}
+	export TOASTER_BASE_MTA=${TOASTER_BASE_MTA:=""}
+	export TOASTER_BASE_PKGS=${TOASTER_BASE_PKGS:="pkg ca_root_nss"}
+	export TOASTER_BUILD_DEBUG=${TOASTER_BUILD_DEBUG:="0"}
+	export TOASTER_EDITOR=${TOASTER_EDITOR:="vim"}
+	export TOASTER_EDITOR_PORT=${TOASTER_EDITOR_PORT:="vim-tiny"}
+	# See https://github.com/msimerson/Mail-Toaster-6/wiki/MySQL
+	export TOASTER_MYSQL=${TOASTER_MYSQL:="1"}
+	export TOASTER_MARIADB=${TOASTER_MARIADB:="0"}
+	export TOASTER_NTP=${TOASTER_NTP:="chrony"}
+	export TOASTER_MSA=${TOASTER_MSA:="haraka"}
+	export TOASTER_PKG_AUDIT=${TOASTER_PKG_AUDIT:="0"}
+	export TOASTER_PKG_BRANCH=${TOASTER_PKG_BRANCH:="latest"}
+	export TOASTER_USE_TMPFS=${TOASTER_USE_TMPFS:="0"}
+	export TOASTER_VPOPMAIL_CLEAR=${TOASTER_VPOPMAIL_CLEAR:="1"}
+	export TOASTER_VPOPMAIL_EXT=${TOASTER_VPOPMAIL_EXT:="0"}
+	export TOASTER_VQADMIN=${TOASTER_VQADMIN:="0"}
+	export TOASTER_WEBMAIL_PROXY=${TOASTER_WEBMAIL_PROXY:="haproxy"}
+	export CLAMAV_FANGFRISCH=${CLAMAV_FANGFRISCH:="0"}
+	export CLAMAV_UNOFFICIAL=${CLAMAV_UNOFFICIAL:="0"}
+	export ROUNDCUBE_SQL=${ROUNDCUBE_SQL:="$TOASTER_MYSQL"}
+	export ROUNDCUBE_PRODUCT_NAME=${ROUNDCUBE_PRODUCT_NAME:="Roundcube Webmail"}
+	export ROUNDCUBE_ATTACHMENT_SIZE_MB=${ROUNDCUBE_ATTACHMENT_SIZE_MB:="25"}
+	export SQUIRREL_SQL=${SQUIRREL_SQL:="$TOASTER_MYSQL"}
+	export WILDDUCK_MAIL_DOMAIN=${WILDDUCK_MAIL_DOMAIN:="$TOASTER_MAIL_DOMAIN"}
+	export WILDDUCK_HOSTNAME=${WILDDUCK_HOSTNAME:="$TOASTER_HOSTNAME"}
+
+	# little below here should need customizing. If so, consider opening
+	# an issue or PR at https://github.com/msimerson/Mail-Toaster-6
+	export ZFS_JAIL_VOL="${ZFS_VOL}${ZFS_JAIL_MNT}"
+	export ZFS_DATA_VOL="${ZFS_VOL}${ZFS_DATA_MNT}"
+
+	export FBSD_REL_VER FBSD_PATCH_VER
+	if [ "$(uname)" = 'FreeBSD' ]; then
+		FBSD_REL_VER=$(/bin/freebsd-version | /usr/bin/cut -f1-2 -d'-')
+		FBSD_PATCH_VER=$(/bin/freebsd-version | /usr/bin/cut -f3 -d'-')
+		FBSD_PATCH_VER=${FBSD_PATCH_VER:="p0"}
+	fi
+
+	# the 'base' jail that other jails are cloned from. This will be named as the
+	# host OS version, eg: base-13.2-RELEASE and the snapshot name will be the OS
+	# patch level, eg: base-13.2-RELEASE@p3
+	export BASE_NAME="base-$FBSD_REL_VER"
+	export BASE_VOL="$ZFS_JAIL_VOL/$BASE_NAME"
+	export BASE_SNAP="${BASE_VOL}@${FBSD_PATCH_VER}"
+	export BASE_MNT="$ZFS_JAIL_MNT/$BASE_NAME"
+
+	export STAGE_MNT="$ZFS_JAIL_MNT/stage"
+}
+
+create_default_config()
+{
+	local _HOSTNAME
+	local _EMAIL_DOMAIN
+	local _ORGNAME
+
+	if [ -t 0 ] && [ "$(uname)" = 'FreeBSD' ]; then
+		echo "editing prefs"
+		_HOSTNAME=$(bsddialog --nocancel --backtitle "mail-toaster.sh" --title TOASTER_HOSTNAME --inputbox "the hostname of this [virtual] machine" 8 70 "mail.example.com" 3>&1 1>&2 2>&3)
+		_EMAIL_DOMAIN=$(bsddialog --nocancel --backtitle "mail-toaster.sh" --title TOASTER_MAIL_DOMAIN --inputbox "the primary email domain" 8 70 "example.com" 3>&1 1>&2 2>&3)
+		_ORGNAME=$(bsddialog --nocancel --backtitle "mail-toaster.sh" --title TOASTER_ORG_NAME --inputbox "the name of your organization" 8 70 "Email Inc" 3>&1 1>&2 2>&3)
+	fi
+
+	# for dev/test environs where bsddialog doesn't exist
+	if [ -z "$_HOSTNAME"     ]; then _HOSTNAME=$(hostname); fi
+	if [ -z "$_EMAIL_DOMAIN" ]; then _EMAIL_DOMAIN=$(hostname); fi
+	if [ -z "$_ORGNAME"      ]; then _ORGNAME="Sparky the Toaster"; fi
+
+	echo "creating mail-toaster.conf with defaults"
+	store_config mail-toaster.conf <<EO_MT_CONF
+export TOASTER_ORG_NAME="$_ORGNAME"
+export TOASTER_HOSTNAME="$_HOSTNAME"
+export TOASTER_MAIL_DOMAIN="$_EMAIL_DOMAIN"
+export TOASTER_ADMIN_EMAIL="postmaster@${_EMAIL_DOMAIN}"
+export TOASTER_SRC_URL="https://raw.githubusercontent.com/msimerson/Mail-Toaster-6/master"
+
+# If your hosts public facing IP(s) are not bound to a local interface, configure it here.
+# Haraka determines it at runtime (with STUN) but the DNS configuration cannot
+export PUBLIC_IP4=""
+export PUBLIC_IP6=""
+
+export JAIL_NET_PREFIX="172.16.15"
+export JAIL_NET_MASK="/19"
+export JAIL_NET_INTERFACE="lo1"
+export JAIL_NET6="$(get_random_ip6net)"
+export ZFS_VOL="zroot"
+export ZFS_JAIL_MNT="/jails"
+export ZFS_DATA_MNT="/data"
+export TOASTER_EDITOR="vim"
+export TOASTER_EDITOR_PORT="vim-tiny"
+export TOASTER_MSA="haraka"
+export TOASTER_MYSQL="1"
+export TOASTER_MYSQL_PASS=""
+export TOASTER_NRPE=""
+export TOASTER_NTP=""
+export TOASTER_PKG_AUDIT="0"
+export TOASTER_PKG_BRANCH="latest"
+export TOASTER_USE_TMPFS="0"
+export TOASTER_VPOPMAIL_CLEAR="1"
+export TOASTER_VPOPMAIL_EXT="0"
+export TOASTER_WEBMAIL_PROXY="haproxy"
+export CLAMAV_FANGFRISCH="0"
+export GEOIP_UPDATER="geoipupdate"
+export MAXMIND_ACCOUNT_ID=""
+export MAXMIND_LICENSE_KEY=""
+export ROUNDCUBE_SQL="0"
+export ROUNDCUBE_DEFAULT_HOST=""
+export ROUNDCUBE_PRODUCT_NAME="Roundcube Webmail"
+export ROUNDCUBE_ATTACHMENT_SIZE_MB="25"
+
+EO_MT_CONF
+
+	chmod 600 mail-toaster.conf
+}
+
+config()
+{
+	if [ ! -f "mail-toaster.conf" ]; then
+		create_default_config
+	fi
+
+	local _mode; _mode=$(stat -f "%OLp" mail-toaster.conf)
+	if [ "$_mode" -ne 600 ]; then
+		echo "tightening permissions on mail-toaster.conf"
+		chmod 600 mail-toaster.conf
+	fi
+
+	echo "loading mail-toaster.conf"
+	# shellcheck disable=SC1091,SC2039
+	. mail-toaster.conf
+}

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -1,0 +1,310 @@
+#!/bin/sh
+
+safe_jailname()
+{
+	# constrain jail name chars to alpha-numeric and _
+	# shellcheck disable=SC2001
+	echo "$1" | sed -e 's/[^a-zA-Z0-9]/_/g'
+}
+
+get_jail_ip()
+{
+	local _start=${JAIL_NET_START:=1}
+
+	case "$1" in
+		syslog) echo "$JAIL_NET_PREFIX.$_start"; return;;
+		base)   echo "$JAIL_NET_PREFIX.$((_start + 1))"; return;;
+		stage)  echo "$JAIL_NET_PREFIX.254"; return;;
+	esac
+
+	if echo "$1" | grep -q ^base; then
+		echo "$JAIL_NET_PREFIX.$((_start + 1))"
+		return
+	fi
+
+	local _octet="$_start"
+
+	for _j in $JAIL_ORDERED_LIST; do
+		if [ "$1" = "$_j" ]; then
+			echo "$JAIL_NET_PREFIX.$_octet"
+			return
+		fi
+		_octet=$((_octet + 1))
+	done
+
+	_dns=$(host "$1" | grep 'has address' | cut -f4 -d' ')
+	if [ -n "$_dns" ]; then
+		echo "$_dns"
+		return
+	fi
+
+	# return error code
+	return 2
+}
+
+get_jail_ip6()
+{
+	local _start=${JAIL_NET_START:=1}
+
+	case "$1" in
+		syslog) echo "$JAIL_NET6:$(dec_to_hex "$_start")";       return;;
+		base)   echo "$JAIL_NET6:$(dec_to_hex $((_start + 1)))"; return;;
+		stage)  echo "$JAIL_NET6:$(dec_to_hex 254)";             return;;
+	esac
+
+	if echo "$1" | grep -q ^base; then
+		echo "$JAIL_NET6:$(dec_to_hex $((_start + 1)))"
+		return
+	fi
+
+	local _octet="$_start"
+
+	for _j in $JAIL_ORDERED_LIST; do
+		if [ "$1" = "$_j" ]; then
+			echo "$JAIL_NET6:$(dec_to_hex "$_octet")"
+			return
+		fi
+		_octet=$((_octet + 1))
+	done
+
+	_dns=$(host "$1" | grep 'has IPv6 address' | cut -f5 -d' ')
+	if [ -n "$_dns" ]; then
+		echo "$_dns"
+		return
+	fi
+
+	# return error code
+	return 2
+}
+
+get_reverse_ip()
+{
+	local _jail_ip; _jail_ip=$(get_jail_ip "$1")
+	if [ -z "$_jail_ip" ]; then
+		echo "unknown jail: $1"
+		exit
+	fi
+
+	local _rev_ip
+	_rev_ip=$(echo "$_jail_ip" | awk '{split($1,a,".");printf("%s.%s.%s.%s",a[4],a[3],a[2],a[1])}')
+	echo "$_rev_ip.in-addr.arpa"
+}
+
+get_reverse_ip6()
+{
+	_rev_ip=$(get_jail_ip6 "$1" | sed -e 's/://g' | rev | sed -e 's/./&./g')
+	echo "${_rev_ip}ip6.arpa"
+}
+
+jail_conf_header()
+{
+	local _path="$ZFS_JAIL_MNT/$1"
+	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
+
+	cat <<EO_JAIL_CONF_HEAD
+exec.start = "/bin/sh /etc/rc";
+exec.stop = "/bin/sh /etc/rc.shutdown";
+exec.clean;
+devfs_ruleset=5;
+path = "$_path";
+interface = $JAIL_NET_INTERFACE;
+host.hostname = \$name;
+
+EO_JAIL_CONF_HEAD
+}
+
+get_safe_jail_path()
+{
+	local _safe; _safe=$(safe_jailname "$1")
+	if [ "$1" != "$_safe" ]; then
+		echo "
+		path = $ZFS_JAIL_MNT/${1};"
+	else
+		echo ""
+	fi
+}
+
+get_jail_data()
+{
+	if [ "$1" = "base" ]; then
+		echo "$BASE_MNT/data"
+	else
+		echo "$ZFS_DATA_MNT/$1"
+	fi
+}
+
+jail_is_running()
+{
+	jls -d -j "$1" name 2>/dev/null | grep -q "$1"
+}
+
+stop_jail()
+{
+	tell_status "stopping jail $1"
+	local _safe; _safe=$(safe_jailname "$1")
+	if jail_is_running "$_safe"; then
+		echo "service jail stop $_safe"
+		if ! service jail stop "$_safe"; then
+			echo "jail -r $_safe"
+			if jail -r "$_safe" 2>/dev/null; then echo "removed"; fi
+		fi
+	fi
+
+	if jail_is_running "$_safe"; then
+		echo "jail -r $_safe"
+		if jail -r "$_safe" 2>/dev/null; then echo "removed"; fi
+	fi
+}
+
+jail_rename()
+{
+	if [ -z "$1" ] || [ -z "$2" ]; then
+		echo "$0 <existing jail name> <new jail name>"
+		exit
+	fi
+
+	echo "renaming $1 to $2"
+	service jail stop "$1"  || exit
+
+	for _f in data jails
+	do
+		zfs unmount "$ZFS_VOL/$_f/$1"
+		zfs rename "$ZFS_VOL/$_f/$1" "$ZFS_VOL/$_f/$2"  || exit
+		zfs set mountpoint="/$_f/$2" "$ZFS_VOL/$_f/$2"  || exit
+		zfs mount "$ZFS_VOL/$_f/$2"
+	done
+
+	sed -i.bak \
+		-e "/^$1\s/ s/$1/$2/" \
+		/etc/jail.conf || exit
+
+	service jail start "$2"
+
+	echo "Don't forget to update your PF and/or Haproxy rules"
+}
+
+assure_jail()
+{
+	local _jid; _jid=$(jls -j "$1" jid)
+	if [ -z "$_jid" ]; then
+		echo "jail $1 is required but not available"
+		exit
+	fi
+}
+
+enable_jail()
+{
+	case " $(sysrc -n jail_list) " in *" $1 "*)
+		#echo "jail $1 already enabled at startup"
+		return ;;
+	esac
+
+	tell_status "enabling jail $1 at startup"
+	sysrc jail_list+=" $1"
+	sysrc -f /etc/periodic.conf security_status_pkgaudit_jails+=" $1"
+}
+
+add_jail_conf()
+{
+	local _jail_ip; _jail_ip=$(get_jail_ip "$1");
+	if [ -z "$_jail_ip" ]; then
+		fatal_err "can't determine IP for $1"
+	fi
+
+	if [ -d /etc/jail.conf.d ]; then
+		add_jail_conf_d "$1"
+		return
+	fi
+
+	if [ ! -e /etc/jail.conf ]; then
+		tell_status "adding /etc/jail.conf header"
+		jail_conf_header "$1" | tee -a /etc/jail.conf
+	fi
+
+	if grep -q "^$1\\>" /etc/jail.conf; then
+		tell_status "preserving $1 config in /etc/jail.conf"
+		return
+	fi
+
+	tell_status "adding $1 to /etc/jail.conf"
+	echo "$1	{$(get_safe_jail_path "$1")
+		mount.fstab = \"$ZFS_DATA_MNT/$1/etc/fstab\";
+		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
+		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");${JAIL_CONF_EXTRA}
+	}" | tee -a /etc/jail.conf
+}
+
+add_jail_conf_d()
+{
+	# configure IPv6 if the system has an external/public IPv6 address
+	local _IP6=""
+	get_public_ip ipv6
+	if [ -n "$PUBLIC_IP6" ]; then
+		_IP6="ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");"
+	fi
+
+	local _path="$ZFS_JAIL_MNT/$1"
+	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
+
+	store_config "/etc/jail.conf.d/$(safe_jailname "$1").conf" <<EO_JAIL_RC
+$(safe_jailname "$1")	{$(get_safe_jail_path "$1")
+		host.hostname = \$name;
+		path = "$_path";
+		mount.fstab = "$(get_jail_data "$1")/etc/fstab";
+		devfs_ruleset=5;
+
+		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
+		${_IP6}${JAIL_CONF_EXTRA}
+
+		exec.clean;
+		exec.start = "/bin/sh /etc/rc";
+		exec.stop = "/bin/sh /etc/rc.shutdown";
+		exec.created = "$(get_jail_data "$1")/etc/pf.conf.d/pfrule.sh load";
+		exec.poststop = "$(get_jail_data "$1")/etc/pf.conf.d/pfrule.sh unload";
+	}
+EO_JAIL_RC
+}
+
+add_automount()
+{
+	if grep -qs auto_ports /etc/auto_master; then
+		if grep -qs "^$ZFS_JAIL_MNT/$1/" /etc/auto_ports; then
+			tell_status "automount ports already configured"
+		else
+			tell_status "enabling /usr/ports automount"
+			echo "$ZFS_JAIL_MNT/$1/usr/ports		-fstype=nullfs :/usr/ports" | tee -a /etc/auto_ports
+			/usr/sbin/automount
+		fi
+	else
+		echo "automount not enabled, see https://github.com/msimerson/Mail-Toaster-6/wiki/automount"
+	fi
+
+	if grep -qs auto_pkgcache /etc/auto_master; then
+		if grep -qs "^$ZFS_JAIL_MNT/$1/" /etc/auto_pkgcache; then
+			tell_status "automount pkg cache already configured"
+		else
+			tell_status "enabling /var/cache/pkg automount"
+			echo "$ZFS_JAIL_MNT/$1/var/cache/pkg		-fstype=nullfs :/var/cache/pkg" | tee -a /etc/auto_pkgcache
+			/usr/sbin/automount
+		fi
+	fi
+}
+
+assure_ip6_addr_is_declared()
+{
+	if ! grep -qs "^$1" /etc/jail.conf; then
+		# config for this jail hasn't been created yet
+		return
+	fi
+
+	if awk "/^$1/,/}/" /etc/jail.conf | grep -q ip6; then
+		echo "ip6.addr is already declared"
+		return
+	fi
+
+	tell_status "adding ip6.addr to $1 section in /etc/jail.conf"
+	sed -i.bak \
+		-e "/^$1/,/ip4/ s/ip4.*;/&\\
+		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");/" \
+		/etc/jail.conf
+}

--- a/include/network.sh
+++ b/include/network.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+get_public_facing_nic()
+{
+	local _ver=${1:-"ipv4"}
+
+	export PUBLIC_NIC
+
+	if [ "$_ver" = 'ipv6' ]; then
+		PUBLIC_NIC=$(netstat -rn | grep default | awk '{ print $4 }' | tail -n1)
+	else
+		PUBLIC_NIC=$(netstat -rn | grep default | awk '{ print $4 }' | head -n1)
+	fi
+
+	if [ -z "$PUBLIC_NIC" ];
+	then
+		echo "public NIC detection failed"
+		exit 1
+	fi
+}
+
+get_public_ip()
+{
+	local _ver=${1:-"ipv4"}
+
+	get_public_facing_nic "$_ver"
+
+	if [ "$_ver" = "ipv6" ]; then
+		export PUBLIC_IP6
+		PUBLIC_IP6=$(ifconfig "$PUBLIC_NIC" inet6 | grep inet | grep -v fe80 | awk '{print $2}' | head -n1)
+	else
+		export PUBLIC_IP4
+		PUBLIC_IP4=$(ifconfig "$PUBLIC_NIC" inet | grep inet | awk '{print $2}' | head -n1)
+	fi
+}
+
+get_random_ip6net()
+{
+	# shellcheck disable=2039
+	local RAND16
+	RAND16=$(od -t uI -N 2 /dev/urandom | awk '{print $2}')
+	echo "fd7a:e5cd:1fc1:$(dec_to_hex "$RAND16"):dead:beef:cafe"
+}
+
+install_pfrule()
+{
+	local _pfdir
+	_pfdir="$(get_jail_data $1)/etc/pf.conf.d"
+
+	mt6-fetch contrib pfrule.sh
+	install -d "$_pfdir"
+	install -C -m 0755 contrib/pfrule.sh "$_pfdir/pfrule.sh"
+}
+
+port_is_listening()
+{
+	local _port=${1:-"25"}
+	local _jail=${2:-"stage"}
+
+	if [ -n "$(sockstat -l -q -4 -6 -p "$_port" -j "$_jail")" ]; then
+		true
+	else
+		false
+	fi
+}

--- a/include/shell.sh
+++ b/include/shell.sh
@@ -107,8 +107,8 @@ jexecl() {
 EO_BOURNE_SHELL
 	fi
 
-	if ! grep -qs profile "/root/.profile"; then
-		echo ". /etc/profile" >> "/root/.profile"
+	if ! grep -qs profile "$1/root/.profile"; then
+		echo ". /etc/profile" >> "$1/root/.profile"
 	fi
 }
 

--- a/include/util.sh
+++ b/include/util.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 
-tell_status()
-{
-        echo; echo "   ***   $1   ***"; echo
-}
-
 # bump version when a change in mail toaster effects provision scripts
 mt6_version() { echo "20260204"; }
+
+tell_status() { echo; echo "   ***   $1   ***"; echo; }
 
 mt6_version_check()
 {

--- a/include/util.sh
+++ b/include/util.sh
@@ -1,0 +1,196 @@
+#!/bin/sh
+
+# bump version when a change in mail toaster effects provision scripts
+mt6_version() { echo "20260204"; }
+
+mt6_version_check()
+{
+	if [ "$(uname)" != 'FreeBSD' ]; then return; fi
+
+	if [ -d ".git" ]; then echo "v: $(mt6_version)"; return; fi
+
+	local _github
+	_github=$(fetch -o - -q "$TOASTER_SRC_URL/mail-toaster.sh" | grep '^mt6_version(' | cut -f2 -d'"')
+	if [ -z "$_github" ]; then
+		echo "v: <failed lookup>"
+		return
+	else
+		echo "v: $_github"
+	fi
+
+	local _this
+	_this="$(mt6_version)";
+	if [ -n "$_this" ] && [ "$_this" -lt "$_github" ]; then
+		echo "NOTICE: updating mail-toaster.sh"
+		mt6-update
+	fi
+}
+
+dec_to_hex() { printf '%04x\n' "$1"; }
+
+store_config()
+{
+	# $1 - path to config file, $2 - overwrite, STDIN is file contents
+	local _overwrite=${2:-""}
+
+	if [ ! -d "$(dirname "$1")" ]; then
+		tell_status "creating $(dirname "$1")"
+		mkdir -p "$(dirname "$1")"
+	fi
+
+	cat - > "$1.mt6"
+
+	if [ ! -f "$1" ] || [ "$_overwrite" = "overwrite" ]; then
+		tell_status "installing $1"
+		cp "$1.mt6" "$1"
+	else
+		tell_status "preserving $1"
+	fi
+}
+
+store_exec()
+{
+	# $1 - path to file, STDIN is file contents
+	if [ ! -d "$(dirname "$1")" ]; then
+		tell_status "creating $(dirname "$1")"
+		mkdir -p "$(dirname "$1")" || exit 1
+	fi
+
+	tell_status "installing $1"
+	cat - > "$1" || exit 1
+	chmod 755 "$1"
+}
+
+get_random_pass()
+{
+	local _pass_len=${1:-"14"}
+	local _strength=${2:-"good"}
+
+	# Password Entropy = log2(charset_len^pass_len)
+	case "$_strength" in
+		strong)
+			# https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
+			# more entropy with 94 ASCII chars but special chars are often problematic
+			LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c "$_pass_len"
+			;;
+		safe)
+			# good entropy, limited by 62 alpha-num characters (no symbols)
+			LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c "$_pass_len"
+			;;
+		*)
+			# default, good, limited by base64 charset
+			openssl rand -base64 "$(echo "$_pass_len + 4" | bc)" | head -c "$_pass_len"
+			;;
+	esac
+
+	echo
+}
+
+configure_pkg_latest()
+{
+	local _pkg_host="pkg.FreeBSD.org"
+
+	if [ -d "$ZFS_DATA_MNT/bsd_cache/pkg" ]; then
+		tell_status "switching pkg to bsd_cache"
+		_pkg_host="pkg"
+	fi
+
+	local REPODIR="$1/usr/local/etc/pkg/repos"
+	if [ -f "$REPODIR/FreeBSD.conf" ]; then return; fi
+
+	local _major_ver; _major_ver="$(/bin/freebsd-version | cut -f1 -d.)"
+	local _repo_name="FreeBSD-ports"
+	if [ "$_major_ver" -lt "15" ]; then _repo_name="FreeBSD"; fi
+
+	tell_status "switching pkg from quarterly to latest"
+	mkdir -p "$REPODIR"
+	store_config "$REPODIR/FreeBSD.conf" "overwrite" <<EO_PKG
+$_repo_name: {
+  url: "pkg+http://$_pkg_host/\${ABI}/$TOASTER_PKG_BRANCH"
+}
+EO_PKG
+}
+
+preserve_file()
+{
+	local _jail_name=$1
+	local _file_path=$2
+
+	local _active_cfg="$ZFS_JAIL_MNT/$_jail_name/$_file_path"
+	local _stage_cfg="${STAGE_MNT}/$_file_path"
+
+	if [ -f "$_active_cfg" ]; then
+		tell_status "preserving $_active_cfg"
+		cp -p "$_active_cfg" "$_stage_cfg" || return 1
+		return
+	fi
+
+	if [ -d "$ZFS_JAIL_MNT/$_jail_name.last" ]; then
+		_active_cfg="$ZFS_JAIL_MNT/$_jail_name.last/$_file_path"
+		if [ -f "$_active_cfg" ]; then
+			tell_status "preserving $_active_cfg"
+			cp -p "$_active_cfg" "$_stage_cfg" || return 1
+			return
+		fi
+	fi
+}
+
+reverse_list()
+{
+	# shellcheck disable=2068
+	for _j in $@; do
+		local _rev_list="${_j} ${_rev_list}"
+	done
+	echo "$_rev_list"
+}
+
+enable_bsd_cache()
+{
+	if ! jail_is_running bsd_cache; then return; fi
+	if ! jail_is_running dns; then return; fi
+
+	# assure services are available
+	sockstat -4 -6 -p 80 -q -j bsd_cache | grep -q . || return
+	sockstat -4 -6 -p 53 -q -j dns | grep -q . || return
+
+	tell_status "enabling bsd_cache"
+
+	store_config "$STAGE_MNT/etc/resolv.conf" "overwrite" <<EO_RESOLV
+nameserver $(get_jail_ip dns)
+nameserver $(get_jail_ip6 dns)
+EO_RESOLV
+
+	local _repo_dir="$ZFS_JAIL_MNT/stage/usr/local/etc/pkg/repos"
+	if [ ! -d "$_repo_dir" ]; then mkdir -p "$_repo_dir"; fi
+
+	local _major_ver; _major_ver="$(/bin/freebsd-version | cut -f1 -d.)"
+	local _repo_name="FreeBSD-ports"
+	if [ "$_major_ver" -lt "15" ]; then _repo_name="FreeBSD"; fi
+
+	store_config "$_repo_dir/FreeBSD.conf" <<EO_PKG_CONF
+$_repo_name: {
+	enabled: no
+}
+EO_PKG_CONF
+
+	store_config "$_repo_dir/MT6.conf" <<EO_PKG_MT6
+MT6: {
+	url: "http://pkg/\${ABI}/$TOASTER_PKG_BRANCH",
+	enabled: yes
+}
+EO_PKG_MT6
+
+	# cache pkg audit vulnerability db
+	sed -i '' \
+		-e '/^#VULNXML_SITE/ s/^#//' \
+		-e '/^VULNXML_SITE/ s/vuxml.freebsd.org/vulnxml/' \
+		"$ZFS_JAIL_MNT/stage/usr/local/etc/pkg.conf"
+
+	sed -i '' -e '/^ServerName/ s/update.FreeBSD.org/freebsd-update/' \
+		"$ZFS_JAIL_MNT/stage/etc/freebsd-update.conf"
+}
+
+tell_status()
+{
+        echo; echo "   ***   $1   ***"; echo
+}

--- a/include/util.sh
+++ b/include/util.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+tell_status()
+{
+        echo; echo "   ***   $1   ***"; echo
+}
+
 # bump version when a change in mail toaster effects provision scripts
 mt6_version() { echo "20260204"; }
 
@@ -188,9 +193,4 @@ EO_PKG_MT6
 
 	sed -i '' -e '/^ServerName/ s/update.FreeBSD.org/freebsd-update/' \
 		"$ZFS_JAIL_MNT/stage/etc/freebsd-update.conf"
-}
-
-tell_status()
-{
-        echo; echo "   ***   $1   ***"; echo
 }

--- a/include/zfs.sh
+++ b/include/zfs.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+zfs_filesystem_exists()
+{
+	zfs list -t filesystem "$1" 2>/dev/null | grep -q "^$1" || return 1
+	tell_status "$1 filesystem exists"
+	return 0
+}
+
+zfs_snapshot_exists()
+{
+	if zfs list -t snapshot "$1" 2>/dev/null | grep -q "$1"; then
+		echo "$1 snapshot exists"
+		return
+	fi
+	false
+}
+
+zfs_mountpoint_exists()
+{
+	zfs list -t filesystem "$1" 2>/dev/null | grep -q "$1\$" || return 1
+	echo "$1 mountpoint exists"
+	return 0
+}
+
+zfs_create_fs()
+{
+	if zfs_filesystem_exists "$1"; then return; fi
+	if zfs_mountpoint_exists "$2"; then return; fi
+
+	if echo "$1" | grep "$ZFS_DATA_VOL"; then
+		if ! zfs_filesystem_exists "$ZFS_DATA_VOL"; then
+			tell_status "zfs create -o mountpoint=$ZFS_DATA_MNT $ZFS_DATA_VOL"
+			zfs create -o mountpoint="$ZFS_DATA_MNT" "$ZFS_DATA_VOL"  || exit
+		fi
+	fi
+
+	if echo "$1" | grep "$ZFS_JAIL_VOL"; then
+		if ! zfs_filesystem_exists "$ZFS_JAIL_VOL"; then
+			tell_status "zfs create -o mountpoint=$ZFS_JAIL_MNT $ZFS_JAIL_VOL"
+			zfs create -o mountpoint="$ZFS_JAIL_MNT" "$ZFS_JAIL_VOL"  || exit
+		fi
+	fi
+
+	if [ -z "$2" ]; then
+		tell_status "zfs create $1"
+		zfs create "$1" || exit
+		echo "done"
+		return
+	fi
+
+	tell_status "zfs create -o mountpoint=$2 $1"
+	zfs create -o mountpoint="$2" "$1"  || exit
+	echo "done"
+}
+
+zfs_destroy_fs()
+{
+	local _fs="$1"
+	local _flags=${2-}
+
+	if ! zfs_filesystem_exists "$_fs"; then return; fi
+
+	if [ -n "$_flags" ]; then
+		echo "zfs destroy $2 $1"
+		zfs destroy "$2" "$1" || exit 1
+	else
+		echo "zfs destroy $1"
+		zfs destroy "$1" || exit 1
+	fi
+}
+
+base_snapshot_exists()
+{
+	if zfs_snapshot_exists "$BASE_SNAP"; then
+		return 0
+	fi
+
+	echo "$BASE_SNAP does not exist, use 'provision base' to create it"
+	return 1
+}
+
+rename_staged_to_ready()
+{
+	local _new_vol="$ZFS_JAIL_VOL/${1}.ready"
+
+	# remove stages that failed promotion
+	zfs_destroy_fs "$_new_vol"
+
+	# get the wait over with before shutting down production jail
+	local _tries=0
+	local _zfs_rename="zfs rename $ZFS_JAIL_VOL/stage $_new_vol"
+	/bin/sync
+	echo "$_zfs_rename"
+	until $_zfs_rename; do
+		if [ "$_tries" -gt 4 ]; then
+			echo "trying to force rename"
+			_zfs_rename="zfs rename -f $ZFS_JAIL_VOL/stage $_new_vol"
+		fi
+		echo "waiting for ZFS filesystem to quiet ($_tries)"
+		_tries=$((_tries + 1))
+		sleep 2
+	done
+}
+
+rename_active_to_last()
+{
+	local ACTIVE="$ZFS_JAIL_VOL/$1"
+	local LAST="$ACTIVE.last"
+
+	zfs_destroy_fs "$LAST"
+
+	if ! zfs_filesystem_exists "$ACTIVE"; then return; fi
+
+	local _tries=0
+	local _zfs_rename="zfs rename $ACTIVE $LAST"
+	/bin/sync
+	echo "$_zfs_rename"
+	until $_zfs_rename; do
+		if [ $_tries -gt 5 ]; then
+			echo "trying to force rename ($_tries)"
+			_zfs_rename="zfs rename -f $ACTIVE $LAST"
+		fi
+		echo "waiting for ZFS filesystem to quiet ($_tries)"
+		_tries=$((_tries + 1))
+		sleep 4
+	done
+}
+
+rename_ready_to_active()
+{
+	echo "zfs rename $ZFS_JAIL_VOL/${1}.ready $ZFS_JAIL_VOL/$1"
+	zfs rename "$ZFS_JAIL_VOL/${1}.ready" "$ZFS_JAIL_VOL/$1" || exit
+}

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1,123 +1,11 @@
 #!/bin/sh
 
-# bump version when a change in this file effects provision scripts
-mt6_version() { echo "20260204"; }
-
-dec_to_hex() { printf '%04x\n' "$1"; }
-
-get_random_ip6net()
-{
-	# shellcheck disable=2039
-	local RAND16
-	RAND16=$(od -t uI -N 2 /dev/urandom | awk '{print $2}')
-	echo "fd7a:e5cd:1fc1:$(dec_to_hex "$RAND16"):dead:beef:cafe"
-}
+export MT6_TEST_ENV=0
 
 tell_status()
 {
 	echo; echo "   ***   $1   ***"; echo
-	if [ -t 0 ]; then sleep 1; fi
-}
-
-store_config()
-{
-	# $1 - path to config file, $2 - overwrite, STDIN is file contents
-	local _overwrite=${2:-""}
-
-	if [ ! -d "$(dirname $1)" ]; then
-		tell_status "creating $(dirname $1)"
-		mkdir -p "$(dirname $1)"
-	fi
-
-	cat - > "$1.mt6"
-
-	if [ ! -f "$1" ] || [ "$_overwrite" = "overwrite" ]; then
-		tell_status "installing $1"
-		cp "$1.mt6" "$1"
-	else
-		tell_status "preserving $1"
-	fi
-}
-
-create_default_config()
-{
-	local _HOSTNAME
-	local _EMAIL_DOMAIN
-	local _ORGNAME
-
-	if [ -t 0 ] && [ "$(uname)" = 'FreeBSD' ]; then
-		echo "editing prefs"
-		_HOSTNAME=$(bsddialog --nocancel --backtitle "mail-toaster.sh" --title TOASTER_HOSTNAME --inputbox "the hostname of this [virtual] machine" 8 70 "mail.example.com" 3>&1 1>&2 2>&3)
-		_EMAIL_DOMAIN=$(bsddialog --nocancel --backtitle "mail-toaster.sh" --title TOASTER_MAIL_DOMAIN --inputbox "the primary email domain" 8 70 "example.com" 3>&1 1>&2 2>&3)
-		_ORGNAME=$(bsddialog --nocancel --backtitle "mail-toaster.sh" --title TOASTER_ORG_NAME --inputbox "the name of your organization" 8 70 "Email Inc" 3>&1 1>&2 2>&3)
-	fi
-
-	# for dev/test environs where bsddialog doesn't exist
-	if [ -z "$_HOSTNAME"     ]; then _HOSTNAME=$(hostname); fi
-	if [ -z "$_EMAIL_DOMAIN" ]; then _EMAIL_DOMAIN=$(hostname); fi
-	if [ -z "$_ORGNAME"      ]; then _ORGNAME="Sparky the Toaster"; fi
-
-	echo "creating mail-toaster.conf with defaults"
-	store_config mail-toaster.conf <<EO_MT_CONF
-export TOASTER_ORG_NAME="$_ORGNAME"
-export TOASTER_HOSTNAME="$_HOSTNAME"
-export TOASTER_MAIL_DOMAIN="$_EMAIL_DOMAIN"
-export TOASTER_ADMIN_EMAIL="postmaster@${_EMAIL_DOMAIN}"
-export TOASTER_SRC_URL="https://raw.githubusercontent.com/msimerson/Mail-Toaster-6/master"
-
-# If your hosts public facing IP(s) are not bound to a local interface, configure it here.
-# Haraka determines it at runtime (with STUN) but the DNS configuration cannot
-export PUBLIC_IP4=""
-export PUBLIC_IP6=""
-
-export JAIL_NET_PREFIX="172.16.15"
-export JAIL_NET_MASK="/19"
-export JAIL_NET_INTERFACE="lo1"
-export JAIL_NET6="$(get_random_ip6net)"
-export ZFS_VOL="zroot"
-export ZFS_JAIL_MNT="/jails"
-export ZFS_DATA_MNT="/data"
-export TOASTER_EDITOR="vim"
-export TOASTER_EDITOR_PORT="vim-tiny"
-export TOASTER_MSA="haraka"
-export TOASTER_MYSQL="1"
-export TOASTER_MYSQL_PASS=""
-export TOASTER_NRPE=""
-export TOASTER_PKG_AUDIT="0"
-export TOASTER_PKG_BRANCH="latest"
-export TOASTER_USE_TMPFS="0"
-export TOASTER_VPOPMAIL_CLEAR="1"
-export TOASTER_VPOPMAIL_EXT="0"
-export TOASTER_WEBMAIL_PROXY="haproxy"
-export CLAMAV_FANGFRISCH="0"
-export GEOIP_UPDATER="geoipupdate"
-export MAXMIND_ACCOUNT_ID=""
-export MAXMIND_LICENSE_KEY=""
-export ROUNDCUBE_SQL="0"
-export ROUNDCUBE_DEFAULT_HOST=""
-export ROUNDCUBE_PRODUCT_NAME="Roundcube Webmail"
-export ROUNDCUBE_ATTACHMENT_SIZE_MB="25"
-
-EO_MT_CONF
-
-	chmod 600 mail-toaster.conf
-}
-
-config()
-{
-	if [ ! -f "mail-toaster.conf" ]; then
-		create_default_config
-	fi
-
-	local _mode; _mode=$(stat -f "%OLp" mail-toaster.conf)
-	if [ "$_mode" -ne 600 ]; then
-		echo "tightening permissions on mail-toaster.conf"
-		chmod 600 mail-toaster.conf
-	fi
-
-	echo "loading mail-toaster.conf"
-	# shellcheck disable=SC1091,SC2039
-	. mail-toaster.conf
+	if [ -t 0 ] && [ "$MT6_TEST_ENV" != "1" ]; then sleep 1; fi
 }
 
 mt6-update()
@@ -127,458 +15,131 @@ mt6-update()
 	. mail-toaster.sh
 }
 
-mt6_version_check()
+check_last_hour() {
+        timestamp_file="${TMPDIR:-/tmp}/.mt6_fetch"
+        current=$(date +%s)
+        last=$(cat "$timestamp_file" 2>/dev/null || echo 0)
+
+        if [ $((current - last)) -ge 3600 ]; then
+                echo "$current" > "$timestamp_file"
+                return 1  # Not within last hour (or first run)
+        else
+                return 0  # Within last hour
+        fi
+}
+
+mt6-fetch()
 {
-	if [ "$(uname)" != 'FreeBSD' ]; then return; fi
+	local _dir="$1"
+	local _file="$2"
 
-	if [ -d ".git" ]; then echo "v: $(mt6_version)"; return; fi
+	if [ -z "$_dir" ] || [ -z "$_file" ]; then
+		echo "FATAL: invalid args to mt6-fetch"; return 1
+	fi
 
-	local _github
-	_github=$(fetch -o - -q "$TOASTER_SRC_URL/mail-toaster.sh" | grep '^mt6_version(' | cut -f2 -d'"')
-	if [ -z "$_github" ]; then
-		echo "v: <failed lookup>"
+	if [ -d ".git" ]; then
+		if ! check_last_hour; then
+			tell_status "git repo, check status, skip fetch"
+			git remote update && git status
+		fi
 		return
-	else
-		echo "v: $_github"
 	fi
 
-	local _this
-	_this="$(mt6_version)";
-	if [ -n "$_this" ] && [ "$_this" -lt "$_github" ]; then
-		echo "NOTICE: updating mail-toaster.sh"
-		mt6-update
+	if [ ! -d "$_dir" ]; then mkdir "$_dir"; fi
+
+	fetch -o "$_dir" -m "$TOASTER_SRC_URL/$_dir/$2"
+}
+
+mt6-include()
+{
+	mt6-fetch include "$1.sh"
+
+	if [ ! -f "include/$1.sh" ]; then
+		echo "unable to download include/$1.sh"
+		exit
 	fi
+
+	# shellcheck source=include/$.sh disable=SC1091
+	. "include/$1.sh"
+}
+
+mt6_init()
+{
+	for _i in util config zfs jail network; do
+		mt6-include "$_i"
+	done
+
+	mt6_defaults
+	mt6_version_check
+	# load the local config file
+	config
+
+	# Required settings
+	export TOASTER_HOSTNAME=${TOASTER_HOSTNAME:="mail.example.com"} || exit 1
+	export TOASTER_MAIL_DOMAIN=${TOASTER_MAIL_DOMAIN:="example.com"}
+	export TOASTER_ADMIN_EMAIL=${TOASTER_ADMIN_EMAIL:="postmaster@$TOASTER_MAIL_DOMAIN"}
+
+	# shellcheck disable=2009,2317
+	if ps -o args= -p "$$" | grep csh; then
+		echo; echo "ERROR: switch to sh or bash"; return 1; exit 1;
+	fi
+	echo "shell: $SHELL"
+
+	if [ "$TOASTER_MYSQL" = "1" ]; then
+		echo "mysql enabled"
+	fi
+
+	# shellcheck disable=2317
+	if [ "$TOASTER_HOSTNAME" = "mail.example.com" ]; then
+		usage TOASTER_HOSTNAME; return 1; exit 1
+	fi
+	echo "toaster host: $TOASTER_HOSTNAME"
+
+	# shellcheck disable=2317
+	if [ "$TOASTER_MAIL_DOMAIN" = "example.com" ]; then
+		usage TOASTER_MAIL_DOMAIN; return 1; exit 1
+	fi
+	echo "email domain: $TOASTER_MAIL_DOMAIN"
+
+	if [ -z "$JAIL_NET6" ]; then
+		JAIL_NET6=$(get_random_ip6net)
+		echo "export JAIL_NET6=\"$JAIL_NET6\"" >> mail-toaster.conf
+		export JAIL_NET6
+	fi
+
+	# little below here should need customizing. If so, consider opening
+	# an issue or PR at https://github.com/msimerson/Mail-Toaster-6
+	export ZFS_JAIL_VOL="${ZFS_VOL}${ZFS_JAIL_MNT}"
+	export ZFS_DATA_VOL="${ZFS_VOL}${ZFS_DATA_MNT}"
+
+	export FBSD_REL_VER FBSD_PATCH_VER
+	if [ "$(uname)" = 'FreeBSD' ]; then
+		FBSD_REL_VER=$(/bin/freebsd-version | /usr/bin/cut -f1-2 -d'-')
+		FBSD_PATCH_VER=$(/bin/freebsd-version | /usr/bin/cut -f3 -d'-')
+		FBSD_PATCH_VER=${FBSD_PATCH_VER:="p0"}
+	fi
+
+	# the 'base' jail that other jails are cloned from. This will be named as the
+	# host OS version, eg: base-13.2-RELEASE and the snapshot name will be the OS
+	# patch level, eg: base-13.2-RELEASE@p3
+	export BASE_NAME="base-$FBSD_REL_VER"
+	export BASE_VOL="$ZFS_JAIL_VOL/$BASE_NAME"
+	export BASE_SNAP="${BASE_VOL}@${FBSD_PATCH_VER}"
+	export BASE_MNT="$ZFS_JAIL_MNT/$BASE_NAME"
+
+	export STAGE_MNT="$ZFS_JAIL_MNT/stage"
+
+	export SAFE_NAME; SAFE_NAME=$(safe_jailname stage)
+	if [ -z "$SAFE_NAME" ]; then echo "unset SAFE_NAME"; exit; fi
 }
 
 export TOASTER_SRC_URL=${TOASTER_SRC_URL:="https://raw.githubusercontent.com/msimerson/Mail-Toaster-6/master"}
 
-mt6_version_check
-# load the local config file
-config
-
-# Required settings
-export TOASTER_HOSTNAME=${TOASTER_HOSTNAME:="mail.example.com"} || exit 1
-export TOASTER_MAIL_DOMAIN=${TOASTER_MAIL_DOMAIN:="example.com"}
-export TOASTER_ADMIN_EMAIL=${TOASTER_ADMIN_EMAIL:="postmaster@$TOASTER_MAIL_DOMAIN"}
-
-# export these in your environment to customize
-export BOURNE_SHELL=${BOURNE_SHELL:="bash"}
-export JAIL_NET_PREFIX=${JAIL_NET_PREFIX:="172.16.15"}
-export JAIL_NET_MASK=${JAIL_NET_MASK:="/19"}
-export JAIL_NET_INTERFACE=${JAIL_NET_INTERFACE:="lo1"}
-export JAIL_ORDERED_LIST="syslog base dns mysql clamav spamassassin foundationdb vpopmail haraka webmail munin haproxy rspamd stalwart dovecot redis geoip nginx mailtest apache postgres minecraft joomla php7 memcached sphinxsearch elasticsearch nictool sqwebmail dhcp letsencrypt tinydns roundcube squirrelmail rainloop rsnapshot mediawiki smf wordpress whmcs squirrelcart horde grafana unifi mongodb gitlab gitlab_runner dcc prometheus influxdb telegraf statsd mail_dmarc ghost jekyll borg nagios postfix puppeteer snappymail knot nsd bsd_cache wildduck zonemta centos ubuntu bhyve-ubuntu mailman"
-
-export ZFS_VOL=${ZFS_VOL:="zroot"}
-export ZFS_BHYVE_VOL="${ZFS_BHYVE_VOL:=$ZFS_VOL}"
-export ZFS_JAIL_MNT=${ZFS_JAIL_MNT:="/jails"}
-export ZFS_DATA_MNT=${ZFS_DATA_MNT:="/data"}
-export FBSD_MIRROR=${FBSD_MIRROR:="ftp://ftp.freebsd.org"}
-
-export TLS_LIBRARY=${TLS_LIBRARY:=""}
-export TOASTER_BASE_MTA=${TOASTER_BASE_MTA:=""}
-export TOASTER_BASE_PKGS=${TOASTER_BASE_PKGS:="pkg ca_root_nss"}
-export TOASTER_BUILD_DEBUG=${TOASTER_BUILD_DEBUG:="0"}
-export TOASTER_EDITOR=${TOASTER_EDITOR:="vim"}
-export TOASTER_EDITOR_PORT=${TOASTER_EDITOR_PORT:="vim-tiny"}
-# See https://github.com/msimerson/Mail-Toaster-6/wiki/MySQL
-export TOASTER_MYSQL=${TOASTER_MYSQL:="1"}
-export TOASTER_MARIADB=${TOASTER_MARIADB:="0"}
-export TOASTER_NTP=${TOASTER_NTP:="openntpd"}
-export TOASTER_MSA=${TOASTER_MSA:="haraka"}
-export TOASTER_PKG_AUDIT=${TOASTER_PKG_AUDIT:="0"}
-export TOASTER_PKG_BRANCH=${TOASTER_PKG_BRANCH:="latest"}
-export TOASTER_USE_TMPFS=${TOASTER_USE_TMPFS:="0"}
-export TOASTER_VPOPMAIL_CLEAR=${TOASTER_VPOPMAIL_CLEAR:="1"}
-export TOASTER_VPOPMAIL_EXT=${TOASTER_VPOPMAIL_EXT:="0"}
-export TOASTER_VQADMIN=${TOASTER_VQADMIN:="0"}
-export TOASTER_WEBMAIL_PROXY=${TOASTER_WEBMAIL_PROXY:="haproxy"}
-export CLAMAV_FANGFRISCH=${CLAMAV_FANGFRISCH:="0"}
-export CLAMAV_UNOFFICIAL=${CLAMAV_UNOFFICIAL:="0"}
-export ROUNDCUBE_SQL=${ROUNDCUBE_SQL:="$TOASTER_MYSQL"}
-export ROUNDCUBE_PRODUCT_NAME=${ROUNDCUBE_PRODUCT_NAME:="Roundcube Webmail"}
-export ROUNDCUBE_ATTACHMENT_SIZE_MB=${ROUNDCUBE_ATTACHMENT_SIZE_MB:="25"}
-export SQUIRREL_SQL=${SQUIRREL_SQL:="$TOASTER_MYSQL"}
-export WILDDUCK_MAIL_DOMAIN=${WILDDUCK_MAIL_DOMAIN:="$TOASTER_MAIL_DOMAIN"}
-export WILDDUCK_HOSTNAME=${WILDDUCK_HOSTNAME:="$TOASTER_HOSTNAME"}
-
-# shellcheck disable=2009,2317
-if ps -o args= -p "$$" | grep csh; then
-	echo; echo "ERROR: switch to sh or bash"; return 1; exit 1;
+if [ "${MT6_TEST_ENV:-0}" != "1" ]; then
+	mt6_init
 fi
-echo "shell: $SHELL"
-
-if [ "$TOASTER_MYSQL" = "1" ]; then
-	echo "mysql enabled"
-fi
-
-usage()
-{
-	if [ -n "$1" ]; then echo; echo "ERROR: invalid $1"; echo; fi
-	echo; echo "Next step, edit mail-toaster.conf!"; echo
-	echo "See: https://github.com/msimerson/Mail-Toaster-6/wiki/FreeBSD"; echo
-}
-# shellcheck disable=2317
-if [ "$TOASTER_HOSTNAME" = "mail.example.com" ]; then
-	usage TOASTER_HOSTNAME; return 1; exit 1
-fi
-echo "toaster host: $TOASTER_HOSTNAME"
-
-# shellcheck disable=2317
-if [ "$TOASTER_MAIL_DOMAIN" = "example.com" ]; then
-	usage TOASTER_MAIL_DOMAIN; return 1; exit 1
-fi
-echo "email domain: $TOASTER_MAIL_DOMAIN"
-
-if [ -z "$JAIL_NET6" ]; then
-	JAIL_NET6=$(get_random_ip6net)
-	echo "export JAIL_NET6=\"$JAIL_NET6\"" >> mail-toaster.conf
-	export JAIL_NET6
-fi
-
-# little below here should need customizing. If so, consider opening
-# an issue or PR at https://github.com/msimerson/Mail-Toaster-6
-export ZFS_JAIL_VOL="${ZFS_VOL}${ZFS_JAIL_MNT}"
-export ZFS_DATA_VOL="${ZFS_VOL}${ZFS_DATA_MNT}"
-
-export FBSD_REL_VER FBSD_PATCH_VER
-if [ "$(uname)" = 'FreeBSD' ]; then
-	FBSD_REL_VER=$(/bin/freebsd-version | /usr/bin/cut -f1-2 -d'-')
-	FBSD_PATCH_VER=$(/bin/freebsd-version | /usr/bin/cut -f3 -d'-')
-	FBSD_PATCH_VER=${FBSD_PATCH_VER:="p0"}
-fi
-
-# the 'base' jail that other jails are cloned from. This will be named as the
-# host OS version, eg: base-13.2-RELEASE and the snapshot name will be the OS
-# patch level, eg: base-13.2-RELEASE@p3
-export BASE_NAME="base-$FBSD_REL_VER"
-export BASE_VOL="$ZFS_JAIL_VOL/$BASE_NAME"
-export BASE_SNAP="${BASE_VOL}@${FBSD_PATCH_VER}"
-export BASE_MNT="$ZFS_JAIL_MNT/$BASE_NAME"
-
-export STAGE_MNT="$ZFS_JAIL_MNT/stage"
 
 fatal_err() { echo; echo "FATAL: $1"; echo; exit 1; }
-
-safe_jailname()
-{
-	# constrain jail name chars to alpha-numeric and _
-	# shellcheck disable=SC2001
-	echo "$1" | sed -e 's/[^a-zA-Z0-9]/_/g'
-}
-
-export SAFE_NAME; SAFE_NAME=$(safe_jailname stage)
-if [ -z "$SAFE_NAME" ]; then echo "unset SAFE_NAME"; exit; fi
-
-zfs_filesystem_exists()
-{
-	zfs list -t filesystem "$1" 2>/dev/null | grep -q "^$1" || return 1
-	tell_status "$1 filesystem exists"
-	return 0
-}
-
-zfs_snapshot_exists()
-{
-	if zfs list -t snapshot "$1" 2>/dev/null | grep -q "$1"; then
-		echo "$1 snapshot exists"
-		return
-	fi
-	false
-}
-
-zfs_mountpoint_exists()
-{
-	zfs list -t filesystem "$1" 2>/dev/null | grep -q "$1\$" || return 1
-	echo "$1 mountpoint exists"
-	return 0
-}
-
-zfs_create_fs()
-{
-	if zfs_filesystem_exists "$1"; then return; fi
-	if zfs_mountpoint_exists "$2"; then return; fi
-
-	if echo "$1" | grep "$ZFS_DATA_VOL"; then
-		if ! zfs_filesystem_exists "$ZFS_DATA_VOL"; then
-			tell_status "zfs create -o mountpoint=$ZFS_DATA_MNT $ZFS_DATA_VOL"
-			zfs create -o mountpoint="$ZFS_DATA_MNT" "$ZFS_DATA_VOL"  || exit
-		fi
-	fi
-
-	if echo "$1" | grep "$ZFS_JAIL_VOL"; then
-		if ! zfs_filesystem_exists "$ZFS_JAIL_VOL"; then
-			tell_status "zfs create -o mountpoint=$ZFS_JAIL_MNT $ZFS_JAIL_VOL"
-			zfs create -o mountpoint="$ZFS_JAIL_MNT" "$ZFS_JAIL_VOL"  || exit
-		fi
-	fi
-
-	if [ -z "$2" ]; then
-		tell_status "zfs create $1"
-		zfs create "$1" || exit
-		echo "done"
-		return
-	fi
-
-	tell_status "zfs create -o mountpoint=$2 $1"
-	zfs create -o mountpoint="$2" "$1"  || exit
-	echo "done"
-}
-
-zfs_destroy_fs()
-{
-	local _fs="$1"
-	local _flags=${2-}
-
-	if ! zfs_filesystem_exists "$_fs"; then return; fi
-
-	if [ -n "$_flags" ]; then
-		echo "zfs destroy $2 $1"
-		zfs destroy "$2" "$1" || exit 1
-	else
-		echo "zfs destroy $1"
-		zfs destroy "$1" || exit 1
-	fi
-}
-
-base_snapshot_exists()
-{
-	if zfs_snapshot_exists "$BASE_SNAP"; then
-		return 0
-	fi
-
-	echo "$BASE_SNAP does not exist, use 'provision base' to create it"
-	return 1
-}
-
-jail_conf_header()
-{
-	local _path="$ZFS_JAIL_MNT/$1"
-	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
-
-	cat <<EO_JAIL_CONF_HEAD
-exec.start = "/bin/sh /etc/rc";
-exec.stop = "/bin/sh /etc/rc.shutdown";
-exec.clean;
-devfs_ruleset=5;
-path = "$_path";
-interface = $JAIL_NET_INTERFACE;
-host.hostname = \$name;
-
-EO_JAIL_CONF_HEAD
-}
-
-get_jail_ip()
-{
-	local _start=${JAIL_NET_START:=1}
-
-	case "$1" in
-		syslog) echo "$JAIL_NET_PREFIX.$_start"; return;;
-		base)   echo "$JAIL_NET_PREFIX.$((_start + 1))"; return;;
-		stage)  echo "$JAIL_NET_PREFIX.254"; return;;
-	esac
-
-	if echo "$1" | grep -q ^base; then
-		echo "$JAIL_NET_PREFIX.$((_start + 1))"
-		return
-	fi
-
-	local _octet="$_start"
-
-	for _j in $JAIL_ORDERED_LIST; do
-		if [ "$1" = "$_j" ]; then
-			echo "$JAIL_NET_PREFIX.$_octet"
-			return
-		fi
-		_octet=$((_octet + 1))
-	done
-
-	_dns=$(host "$1" | grep 'has address' | cut -f4 -d' ')
-	if [ -n "$_dns" ]; then
-		echo "$_dns"
-		return
-	fi
-
-	# return error code
-	return 2
-}
-
-get_jail_ip6()
-{
-	local _start=${JAIL_NET_START:=1}
-
-	case "$1" in
-		syslog) echo "$JAIL_NET6:$(dec_to_hex "$_start")";       return;;
-		base)   echo "$JAIL_NET6:$(dec_to_hex $((_start + 1)))"; return;;
-		stage)  echo "$JAIL_NET6:$(dec_to_hex 254)";             return;;
-	esac
-
-	if echo "$1" | grep -q ^base; then
-		echo "$JAIL_NET6:$(dec_to_hex $((_start + 1)))"
-		return
-	fi
-
-	local _octet="$_start"
-
-	for _j in $JAIL_ORDERED_LIST; do
-		if [ "$1" = "$_j" ]; then
-			echo "$JAIL_NET6:$(dec_to_hex "$_octet")"
-			return
-		fi
-		_octet=$((_octet + 1))
-	done
-
-	_dns=$(host "$1" | grep 'has IPv6 address' | cut -f5 -d' ')
-	if [ -n "$_dns" ]; then
-		echo "$_dns"
-		return
-	fi
-
-	# return error code
-	return 2
-}
-
-get_reverse_ip()
-{
-	local _jail_ip; _jail_ip=$(get_jail_ip "$1")
-	if [ -z "$_jail_ip" ]; then
-		echo "unknown jail: $1"
-		exit
-	fi
-
-	local _rev_ip
-	_rev_ip=$(echo "$_jail_ip" | awk '{split($1,a,".");printf("%s.%s.%s.%s",a[4],a[3],a[2],a[1])}')
-	echo "$_rev_ip.in-addr.arpa"
-}
-
-get_reverse_ip6()
-{
-	_rev_ip=$(get_jail_ip6 "$1" | sed -e 's/://g' | rev | sed -e 's/./&./g')
-	echo "${_rev_ip}ip6.arpa"
-}
-
-add_jail_conf()
-{
-	local _jail_ip; _jail_ip=$(get_jail_ip "$1");
-	if [ -z "$_jail_ip" ]; then
-		fatal_err "can't determine IP for $1"
-	fi
-
-	if [ -d /etc/jail.conf.d ]; then
-		add_jail_conf_d $1
-		return
-	fi
-
-	if [ ! -e /etc/jail.conf ]; then
-		tell_status "adding /etc/jail.conf header"
-		jail_conf_header $1 | tee -a /etc/jail.conf
-	fi
-
-	if grep -q "^$1\\>" /etc/jail.conf; then
-		tell_status "preserving $1 config in /etc/jail.conf"
-		return
-	fi
-
-	tell_status "adding $1 to /etc/jail.conf"
-	echo "$1	{$(get_safe_jail_path $1)
-		mount.fstab = \"$ZFS_DATA_MNT/$1/etc/fstab\";
-		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
-		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 $1);${JAIL_CONF_EXTRA}
-	}" | tee -a /etc/jail.conf
-}
-
-get_safe_jail_path()
-{
-	local _safe; _safe=$(safe_jailname "$1")
-	if [ "$1" != "$_safe" ]; then
-		echo "
-		path = $ZFS_JAIL_MNT/${1};"
-	else
-		echo ""
-	fi
-}
-
-get_jail_data()
-{
-	if [ "$1" = "base" ]; then
-		echo "$BASE_MNT/data"
-	else
-		echo "$ZFS_DATA_MNT/$1"
-	fi
-}
-
-add_jail_conf_d()
-{
-	# configure IPv6 if the system has an external/public IPv6 address
-	local _IP6=""
-	get_public_ip ipv6
-	if [ -n "$PUBLIC_IP6" ]; then
-		_IP6="ip6.addr = $(get_jail_ip6 $1);"
-	fi
-
-	local _path="$ZFS_JAIL_MNT/$1"
-	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
-
-	store_config "/etc/jail.conf.d/$(safe_jailname $1).conf" <<EO_JAIL_RC
-$(safe_jailname $1)	{$(get_safe_jail_path $1)
-		host.hostname = \$name;
-		path = "$_path";
-		mount.fstab = "$(get_jail_data $1)/etc/fstab";
-		devfs_ruleset=5;
-
-		interface = $JAIL_NET_INTERFACE;
-		ip4.addr = ${_jail_ip};
-		${_IP6}${JAIL_CONF_EXTRA}
-
-		exec.clean;
-		exec.start = "/bin/sh /etc/rc";
-		exec.stop = "/bin/sh /etc/rc.shutdown";
-		exec.created = "$(get_jail_data $1)/etc/pf.conf.d/pfrule.sh load";
-		exec.poststop = "$(get_jail_data $1)/etc/pf.conf.d/pfrule.sh unload";
-	}
-EO_JAIL_RC
-}
-
-add_automount()
-{
-	if grep -qs auto_ports /etc/auto_master; then
-		if grep -qs "^$ZFS_JAIL_MNT/$1/" /etc/auto_ports; then
-			tell_status "automount ports already configured"
-		else
-			tell_status "enabling /usr/ports automount"
-			echo "$ZFS_JAIL_MNT/$1/usr/ports		-fstype=nullfs :/usr/ports" | tee -a /etc/auto_ports
-			/usr/sbin/automount
-		fi
-	else
-		echo "automount not enabled, see https://github.com/msimerson/Mail-Toaster-6/wiki/automount"
-	fi
-
-	if grep -qs auto_pkgcache /etc/auto_master; then
-		if grep -qs "^$ZFS_JAIL_MNT/$1/" /etc/auto_pkgcache; then
-			tell_status "automount pkg cache already configured"
-		else
-			tell_status "enabling /var/cache/pkg automount"
-			echo "$ZFS_JAIL_MNT/$1/var/cache/pkg		-fstype=nullfs :/var/cache/pkg" | tee -a /etc/auto_pkgcache
-			/usr/sbin/automount
-		fi
-	fi
-}
-
-stop_jail()
-{
-	tell_status "stopping jail $1"
-	local _safe; _safe=$(safe_jailname "$1")
-	if jail_is_running "$_safe"; then
-		echo "service jail stop $_safe"
-		if ! service jail stop "$_safe"; then
-			echo "jail -r $_safe"
-			if jail -r "$_safe" 2>/dev/null; then echo "removed"; fi
-		fi
-	fi
-
-	if jail_is_running "$_safe"; then
-		echo "jail -r $_safe"
-		if jail -r "$_safe" 2>/dev/null; then echo "removed"; fi
-	fi
-}
 
 stage_unmount()
 {
@@ -607,16 +168,6 @@ cleanup_staged_fs()
 	stop_jail stage
 	stage_unmount "$1"
 	zfs_destroy_fs "$ZFS_JAIL_VOL/stage" -f
-}
-
-install_pfrule()
-{
-	local _pfdir
-	_pfdir="$(get_jail_data $1)/etc/pf.conf.d"
-
-	mt6-fetch contrib pfrule.sh
-	install -d "$_pfdir"
-	install -C -m 0755 contrib/pfrule.sh "$_pfdir/pfrule.sh"
 }
 
 install_fstab()
@@ -662,6 +213,28 @@ install_fstab()
 	cp "$_fstab.stage" "$ZFS_DATA_MNT/stage/etc/fstab" || exit 1
 }
 
+fstab_add_mount() {
+	if [ -z "$3" ]; then
+		echo "Error: invalid args to fstab_add_mount" >&2
+		exit 1
+	fi
+
+	local jail_name="$1"
+	local fs_path="$2"
+	local mount_point="$3"
+	local fs_type="${4:-nullfs}"
+	local opts="${5:-rw}"
+	local fstab="$ZFS_DATA_MNT/$jail_name/etc/fstab"
+
+	for _file in "$fstab" "${fstab}.stage"; do
+		if ! grep -qs "^$fs_path" "$_file"; then
+			tell_status "adding $fs_path volume to $_file"
+			printf "%s\t%s\t%s\t%s\t0\t0\n" "$fs_path" "$mount_point" "$fs_type" "$opts" | \
+				tee -a "$_file"
+		fi
+	done
+}
+
 create_staged_fs()
 {
 	cleanup_staged_fs "$1"
@@ -692,52 +265,6 @@ create_staged_fs()
 	install_fstab $1
 	install_pfrule $1
 	echo
-}
-
-enable_bsd_cache()
-{
-	if ! jail_is_running bsd_cache; then return; fi
-	if ! jail_is_running dns; then return; fi
-
-	# assure services are available
-	sockstat -4 -6 -p 80 -q -j bsd_cache | grep -q . || return
-	sockstat -4 -6 -p 53 -q -j dns | grep -q . || return
-
-	tell_status "enabling bsd_cache"
-
-	store_config "$STAGE_MNT/etc/resolv.conf" "overwrite" <<EO_RESOLV
-nameserver $(get_jail_ip dns)
-nameserver $(get_jail_ip6 dns)
-EO_RESOLV
-
-	local _repo_dir="$ZFS_JAIL_MNT/stage/usr/local/etc/pkg/repos"
-	if [ ! -d "$_repo_dir" ]; then mkdir -p "$_repo_dir"; fi
-
-	local _major_ver; _major_ver="$(/bin/freebsd-version | cut -f1 -d.)"
-	local _repo_name="FreeBSD-ports"
-	if [ "$_major_ver" -lt "15" ]; then _repo_name="FreeBSD"; fi
-
-	store_config "$_repo_dir/FreeBSD.conf" <<EO_PKG_CONF
-$_repo_name: {
-	enabled: no
-}
-EO_PKG_CONF
-
-	store_config "$_repo_dir/MT6.conf" <<EO_PKG_MT6
-MT6: {
-	url: "http://pkg/\${ABI}/$TOASTER_PKG_BRANCH",
-	enabled: yes
-}
-EO_PKG_MT6
-
-	# cache pkg audit vulnerability db
-	sed -i '' \
-		-e '/^#VULNXML_SITE/ s/^#//' \
-		-e '/^VULNXML_SITE/ s/vuxml.freebsd.org/vulnxml/' \
-		"$ZFS_JAIL_MNT/stage/usr/local/etc/pkg.conf"
-
-	sed -i '' -e '/^ServerName/ s/update.FreeBSD.org/freebsd-update/' \
-		"$ZFS_JAIL_MNT/stage/etc/freebsd-update.conf"
 }
 
 start_staged_jail()
@@ -771,63 +298,12 @@ start_staged_jail()
 	pkg -j stage update
 }
 
-rename_staged_to_ready()
-{
-	local _new_vol="$ZFS_JAIL_VOL/${1}.ready"
-
-	# remove stages that failed promotion
-	zfs_destroy_fs "$_new_vol"
-
-	# get the wait over with before shutting down production jail
-	local _tries=0
-	local _zfs_rename="zfs rename $ZFS_JAIL_VOL/stage $_new_vol"
-	echo "$_zfs_rename"
-	until $_zfs_rename; do
-		if [ "$_tries" -gt 5 ]; then
-			echo "trying to force rename"
-			_zfs_rename="zfs rename -f $ZFS_JAIL_VOL/stage $_new_vol"
-		fi
-		echo "waiting for ZFS filesystem to quiet ($_tries)"
-		_tries=$((_tries + 1))
-		sleep 3
-	done
-}
-
-rename_active_to_last()
-{
-	local ACTIVE="$ZFS_JAIL_VOL/$1"
-	local LAST="$ACTIVE.last"
-
-	zfs_destroy_fs "$LAST"
-
-	if ! zfs_filesystem_exists "$ACTIVE"; then return; fi
-
-	local _tries=0
-	local _zfs_rename="zfs rename $ACTIVE $LAST"
-	echo "$_zfs_rename"
-	until $_zfs_rename; do
-		if [ $_tries -gt 5 ]; then
-			echo "trying to force rename ($_tries)"
-			_zfs_rename="zfs rename -f $ACTIVE $LAST"
-		fi
-		echo "waiting for ZFS filesystem to quiet ($_tries)"
-		_tries=$((_tries + 1))
-		sleep 4
-	done
-}
-
-rename_ready_to_active()
-{
-	echo "zfs rename $ZFS_JAIL_VOL/${1}.ready $ZFS_JAIL_VOL/$1"
-	zfs rename "$ZFS_JAIL_VOL/${1}.ready" "$ZFS_JAIL_VOL/$1" || exit
-}
-
 tell_settings()
 {
 	echo; echo "   ***   Configured $1 settings:   ***"; echo
 	set | grep "^$1_"
 	echo
-	if [ -t 0 ]; then sleep 2; fi
+	if [ -t 0 ] && [ "$MT6_TEST_ENV" != "1" ]; then sleep 2; fi
 }
 
 proclaim_success()
@@ -859,18 +335,6 @@ seed_pkg_audit()
 		tell_status "installing FreeBSD package audit database"
 		stage_exec /usr/sbin/pkg audit -F || echo ''
 	fi
-}
-
-enable_jail()
-{
-	case " $(sysrc -n jail_list) " in *" $1 "*)
-		#echo "jail $1 already enabled at startup"
-		return ;;
-	esac
-
-	tell_status "enabling jail $1 at startup"
-	sysrc jail_list+=" $1"
-	sysrc -f /etc/periodic.conf security_status_pkgaudit_jails+=" $1"
 }
 
 promote_staged_jail()
@@ -936,18 +400,6 @@ stage_exec()
 {
 	echo "jexec $SAFE_NAME $*"
 	jexec "$SAFE_NAME" "$@"
-}
-
-port_is_listening()
-{
-	local _port=${1:-"25"}
-	local _jail=${2:-"stage"}
-
-	if [ -n "$(sockstat -l -q -4 -6 -p "$_port" -j "$_jail")" ]; then
-		true
-	else
-		false
-	fi
 }
 
 stage_listening()
@@ -1064,40 +516,6 @@ unmount_data()
 	fi
 }
 
-get_public_facing_nic()
-{
-	local _ver=${1:-"ipv4"}
-
-	export PUBLIC_NIC
-
-	if [ "$_ver" = 'ipv6' ]; then
-		PUBLIC_NIC=$(netstat -rn | grep default | awk '{ print $4 }' | tail -n1)
-	else
-		PUBLIC_NIC=$(netstat -rn | grep default | awk '{ print $4 }' | head -n1)
-	fi
-
-	if [ -z "$PUBLIC_NIC" ];
-	then
-		echo "public NIC detection failed"
-		exit 1
-	fi
-}
-
-get_public_ip()
-{
-	local _ver=${1:-"ipv4"}
-
-	get_public_facing_nic "$_ver"
-
-	if [ "$_ver" = "ipv6" ]; then
-		export PUBLIC_IP6
-		PUBLIC_IP6=$(ifconfig "$PUBLIC_NIC" inet6 | grep inet | grep -v fe80 | awk '{print $2}' | head -n1)
-	else
-		export PUBLIC_IP4
-		PUBLIC_IP4=$(ifconfig "$PUBLIC_NIC" inet | grep inet | awk '{print $2}' | head -n1)
-	fi
-}
-
 fetch_and_exec()
 {
 	mt6-fetch provision "$1.sh"
@@ -1181,15 +599,6 @@ provision()
 	fi
 
 	fetch_and_exec "$1"
-}
-
-reverse_list()
-{
-	# shellcheck disable=2068
-	for _j in $@; do
-		local _rev_list="${_j} ${_rev_list}"
-	done
-	echo "$_rev_list"
 }
 
 unprovision_last()
@@ -1303,189 +712,10 @@ unprovision()
 	echo "done"
 }
 
-mt6-fetch()
-{
-	local _dir="$1"
-	local _file="$2"
-
-	if [ -z "$_dir" ] || [ -z "$_file" ]; then
-		echo "FATAL: invalid args to mt6-fetch"; return 1
-	fi
-
-	if [ -d ".git" ]; then
-		tell_status "running from git, skipping fetch"
-		git remote update && git status
-		return
-	fi
-
-	if [ ! -d "$_dir" ]; then mkdir "$_dir"; fi
-
-	fetch -o "$_dir" -m "$TOASTER_SRC_URL/$_dir/$2"
-}
-
-mt6-include()
-{
-	mt6-fetch include "$1.sh"
-
-	if [ ! -f "include/$1.sh" ]; then
-		echo "unable to download include/$1.sh"
-		exit
-	fi
-
-	# shellcheck source=include/$.sh disable=SC1091
-	. "include/$1.sh"
-}
-
-jail_is_running()
-{
-	jls -d -j $1 name 2>/dev/null | grep -q $1
-}
-
-jail_rename()
-{
-	if [ -z "$1" ] || [ -z "$2" ]; then
-		echo "$0 <existing jail name> <new jail name>"
-		exit
-	fi
-
-	echo "renaming $1 to $2"
-	service jail stop "$1"  || exit
-
-	for _f in data jails
-	do
-		zfs unmount "$ZFS_VOL/$_f/$1"
-		zfs rename "$ZFS_VOL/$_f/$1" "$ZFS_VOL/$_f/$2"  || exit
-		zfs set mountpoint="/$_f/$2" "$ZFS_VOL/$_f/$2"  || exit
-		zfs mount "$ZFS_VOL/$_f/$2"
-	done
-
-	sed -i.bak \
-		-e "/^$1\s/ s/$1/$2/" \
-		/etc/jail.conf || exit
-
-	service jail start "$2"
-
-	echo "Don't forget to update your PF and/or Haproxy rules"
-}
-
-configure_pkg_latest()
-{
-	local _pkg_host="pkg.FreeBSD.org"
-
-	if [ -d "$ZFS_DATA_MNT/bsd_cache/pkg" ]; then
-		tell_status "switching pkg to bsd_cache"
-		_pkg_host="pkg"
-	fi
-
-	local REPODIR="$1/usr/local/etc/pkg/repos"
-	if [ -f "$REPODIR/FreeBSD.conf" ]; then return; fi
-
-	local _major_ver; _major_ver="$(/bin/freebsd-version | cut -f1 -d.)"
-	local _repo_name="FreeBSD-ports"
-	if [ "$_major_ver" -lt "15" ]; then _repo_name="FreeBSD"; fi
-
-	tell_status "switching pkg from quarterly to latest"
-	mkdir -p "$REPODIR"
-	store_config "$REPODIR/FreeBSD.conf" "overwrite" <<EO_PKG
-$_repo_name: {
-  url: "pkg+http://$_pkg_host/\${ABI}/$TOASTER_PKG_BRANCH"
-}
-EO_PKG
-}
-
-assure_ip6_addr_is_declared()
-{
-	if ! grep -qs "^$1" /etc/jail.conf; then
-		# config for this jail hasn't been created yet
-		return
-	fi
-
-	if awk "/^$1/,/}/" /etc/jail.conf | grep -q ip6; then
-		echo "ip6.addr is already declared"
-		return
-	fi
-
-	tell_status "adding ip6.addr to $1 section in /etc/jail.conf"
-	sed -i.bak \
-		-e "/^$1/,/ip4/ s/ip4.*;/&\\
-		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");/" \
-		/etc/jail.conf
-}
-
-assure_jail()
-{
-	local _jid; _jid=$(jls -j "$1" jid)
-	if [ -z "$_jid" ]; then
-		echo "jail $1 is required but not available"
-		exit
-	fi
-}
-
-preserve_file()
-{
-	local _jail_name=$1
-	local _file_path=$2
-
-	local _active_cfg="$ZFS_JAIL_MNT/$_jail_name/$_file_path"
-	local _stage_cfg="${STAGE_MNT}/$_file_path"
-
-	if [ -f "$_active_cfg" ]; then
-		tell_status "preserving $_active_cfg"
-		cp -p "$_active_cfg" "$_stage_cfg" || return 1
-		return
-	fi
-
-	if [ -d "$ZFS_JAIL_MNT/$_jail_name.last" ]; then
-		_active_cfg="$ZFS_JAIL_MNT/$_jail_name.last/$_file_path"
-		if [ -f "$_active_cfg" ]; then
-			tell_status "preserving $_active_cfg"
-			cp -p "$_active_cfg" "$_stage_cfg" || return 1
-			return
-		fi
-	fi
-}
-
-get_random_pass()
-{
-	local _pass_len=${1:-"14"}
-	local _strength=${2:-"good"}
-
-	# Password Entropy = log2(charset_len^pass_len)
-	case "$_strength" in
-		strong)
-			# https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
-			# more entropy with 94 ASCII chars but special chars are often problematic
-			LC_ALL=C tr -dc '[:graph:]' </dev/urandom | head -c "$_pass_len"
-			;;
-		safe)
-			# good entropy, limited by 62 alpha-num characters (no symbols)
-			LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c "$_pass_len"
-			;;
-		*)
-			# default, good, limited by base64 charset
-			openssl rand -base64 "$(echo "$_pass_len + 4" | bc)" | head -c "$_pass_len"
-			;;
-	esac
-
-	echo
-}
-
-store_exec()
-{
-	# $1 - path to file, STDIN is file contents
-	if [ ! -d "$(dirname $1)" ]; then
-		tell_status "creating $(dirname $1)"
-		mkdir -p "$(dirname $1)" || exit 1
-	fi
-
-	tell_status "installing $1"
-	cat - > "$1" || exit 1
-	chmod 755 "$1"
-}
-
 # shellcheck disable=3044,3018
 onexit() { while caller $((n++)); do :; done; }
 
 if [ "$TOASTER_BUILD_DEBUG" = "1" ]; then
 	trap onexit EXIT
 fi
+

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export MT6_TEST_ENV=0
+export MT6_TEST_ENV=${MT6_TEST_ENV:-0}
 
 tell_status()
 {

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -91,7 +91,7 @@ disable_root_password()
 	# prevent a nightly email notice about the empty root password
 	tell_status "disabling passwordless root account"
 	sed -i.bak -e 's/^root::/root:*:/' "$BASE_MNT/etc/master.passwd"
-	stage_exec pwd_mkdb "$BASE_MNT/etc/master.passwd"
+	stage_exec pwd_mkdb /etc/master.passwd
 }
 
 disable_cron_jobs()

--- a/provision/haproxy.sh
+++ b/provision/haproxy.sh
@@ -309,13 +309,13 @@ for pem in *.pem; do
     # Only process the certificate if we have a .issuer file
     if [ -r "${pem}.issuer" ]; then
 
-    # Request the OCSP response from the issuer and store it
-    $OPENSSL ocsp \
-        -issuer "${pem}.issuer" \
-        -cert "${pem}" \
-        -url "${ocsp_url}" \
-        -header "Host=${ocsp_host}" \
-        -respout "${pem}.ocsp" || echo -n ""
+        # Request the OCSP response from the issuer and store it
+        $OPENSSL ocsp \
+            -issuer "${pem}.issuer" \
+            -cert "${pem}" \
+            -url "${ocsp_url}" \
+            -header "Host=${ocsp_host}" \
+            -respout "${pem}.ocsp" || echo -n ""
 
         UPDATED=$(( $UPDATED + 1 ))
     fi

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -164,7 +164,8 @@ configure_haraka_qmail_deliverable()
 		tell_status "config recipient validation with Qmail::Deliverable"
 		echo "check_outbound=true
 host=$(get_jail_ip vpopmail)
-queue=smtp_forward" | \
+queue=smtp_forward
+next_hop=lmtp://$(get_jail_ip dovecot)" | \
 			tee -a "$HARAKA_CONF/qmail-deliverable.ini"
 	fi
 

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -44,15 +44,7 @@ install_geoip_dbs()
 
 	mount_nullfs "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/stage/usr/local/share/GeoIP"
 
-	local _fstab="$ZFS_DATA_MNT/haraka/etc/fstab"
-	for _f in "$_fstab" "$_fstab.stage"; do
-		if ! grep -qs GeoIP "$_f"; then
-			tell_status "adding GeoIP volume to $_f"
-			tee -a "$_f" <<EO_GEOIP
-$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP nullfs rw 0 0"
-EO_GEOIP
-		fi
-	done
+	fstab_add_mount haraka "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP"
 
 	if ! grep -qs ^geoip "$HARAKA_CONF/plugins"; then
 		tell_status "enabling Haraka geoip plugin"

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -458,7 +458,7 @@ install_jailmanage()
 	chmod 755 /usr/local/bin/jailmanage
 }
 
-enable_jails()
+enable_jails_start()
 {
 	tell_status "enabling jails"
 	sysrc jail_enable=YES
@@ -633,7 +633,7 @@ update_host() {
 	configure_tls_certs
 	configure_dhparams
 	install_sshguard
-	enable_jails
+	enable_jails_start
 	install_jailmanage
 	configure_etc_hosts
 	configure_csh_shell ""

--- a/provision/snappymail.sh
+++ b/provision/snappymail.sh
@@ -11,7 +11,7 @@ export JAIL_FSTAB=""
 mt6-include php
 mt6-include nginx
 
-PHP_VER="82"
+PHP_VER="83"
 
 install_snappymail()
 {
@@ -33,7 +33,7 @@ install_snappymail()
 	install_php "$PHP_VER" "$_php_modules"
 	install_nginx
 
-	if ! stage_exec pkg install -y php82-pecl-xxtea; then
+	if ! stage_exec pkg install -y php${PHP_VER}-pecl-xxtea; then
 		stage_pkg_install bsddialog gnupg autoconf automake re2c pcre2 pkgconf libxml2
 	fi
 

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -6,7 +6,7 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB=""
+export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0"
 
 mt6-include mysql
 
@@ -37,14 +37,14 @@ install_sought_rules() {
 install_spamassassin_port()
 {
 	tell_status "install SpamAssassin from ports (w/opts)"
-	stage_pkg_install p5-Encode-Detect p5-Test-NoWarnings
+	stage_pkg_install p5-Encode-Detect p5-Test-NoWarnings p5-HTTP-Tiny p5-Mail-DMARC
 
-	local _SA_OPTS="AS_ROOT DCC DKIM RAZOR SPF_QUERY GNUPG_NONE"
+	local _SA_OPTS="AS_ROOT DCC DKIM DMARC RAZOR SPF_QUERY GNUPG_NONE RELAY_COUNTRY"
 	if [    "$TOASTER_MYSQL" = "1" ]; then _SA_OPTS="MYSQL $_SA_OPTS"; fi
 	if [ -n "$MAXMIND_LICENSE_KEY" ]; then _SA_OPTS="RELAY_COUNTRY $_SA_OPTS"; fi
 
 	stage_make_conf mail_spamassassin_SET "mail_spamassassin_SET=$_SA_OPTS"
-	stage_make_conf mail_spamassassin_UNSET 'mail_spamassassin_UNSET=DOCS SSL GNUPG GNUPG2 PYZOR DMARC PGSQL RLIMIT'
+	stage_make_conf mail_spamassassin_UNSET 'mail_spamassassin_UNSET=DOCS SSL GNUPG GNUPG2 PYZOR PGSQL RLIMIT'
 	stage_make_conf dcc-dccd_SET 'mail_dcc-dccd_SET=DCCIFD IPV6'
 	stage_make_conf dcc-dccd_UNSET 'mail_dcc-dccd_UNSET=DCCGREY DCCD DCCM PORTS_MILTER'
 	stage_make_conf LICENSES_ACCEPTED 'LICENSES_ACCEPTED=DCC'
@@ -159,15 +159,7 @@ configure_geoip()
 		return
 	fi
 
-	local _fstab="$ZFS_DATA_MNT/spamassassin/etc/fstab"
-	for _f in "$_fstab" "${_fstab}.stage"; do
-		if ! grep -qs GeoIP "$_f"; then
-			tell_status "adding GeoIP volume to $_f"
-			tee -a "$_f" <<EO_GEOIP
-$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0
-EO_GEOIP
-		fi
-	done
+	fstab_add_mount spamassassin "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP"
 }
 
 configure_spamassassin()
@@ -181,6 +173,7 @@ loadplugin Mail::SpamAssassin::Plugin::TextCat
 loadplugin Mail::SpamAssassin::Plugin::ASN
 loadplugin Mail::SpamAssassin::Plugin::PDFInfo
 loadplugin Mail::SpamAssassin::Plugin::DMARC
+loadplugin Mail::SpamAssassin::Plugin::TxRep
 EO_LOCAL_PRE
 	fi
 
@@ -265,8 +258,9 @@ configure_spamassassin_mysql()
     # bayes_sql_password              $_my_pass
     # bayes_sql_override_username     someusername
 
-    # Not commonly enabled.
+    # for AWL or TxRep plugin
     # auto_whitelist_factory       Mail::SpamAssassin::SQLBasedAddrList
+    # txrep_factory                Mail::SpamAssassin::DBBasedAddrList
     # user_awl_dsn                 DBI:mysql:spamassassin:$(get_jail_ip mysql)
     # user_awl_sql_username        spamassassin
     # user_awl_sql_password        $_my_pass
@@ -275,13 +269,25 @@ EO_MYSQL_CONF
 
 	mysql_create_db spamassassin
 
-	# bayes_mysql
-	for _import_file in awl_mysql userpref_mysql;
-	do
-		local _f="$STAGE_MNT/usr/local/share/doc/spamassassin/sql/${_import_file}.sql"
-		# shellcheck disable=SC2002
-		cat "$_f" | sed -e 's/TYPE=MyISAM//' | mysql_query spamassassin
-	done
+	echo "CREATE TABLE IF NOT EXISTS userpref (
+  username   varchar(100) NOT NULL,
+  preference varchar(50) NOT NULL,
+  value      varchar(100) NOT NULL,
+  prefid     int(11) NOT NULL auto_increment,
+  PRIMARY KEY (prefid),
+  INDEX (username)
+) ENGINE=InnoDB;" | mysql_query spamassassin
+
+	echo "CREATE TABLE IF NOT EXISTS awl (
+  username   varchar(100) NOT NULL DEFAULT '',
+  email      varchar(200) NOT NULL DEFAULT '',
+  ip         varchar(10) NOT NULL DEFAULT '',
+  count      int DEFAULT '0',
+  totscore   float DEFAULT '0',
+  signedby   varchar(255) NOT NULL DEFAULT '',
+  lastupdate timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (username,email,ip)
+) ENGINE=InnoDB;" | mysql_query spamassassin
 
 	for _jail in spamassassin stage squirrelmail;
 	do

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -40,8 +40,8 @@ EO_MAILDROP_310
 install_maildrop()
 {
 	tell_status "installing maildrop"
-	# stage_pkg_install maildrop
-	install_maildrop_port
+	stage_pkg_install maildrop
+	#install_maildrop_port
 
 	tell_status "installing maildrop filter file"
 	fetch -o "$STAGE_MNT/etc/mailfilter" "$TOASTER_SRC_URL/qmail/filter.txt"
@@ -127,8 +127,8 @@ install_qmailadmin()
 	tell_status "installing qmailadmin"
 	stage_pkg_install autorespond ezmlm-idx autoconf automake help2man
 	stage_make_conf mail_qmailadmin_ '
-mail_qmailadmin_SET=HELP IDX MODIFY_QUOTA TRIVIAL_PASSWORD USER_INDEX
-mail_qmailadmin_UNSET=CATCHALL CRACKLIB IDX_SQL SPAM_DETECTION SPAM_NEEDS_EMAIL
+mail_qmailadmin_SET=HELP IDX IPAUTH MODIFY_QUOTA NOCACHE TRIVIAL_PASSWORD USER_INDEX
+mail_qmailadmin_UNSET=CATCHALL CRACKLIB DOMAIN_AUTOFILL IDX_SQL SPAM_DETECTION SPAM_NEEDS_EMAIL
 '
 
 	if [ -f "$ZFS_JAIL_MNT/vpopmail/var/db/ports/mail_qmailadmin/options" ]; then

--- a/provision/whmcs.sh
+++ b/provision/whmcs.sh
@@ -82,6 +82,8 @@ configure_whmcs()
 EO_CRONTAB
 
 	configure_whmcs_nginx
+
+	fstab_add_mount whmcs "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP"
 }
 
 start_whmcs()

--- a/qmail/filter.txt
+++ b/qmail/filter.txt
@@ -2,264 +2,30 @@ SHELL="/bin/sh"
 import EXT
 import HOST
 VHOME=`pwd`
-TIMESTAMP=`date "+%b %d %H:%M:%S"`
+
+to "$VHOME/Maildir"
+log "=== END ===  $EXT@$HOST  success"
+EXITCODE=0
+exit
 
 ##
 #  title:  mailfilter-site
 #  author: Matt Simerson
-#  version 3.2
+#  version 4
 #
-#  Usage: Install this file in /etc/mailfilter.
+#  Usage: Install this file in /etc/mailfilter. It sometimes works with
+#         courier > 3.1.1, which is better than never.
 #
-#  Create a .qmail file in each users Maildir as follows:
-#  echo "| /usr/local/bin/maildrop /etc/mailfilter" > ~vpopmail/domains/example.com/user/.qmail
+#        THE PROBLEM (2023)
+#  maildrop: Timeout quota exceeded
+#  https://github.com/msimerson/Mail-Toaster-6/issues/534
 #
-#  Qmailadmin v1.0.26 or higher does that automatically with
-#  options --enable-modify-spam and --enable-spam-command.
+#        THE WORKAROUND
+#  For several years, I modified the FreeBSD port to install 3.1.0. That
+#  stopped working in March 2026 due to libidn build errors.
+
+#        THE SOLUTION (2026)
+#  Delete all .qmail files with maildrop in them. Configure Sieve:
+#  https://github.com/msimerson/Mail-Toaster-6/discussions/556
 #
-# Environment Variables from qmail-local:
-#  SENDER    is  the envelope sender address
-#  NEWSENDER is the forwarding envelope sender address
-#  RECIPIENT is the envelope recipient address, local@domain
-#  USER  is user
-#  HOME  is your home directory
-#  HOST  is the domain part of the recipient address
-#  LOCAL is the local part
-#  EXT   is  the  address extension, ext.
-#  HOST2 is the portion of HOST preceding the last dot
-#  HOST3 is the portion of HOST preceding the second-to-last dot
-#  HOST4 is the portion of HOST preceding the third-to-last dot
-#  EXT2  is the portion of EXT following the first dash
-#  EXT3  is the portion following the second dash;
-#  EXT4  is the portion following the third dash.
-#  DEFAULT is  the  portion corresponding to the default part of the .qmail-... file name
-#  DEFAULT is not set if the file name does not end with default
-#  DTLINE  and  RPLINE are the usual Delivered-To and Return-Path lines, including newlines
-#
-# qmail-local will call maildrop. The exit codes that qmail-local understands are:
-#     0 - delivery is complete
-#   111 - temporary error
-#   xxx - unknown failure
-##
-#logfile "/var/log/mail/maildrop.log"
-log "$TIMESTAMP - BEGIN maildrop processing for $EXT@$HOST ==="
-
-# sysadmin blunders can cause EXT or HOST to be unset. 
-# test and make assure things are not too messed up.
-#
-# By exiting with error 111, the error will be logged, giving an admin
-# the chance to notice and fix the problem before the message bounces.
-
-if ( $EXT eq "" )
-{
-        log "  FAILURE: EXT is not a valid value"
-        log "=== END ===  $EXT@$HOST failure (EXT variable not imported)"
-        EXITCODE=111
-        exit
-}
-
-if ( $HOST eq "" )
-{
-        log "  FAILURE: HOST is not a valid value"
-        log "=== END ===  $EXT@$HOST failure (HOST variable not imported)"
-        EXITCODE=111
-        exit
-}
-
-##
-# Include user rules, for overrides of the the sitewide mailfilter
-#
-# this is also the "suggested" way to set individual values
-# for maildrop such as quota.
-##
-
-`test -r $VHOME/.mailfilter`
-if( $RETURNCODE == 0 )
-{
-        log "   including $VHOME/.mailfilter"
-        exception {
-                include $VHOME/.mailfilter
-        }
-}
-
-##
-# if it does not exist, create the maildirsize file 
-# (can also be done via "deliverquota user@dom.com 10MS,1000C)
-##
-
-`test -e $VHOME/Maildir/maildirsize`
-if( $RETURNCODE == 1)
-{
-        VUSERINFO="/usr/local/vpopmail/bin/vuserinfo"
-        `test -x $VUSERINFO`
-        if ( $RETURNCODE == 0)
-        {
-                log "   creating $VHOME/Maildir/maildirsize for quotas"
-                `$VUSERINFO -Q $EXT@$HOST`
-
-                `test -s "$VHOME/Maildir/maildirsize"`
-                if ( $RETURNCODE == 0 )
-                {
-                        `/usr/sbin/chown vpopmail:vchkpw $VHOME/Maildir/maildirsize`
-                                `/bin/chmod 640 $VHOME/Maildir/maildirsize`
-                }
-        }
-        else
-        {
-                log "   WARNING: cannot find vuserinfo! Please edit mailfilter"
-        }
-}
-
-##
-# Set MAILDIRQUOTA. If not set, maildrop and deliverquota
-# will not enforce quotas for message delivery.
-##
-
-`test -e $VHOME/Maildir/maildirsize`
-if( $RETURNCODE == 0)
-{
-        MAILDIRQUOTA=`/usr/bin/head -n1 $VHOME/Maildir/maildirsize`
-}
-
-# if the user does not have a Junk folder, create it.
-
-`test -d $VHOME/Maildir/.Junk`
-if( $RETURNCODE == 1 )
-{
-
-    MAILDIRMAKE="/usr/local/bin/maildirmake"
-    `test -x $MAILDIRMAKE`
-    if ( $RETURNCODE == 1 )
-    {
-        MAILDIRMAKE="/usr/local/bin/maildrop-maildirmake"
-        `test -x $MAILDIRMAKE`
-    }
-
-    if ( $RETURNCODE == 1 )
-    {
-        log "   WARNING: no maildirmake!"
-    }
-    else
-    {
-        log "   creating $VHOME/Maildir/.Junk "
-        `$MAILDIRMAKE -f Junk $VHOME/Maildir`
-    }
-}
-
-##
-# The message should be tagged, lets bag it.
-##
-# HAM:  X-Spam-Status: No, score=-2.6 required=5.0
-# SPAM: X-Spam-Status: Yes, score=8.9 required=5.0
-#
-# Note: SA < 3.0 uses "hits" instead of "score"
-#
-# if ( /^X-Spam-Status: *Yes/)  # test if spam status is yes
-# The following regexp matches any spam message and sets the
-# variable $MATCH2 to the spam score.
-
-if ( /X-Spam-Status: Yes/:h)
-{
-    if ( /X-Spam-Status: Yes, (hits|score)=([\d\.\-]+)\s/:h)
-    {
-        # if the message scored a 12 or higher, then there is no point in
-        # keeping it around. SpamAssassin already knows it as spam, and
-        # has already "autolearned" from it if you have that enabled. The
-        # end user likely does not want it. If you wanted to cc it, or
-        # deliver it elsewhere for inclusion in a spam corpus, you could
-        # easily do so with a cc or xfilter command
-
-        if ( $MATCH2 >= 12 )   # from Adam Senuik post to mail-toasters
-        {
-            log "   SPAM: score $MATCH2 exceeds 12: nuking message!"
-            log "=== END === $EXT@$HOST success (discarded)"
-            EXITCODE=0
-            exit
-        }
-        log "   SPAM: score $MATCH2: delivering to $VHOME/Maildir/.Junk"
-        log "=== END ===  $EXT@$HOST success"
-        exception {
-            to "$VHOME/Maildir/.Junk"
-        }
-    }
-    else
-    {
-        log "   SpamAssassin regexp match error!"
-    }
-}
-
-if ( /^X-Spam-Status: No, (score|hits)=([\d\.\-]+)\s/:h)
-{
-    log "   message is SA clean ($MATCH2)"
-}
-
-##
-# Include any other rules that the user might have from
-# sqwebmail or other compatible program
-##
-
-`test -r $VHOME/Maildir/.mailfilter`
-if( $RETURNCODE == 0 )
-{
-        log "   including $VHOME/Maildir/.mailfilter"
-        exception {
-                include $VHOME/Maildir/.mailfilter
-        }
-}
-
-`test -r $VHOME/Maildir/mailfilter`
-if( $RETURNCODE == 0 )
-{
-        log "   including $VHOME/Maildir/mailfilter"
-        exception {
-                include $VHOME/Maildir/mailfilter
-        }
-}
-
-log "   delivering to $VHOME/Maildir"
-
-# make sure the deliverquota binary exists and is executable
-# if not, then we cannot enforce quotas. If we do not check
-# and the binary is missing, maildrop silently discards mail.
-
-DELIVERQUOTA="/usr/local/bin/deliverquota"
-`test -x $DELIVERQUOTA`
-if ( $RETURNCODE == 1 )
-{
-    DELIVERQUOTA="/usr/local/bin/maildrop-deliverquota"
-    `test -x $DELIVERQUOTA`
-}
-
-if ( $RETURNCODE == 1 )
-{
-    log "   WARNING: no deliverquota!"
-    log "=== END ===  $EXT@$HOST success"
-    exception {
-        to "$VHOME/Maildir"
-    }
-}
-else
-{
-    exception {
-        xfilter "$DELIVERQUOTA -w 90 $VHOME/Maildir"
-    }
-
-    ##
-    # check to make sure the message was delivered
-    # returncode 77 means that the maildir was over quota - bounce mail
-    ##
-    if( $RETURNCODE == 77)
-    {
-        #log "   BOUNCED: bouncesaying '$EXT@$HOST is over quota'"
-        log "=== END ===  $EXT@$HOST  bounced"
-        to "|/var/qmail/bin/bouncesaying '$EXT@$HOST is over quota'"
-    }
-    else
-    {
-        log "=== END ===  $EXT@$HOST  success (quota)"
-        EXITCODE=0
-        exit
-    }
-}
-
-log "WARNING: This message should never be printed!"
+#  hint: find /data/vpopmail/home/domains -name .qmail -type f -exec grep -H maildrop {} \;

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -82,7 +82,7 @@ setup() {
 }
 
 @test "add_jail_conf" {
-  JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
   dec_to_hex() {
     if [ "$1" -eq 3 ]; then echo "3"; fi
   }
@@ -94,7 +94,7 @@ setup() {
 
   # Mock grep to not find jail.conf
   grep() { return 1; }
-  get_public_ip() { :; }
+  get_public_ip() { export PUBLIC_IP6="2001:db8::1"; }
   store_config() {
     cat -
   }
@@ -103,13 +103,13 @@ setup() {
   assert_success
   assert_output --partial "mysql	{"
   assert_output --partial "ip4.addr = lo1|172.16.15.3;"
+  assert_output --partial "ip6.addr = lo1|fd7a:e5cd:1fc1:c597:3;"
 }
 
 @test "add_jail_conf_d" {
   export JAIL_NET6="fd7a:e5cd:1fc1:c597"
-  export PUBLIC_IP6="fd7a:e5cd:1fc1:c597"
   dec_to_hex() { if [ "$1" -eq 3 ]; then echo "3"; fi; }
-  get_public_ip() { :; }
+  get_public_ip() { export PUBLIC_IP6="2001:db8::1"; }
   store_config() {
     cat -
   }

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -1,0 +1,122 @@
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  # Mock variables
+  export JAIL_NET_PREFIX="172.16.15"
+  export JAIL_NET_INTERFACE="lo1"
+  export JAIL_NET_START=1
+  export JAIL_ORDERED_LIST="syslog dns mysql"
+  export ZFS_JAIL_MNT="/jails"
+  export BASE_MNT="/jails/base-13.2-RELEASE"
+
+  # Source the file under test
+  load '../../include/jail.sh'
+  load '../../include/util.sh'
+  load '../../include/network.sh'
+}
+
+@test "safe_jailname - replaces dots" {
+  run safe_jailname "my.jail"
+  assert_output "my_jail"
+}
+
+@test "safe_jailname - replaces dashes" {
+  run safe_jailname "my-jail"
+  assert_output "my_jail"
+}
+
+@test "get_jail_ip - syslog" {
+  run get_jail_ip syslog
+  assert_output "172.16.15.1"
+}
+
+@test "get_jail_ip - dns" {
+  run get_jail_ip dns
+  assert_output "172.16.15.2"
+}
+
+@test "get_jail_ip - mysql" {
+  run get_jail_ip mysql
+  assert_output "172.16.15.3"
+}
+
+@test "jail_is_running - yes" {
+  jls() {
+    echo "myjail"
+  }
+  run jail_is_running myjail
+  assert_success
+}
+
+@test "jail_is_running - no" {
+  jls() { return 1; }
+  run jail_is_running myjail
+  assert_failure
+}
+
+@test "jail_conf_header - dns" {
+  run jail_conf_header dns
+  assert_output --partial "path = \"/jails/dns\";"
+  assert_output --partial "interface = lo1;"
+}
+
+@test "jail_conf_header - base" {
+  run jail_conf_header base
+  assert_output --partial "path = \"/jails/base-13.2-RELEASE\";"
+}
+
+@test "get_reverse_ip" {
+  run get_reverse_ip mysql
+  assert_output "3.15.16.172.in-addr.arpa"
+}
+
+@test "get_reverse_ip6" {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() {
+    if [ "$1" -eq 3 ]; then echo "3"; fi
+  }
+  run get_reverse_ip6 mysql
+  assert_output "3.7.9.5.c.1.c.f.1.d.c.5.e.a.7.d.f.ip6.arpa"
+}
+
+@test "add_jail_conf" {
+  JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() {
+    if [ "$1" -eq 3 ]; then echo "3"; fi
+  }
+
+  # Mock tee to capture output
+  tee() {
+    cat -
+  }
+
+  # Mock grep to not find jail.conf
+  grep() { return 1; }
+  get_public_ip() { :; }
+  store_config() {
+    cat -
+  }
+
+  run add_jail_conf mysql
+  assert_success
+  assert_output --partial "mysql	{"
+  assert_output --partial "ip4.addr = lo1|172.16.15.3;"
+}
+
+@test "add_jail_conf_d" {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  export PUBLIC_IP6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() { if [ "$1" -eq 3 ]; then echo "3"; fi; }
+  get_public_ip() { :; }
+  store_config() {
+    cat -
+  }
+
+  run add_jail_conf_d mysql
+  assert_success
+  assert_output --partial "ip6.addr = lo1|fd7a:e5cd:1fc1:c597:3;"
+}
+
+

--- a/test/include/mysql.bats
+++ b/test/include/mysql.bats
@@ -1,0 +1,87 @@
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  # Mock some variables that are normally set by mail-toaster.sh
+  export ZFS_JAIL_MNT="/jails"
+  export TOASTER_MYSQL_PASS="secret"
+
+  # Source the file under test
+  load '../../include/mysql.sh'
+}
+
+# Mock jexec since it's a FreeBSD-specific command
+jexec() {
+  local _input
+  read -r _input
+  if [[ "$_input" == *"SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='testdb';"* ]]; then
+    echo "testdb"
+  fi
+}
+
+@test "mysql_password_set - with .my.cnf" {
+  # Mock _root for this test
+  local _tmp_root=$(mktemp -d)
+  _root="$_tmp_root"
+  touch "$_root/.my.cnf"
+  echo "password = some_pass" > "$_root/.my.cnf"
+
+  run mysql_password_set
+  assert_success
+
+  rm -rf "$_tmp_root"
+}
+
+@test "mysql_password_set - without .my.cnf" {
+  local _tmp_root=$(mktemp -d)
+  _root="$_tmp_root"
+
+  run mysql_password_set
+  assert_failure
+
+  rm -rf "$_tmp_root"
+}
+
+@test "mysql_bin - with password set" {
+  # Mock mysql_password_set to return 0
+  mysql_password_set() { return 0; }
+
+  run mysql_bin
+  assert_output "/usr/local/bin/mysql"
+}
+
+@test "mysql_bin - with TOASTER_MYSQL_PASS" {
+  mysql_password_set() { return 1; }
+  export TOASTER_MYSQL_PASS="mypass"
+
+  run mysql_bin
+  assert_output '/usr/local/bin/mysql --password="mypass"'
+}
+
+@test "mysql_db_exists - exists" {
+  mysql_bin() { echo "mysql"; }
+  # Mock jexec to return something when checked
+  jexec() {
+    local _input; read -r _input
+    if [[ "$_input" == *"SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='testdb';"* ]]; then
+      echo "testdb"
+    fi
+  }
+
+  run mysql_db_exists testdb
+  assert_success
+  assert_output --partial "testdb db exists"
+}
+
+@test "mysql_db_exists - does not exist" {
+  mysql_bin() { echo "mysql"; }
+  jexec() {
+    local _input; read -r _input
+    echo ""
+  }
+
+  run mysql_db_exists testdb
+  assert_failure
+  assert_output --partial "testdb db does not exist"
+}

--- a/test/include/mysql.bats
+++ b/test/include/mysql.bats
@@ -85,3 +85,62 @@ jexec() {
   assert_failure
   assert_output --partial "testdb db does not exist"
 }
+
+@test "mysql_query - with db" {
+  mysql_bin() { echo "mysql"; }
+  jexec() {
+    echo "jexec called with $*"
+  }
+
+  run mysql_query testdb
+  assert_success
+  assert_output --partial "db: testdb"
+  assert_output --partial "jexec called with mysql mysql testdb"
+}
+
+@test "mysql_create_db - exists" {
+  mysql_db_exists() { return 0; }
+  tell_status() { echo "tell_status: $*"; }
+
+  run mysql_create_db testdb
+  assert_success
+  assert_output --partial "tell_status: testdb db exists in mysql"
+}
+
+@test "mysql_create_db - create" {
+  mysql_db_exists() { return 1; }
+  tell_status() { echo "tell_status: $*"; }
+  mysql_query() {
+    local _input; read -r _input
+    echo "mysql_query got: $_input"
+  }
+
+  run mysql_create_db testdb
+  assert_success
+  assert_output --partial "tell_status: creating mysql database testdb"
+  assert_output --partial "mysql_query got: CREATE DATABASE testdb"
+}
+
+@test "mysql_user_exists - exists" {
+  mysql_bin() { echo "mysql"; }
+  jexec() {
+    local _input; read -r _input
+    echo "user_record"
+  }
+
+  run mysql_user_exists user host
+  assert_success
+  assert_output --partial "user user exists"
+}
+
+@test "mysql_user_exists - does not exist" {
+  mysql_bin() { echo "mysql"; }
+  jexec() {
+    local _input; read -r _input
+    echo ""
+  }
+
+  run mysql_user_exists user host
+  assert_failure
+  assert_output --partial "user user does not exist"
+}

--- a/test/include/net.bats
+++ b/test/include/net.bats
@@ -1,0 +1,9 @@
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+  export MT6_TEST_ENV=1
+  #load ../../mail-toaster.sh
+  load ../../include/net.sh
+}
+

--- a/test/include/shell.bats
+++ b/test/include/shell.bats
@@ -1,0 +1,60 @@
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  # Mock variables
+  export TOASTER_EDITOR="vim"
+  export STAGE_MNT="/stage"
+
+  # Source the file under test
+  load '../../include/shell.sh'
+}
+
+# Mock helper functions from mail-toaster.sh
+tell_status() { :; }
+stage_pkg_install() { :; }
+stage_exec() { :; }
+
+@test "install_bash - basic" {
+  stage_pkg_install() { echo "pkg install $*"; }
+  stage_exec() { echo "exec $*"; }
+  configure_bash() { echo "configure_bash $*"; }
+  
+  # Mock file checks
+  test() {
+    if [[ "$2" == *"/usr/local/etc/profile" ]]; then return 1; fi
+    if [[ "$2" == *"/root/.bash_profile" ]]; then return 1; fi
+    # fall back to real test for other things
+    command test "$@"
+  }
+
+  run install_bash "/stage"
+  assert_success
+  assert_output --partial "pkg install bash"
+  assert_output --partial "exec chpass -s /usr/local/bin/bash"
+  assert_output --partial "configure_bash /stage"
+}
+
+@test "configure_bourne_shell - basic" {
+  # Mock grep to not find PS1
+  grep() { return 1; }
+  
+  # Mock cat to avoid writing to real files
+  # In bats, we can use a temporary directory
+  local _tmp=$(mktemp -d)
+  mkdir -p "$_tmp/etc/profile.d"
+  mkdir -p "$_tmp/root"
+  touch "$_tmp/root/.profile"
+  
+  run configure_bourne_shell "$_tmp"
+  assert_success
+  
+  # Check if the file was created with correct content
+  [ -f "$_tmp/etc/profile.d/toaster.sh" ]
+  run cat "$_tmp/etc/profile.d/toaster.sh"
+  assert_output --partial "export EDITOR=\"vim\""
+  assert_output --partial "PS1="
+  
+  rm -rf "$_tmp"
+}

--- a/test/include/util.bats
+++ b/test/include/util.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+  load '../../include/util.sh'
+}
+
+@test "dec_to_hex" {
+  run dec_to_hex 255
+  assert_output "00ff"
+}
+
+@test "store_config - new file" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/new_file"
+
+  tell_status() { :; }
+
+  echo "hello" | store_config "$tmpfile"
+
+  run cat "$tmpfile"
+  assert_output "hello"
+
+  rm -rf "$tmpdir"
+}
+
+@test "store_config - preserve existing" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/new_file"
+  echo "original" > "$tmpfile"
+
+  tell_status() { :; }
+
+  echo "new" | store_config "$tmpfile"
+
+  run cat "$tmpfile"
+  assert_output "original"
+
+  rm -rf "$tmpdir"
+}
+
+@test "get_random_pass - length" {
+  run get_random_pass 20
+  assert_success
+  [ "${#output}" -eq 20 ]
+}
+
+@test "reverse_list" {
+  run reverse_list one two three
+  assert_output "three two one "
+}

--- a/test/include/vpopmail.bats
+++ b/test/include/vpopmail.bats
@@ -1,0 +1,100 @@
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  # Mock variables
+  export TOASTER_MYSQL="1"
+  export TOASTER_MARIADB="0"
+  export TOASTER_VPOPMAIL_EXT="1"
+  export TOASTER_VPOPMAIL_CLEAR="1"
+  export ZFS_DATA_MNT="/data"
+  export ZFS_JAIL_MNT="/jails"
+  export STAGE_MNT="/stage"
+
+  # Source the file under test
+  load '../../include/vpopmail.sh'
+}
+
+# Mock helper functions from mail-toaster.sh
+tell_status() { :; }
+stage_pkg_install() { :; }
+stage_exec() { :; }
+stage_make_conf() { :; }
+
+@test "install_vpopmail_deps - mysql enabled" {
+  export TOASTER_MYSQL="1"
+  export TOASTER_MARIADB="0"
+
+  # We want to check if stage_pkg_install is called with the right arguments
+  stage_pkg_install() {
+    echo "pkg install $*"
+  }
+
+  run install_vpopmail_deps
+  assert_success
+  assert_output --partial "pkg install gmake gettext ucspi-tcp netqmail fakeroot mysql80-client"
+}
+
+@test "install_vpopmail_deps - mariadb enabled" {
+  export TOASTER_MYSQL="1"
+  export TOASTER_MARIADB="1"
+
+  stage_pkg_install() {
+    echo "pkg install $*"
+  }
+
+  run install_vpopmail_deps
+  assert_success
+  assert_output --partial "pkg install gmake gettext ucspi-tcp netqmail fakeroot mariadb104-client"
+}
+
+@test "install_vpopmail_port - default options" {
+  export TOASTER_MYSQL="1"
+  export TOASTER_VPOPMAIL_EXT="1"
+  export TOASTER_VPOPMAIL_CLEAR="1"
+
+  # Mock stage_make_conf to capture arguments
+  stage_make_conf() {
+    echo "make_conf $1 $2"
+  }
+  # Mock other commands to avoid failure
+  grep() {
+    if [[ "$*" == *"/usr/ports/mail/vpopmail/Makefile" ]]; then return 0; fi # assume already patched
+    return 1;
+  }
+  tee() { :; }
+  stage_pkg_install() { :; }
+  stage_exec() { :; }
+
+  run install_vpopmail_port
+  assert_success
+  assert_output --partial "make_conf mail_vpopmail_"
+  assert_output --partial "mail_vpopmail_SET= MYSQL VALIAS QMAIL_EXT CLEAR_PASSWD"
+  assert_output --partial "mail_vpopmail_UNSET= CDB"
+}
+
+@test "install_qmail - basic" {
+  export TOASTER_HOSTNAME="mail.example.com"
+  
+  stage_pkg_install() {
+    echo "pkg install $*"
+  }
+  stage_exec() {
+    echo "exec $*"
+  }
+  stage_make_conf() {
+    echo "make_conf $1 $2"
+  }
+  
+  # Mocking directory operations and file checks
+  mkdir() { :; }
+  rm() { :; }
+  grep() { return 1; }
+  
+  run install_qmail
+  assert_success
+  assert_output --partial "pkg install netqmail daemontools ucspi-tcp"
+  assert_output --partial "exec ln -s /usr/local/vpopmail/qmail-control /var/qmail/control"
+  assert_output --partial "make_conf mail_qmail_"
+}

--- a/test/include/vpopmail.bats
+++ b/test/include/vpopmail.bats
@@ -76,7 +76,7 @@ stage_make_conf() { :; }
 
 @test "install_qmail - basic" {
   export TOASTER_HOSTNAME="mail.example.com"
-  
+
   stage_pkg_install() {
     echo "pkg install $*"
   }
@@ -86,15 +86,34 @@ stage_make_conf() { :; }
   stage_make_conf() {
     echo "make_conf $1 $2"
   }
-  
+
   # Mocking directory operations and file checks
   mkdir() { :; }
   rm() { :; }
   grep() { return 1; }
-  
+
   run install_qmail
   assert_success
   assert_output --partial "pkg install netqmail daemontools ucspi-tcp"
   assert_output --partial "exec ln -s /usr/local/vpopmail/qmail-control /var/qmail/control"
   assert_output --partial "make_conf mail_qmail_"
+}
+
+@test "install_vpopmail_source" {
+  export TOASTER_MYSQL="1"
+  export TOASTER_VPOPMAIL_EXT="1"
+  export TOASTER_VPOPMAIL_CLEAR="1"
+
+  stage_pkg_install() { echo "pkg install $*"; }
+  stage_exec() { echo "exec $*"; }
+
+  # Mock git and directory operations
+  git() { echo "git $*"; }
+  mkdir() { :; }
+
+  run install_vpopmail_source
+  assert_success
+  assert_output --partial "pkg install automake"
+  assert_output --partial "git clone https://github.com/brunonymous/vpopmail.git"
+  assert_output --partial "exec sh -c cd /data/src/vpopmail; CFLAGS=\"-fcommon\" ./configure --disable-users-big-dir --enable-logging=y --enable-md5-passwords --disable-sha512-passwords --enable-auth-module=mysql --enable-valias --enable-sql-aliasdomains --enable-qmail-ext --enable-clear-passwd"
 }

--- a/test/include/zfs.bats
+++ b/test/include/zfs.bats
@@ -54,8 +54,56 @@ tell_status() { :; }
     if [[ "$1" == "list" ]]; then return 1; fi
     echo "zfs $*"
   }
-  
+
   run zfs_create_fs myfs /mnt/myfs
   assert_success
   assert_output --partial "zfs create -o mountpoint=/mnt/myfs myfs"
+}
+
+@test "zfs_snapshot_exists - exists" {
+  zfs() {
+    if [[ "$*" == "list -t snapshot mysnap" ]]; then
+      echo "mysnap"
+      return 0
+    fi
+    return 1
+  }
+  run zfs_snapshot_exists mysnap
+  assert_success
+  assert_output --partial "mysnap snapshot exists"
+}
+
+@test "zfs_snapshot_exists - does not exist" {
+  zfs() { return 1; }
+  run zfs_snapshot_exists mysnap
+  assert_failure
+}
+
+@test "zfs_destroy_fs - exists" {
+  zfs() {
+    if [[ "$*" == "list -t filesystem myfs" ]]; then
+      echo "myfs"
+      return 0
+    fi
+    echo "zfs $*"
+  }
+  run zfs_destroy_fs myfs
+  assert_success
+  assert_output --partial "zfs destroy myfs"
+}
+
+@test "zfs_destroy_fs - does not exist" {
+  zfs() { return 1; }
+  run zfs_destroy_fs myfs
+  assert_success
+  refute_output --partial "zfs destroy myfs"
+}
+
+@test "rename_ready_to_active" {
+  zfs() {
+    echo "zfs $*"
+  }
+  run rename_ready_to_active myjail
+  assert_success
+  assert_output --partial "zfs rename zroot/jails/myjail.ready zroot/jails/myjail"
 }

--- a/test/include/zfs.bats
+++ b/test/include/zfs.bats
@@ -1,0 +1,61 @@
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  # Mock variables
+  export ZFS_JAIL_VOL="zroot/jails"
+  export ZFS_DATA_VOL="zroot/data"
+  export ZFS_JAIL_MNT="/jails"
+  export ZFS_DATA_MNT="/data"
+
+  # Source the file under test
+  load '../../include/zfs.sh'
+}
+
+# Mock tell_status
+tell_status() { :; }
+
+@test "zfs_filesystem_exists - exists" {
+  zfs() {
+    if [[ "$*" == "list -t filesystem myfs" ]]; then
+      echo "myfs"
+      return 0
+    fi
+    return 1
+  }
+  
+  run zfs_filesystem_exists myfs
+  assert_success
+}
+
+@test "zfs_filesystem_exists - does not exist" {
+  zfs() { return 1; }
+  
+  run zfs_filesystem_exists myfs
+  assert_failure
+}
+
+@test "zfs_create_fs - simple" {
+  # Mock zfs to track calls
+  zfs() {
+    # If it's a list call, we want it to fail to simulate FS/mountpoint not existing
+    if [[ "$1" == "list" ]]; then return 1; fi
+    echo "zfs $*"
+  }
+  
+  run zfs_create_fs myfs
+  assert_success
+  assert_output --partial "zfs create myfs"
+}
+
+@test "zfs_create_fs - with mountpoint" {
+  zfs() {
+    if [[ "$1" == "list" ]]; then return 1; fi
+    echo "zfs $*"
+  }
+  
+  run zfs_create_fs myfs /mnt/myfs
+  assert_success
+  assert_output --partial "zfs create -o mountpoint=/mnt/myfs myfs"
+}

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -87,3 +87,93 @@ setup() {
   assert_success
   assert_output "172.16.15.9"
 }
+
+@test "fstab_add_mount" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  export ZFS_DATA_MNT="$tmpdir"
+  mkdir -p "$tmpdir/myjail/etc"
+  local fstab="$tmpdir/myjail/etc/fstab"
+  touch "$fstab" "${fstab}.stage"
+
+  # Mock tell_status
+  tell_status() { :; }
+
+  run fstab_add_mount myjail /src /dest
+  assert_success
+
+  run grep "/src" "$fstab"
+  assert_success
+  assert_output --partial "/dest"
+
+  run grep "/src" "${fstab}.stage"
+  assert_success
+
+  rm -rf "$tmpdir"
+}
+
+@test "stage_sysrc" {
+  export STAGE_MNT=$(mktemp -d)
+  # Mock sysrc
+  sysrc() {
+    echo "sysrc called with $*"
+  }
+
+  run stage_sysrc myvar=value
+  assert_success
+  assert_output --partial "sysrc -R $STAGE_MNT myvar=value"
+
+  rm -rf "$STAGE_MNT"
+}
+
+@test "stage_make_conf - new setting" {
+  export STAGE_MNT=$(mktemp -d)
+  mkdir -p "$STAGE_MNT/etc"
+  local make_conf="$STAGE_MNT/etc/make.conf"
+  touch "$make_conf"
+
+  tell_status() { :; }
+
+  run stage_make_conf MY_VAR "MY_VAR=val"
+  assert_success
+
+  run cat "$make_conf"
+  assert_output "MY_VAR=val"
+
+  rm -rf "$STAGE_MNT"
+}
+
+@test "stage_make_conf - existing setting" {
+  export STAGE_MNT=$(mktemp -d)
+  mkdir -p "$STAGE_MNT/etc"
+  local make_conf="$STAGE_MNT/etc/make.conf"
+  echo "MY_VAR=old" > "$make_conf"
+
+  run stage_make_conf MY_VAR "MY_VAR=new"
+  assert_success
+  assert_output --partial "preserving make.conf settings"
+
+  run cat "$make_conf"
+  assert_output "MY_VAR=old"
+
+  rm -rf "$STAGE_MNT"
+}
+
+@test "stage_resolv_conf" {
+  export STAGE_MNT=$(mktemp -d)
+  mkdir -p "$STAGE_MNT/etc"
+
+  # Mock jail_is_running and get_jail_ip
+  jail_is_running() { return 0; }
+  get_jail_ip() { echo "1.2.3.4"; }
+  get_jail_ip6() { echo "fe80::1"; }
+  tell_status() { :; }
+
+  run stage_resolv_conf
+  assert_success
+
+  run cat "$STAGE_MNT/etc/resolv.conf"
+  assert_output --partial "nameserver 1.2.3.4"
+  assert_output --partial "nameserver fe80::1"
+
+  rm -rf "$STAGE_MNT"
+}

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -3,25 +3,16 @@
 setup() {
   load 'test_helper/bats-support/load'
   load 'test_helper/bats-assert/load'
+  export MT6_TEST_ENV=1
   load ../mail-toaster.sh
-}
-
-@test "mt6_version" {
-  run mt6_version
-  assert_success
-  assert_output --partial "2026"
-}
-
-@test "mt6_version_check" {
-  run mt6_version_check
-  #[ "$status" -eq 0 ]
-  assert_success
-}
-
-@test "dec_to_hex" {
-  run dec_to_hex 10
-  assert_success
-  assert_output "000a"
+  # Manually load includes that mt6_init would have loaded
+  load ../include/util.sh
+  load ../include/config.sh
+  load ../include/zfs.sh
+  load ../include/jail.sh
+  load ../include/network.sh
+  # Initialize defaults that mt6_init would have set
+  mt6_defaults
 }
 
 @test "safe_jailname replaces . with _" {

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ -n "$1" ]; then
+    bats "$1"
+    exit
+fi
+
 echo "shellcheck *.sh"
 shellcheck ./*.sh
 


### PR DESCRIPTION
- feat(haraka): enable LMTP to dovecot for new installs
- feat(fstab_add_mount): added
- feat(test/run.sh): run a single script
- fix(mailfilter): remove most of it, so maildrop sometimes works
- change(NTP): switch default server to chrony
- change(spamassassin): updated TxRep/AWL/userpref SQL
  - enable build options for DMARC & RELAY_COUNTRY
  - inline SQL for tables, no longer installed
- change(snappymail): php8.2 -> 8.3
- maildrop: install from package (TODO: test)
- refactoring mail-toaster.sh into test covered modules
  - config, jail, network, util, zfs
- test: added more tests to other modules
