### PR TITLE
redis: create /var/run/redis when TOASTER_USE_TMPFS=1

### DIFF
--- a/provision/redis.sh
+++ b/provision/redis.sh
@@ -12,6 +12,14 @@ install_redis()
 {
 	tell_status "installing redis"
 	stage_pkg_install redis || exit
+
+	if [ "$TOASTER_USE_TMPFS" = 1 ]; then
+		store_config "$STAGE_MNT/etc/rc.local" "append" <<EO_RC_LOCAL
+mkdir -p /var/run/redis
+chown redis:redis /var/run/redis
+EO_RC_LOCAL
+		stage_exec service local start
+	fi
 }
 
 configure_redis()


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add an rc.local script to create /var/run/redis when /var/run is on tmpfs.
