### PR TITLE
postfix: Remove nonexistant lmtpd_tls_security_level

### DIFF
--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -60,7 +60,6 @@ configure_postfix_main_cf()
 	stage_exec postconf -e 'smtpd_tls_security_level = may'
 	stage_exec postconf -e 'smtpd_tls_auth_only = yes'
 	stage_exec postconf -e 'lmtp_tls_security_level = may'
-	stage_exec postconf -e 'lmtpd_tls_security_level = may'
 	stage_exec postconf -e "mynetworks = ${JAIL_NET_PREFIX}.0${JAIL_NET_MASK}"
 
 	if [ -f "$ZFS_DATA_MNT/postfix/etc/sasl_passwd" ]; then


### PR DESCRIPTION
Removed nonexistant `lmtpd_tls_security_level` setting.

### Changes proposed in this pull request:
- Remove nonexistant `lmtpd_tls_security_level` setting.

This is harmless, but noisy:
```
/usr/local/sbin/postconf: warning: /data/etc/main.cf: unused parameter: lmtpd_tls_security_level=may
```
