### PR TITLE
[fix] mt, dcc, dovecot, postfix: Remount tmpfs /tmp without noexec while building ports

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -321,6 +321,13 @@ start_staged_jail()
 	pkg -j stage update
 }
 
+stage_remount_tmp_exec() {
+	if [ "$TOASTER_USE_TMPFS" = 1 ]; then
+		umount $STAGE_MNT/tmp  # some ports needs exec while building
+		mount -t tmpfs -o rw,mode=01777,nosuid tmpfs $STAGE_MNT/tmp
+	fi
+}
+
 tell_settings()
 {
 	echo; echo "   ***   Configured $1 settings:   ***"; echo

--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -118,6 +118,7 @@ base_snapshot_exists || exit 1
 create_staged_fs dcc
 preflight
 start_staged_jail dcc
+stage_remount_tmp_exec
 install_dcc
 configure_dcc
 start_dcc

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -651,6 +651,7 @@ base_snapshot_exists || exit
 create_staged_fs dovecot
 mkdir -p "$STAGE_MNT/usr/local/vpopmail"
 start_staged_jail dovecot
+stage_remount_tmp_exec
 allow_sysvipc_stage
 install_dovecot
 configure_dovecot

--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -150,6 +150,7 @@ test_postfix()
 base_snapshot_exists || exit 1
 create_staged_fs postfix
 start_staged_jail postfix
+stage_remount_tmp_exec
 install_postfix
 configure_postfix
 start_postfix


### PR DESCRIPTION
### Changes proposed in this pull request:
- Some ports require /tmp to be mounted without noexec while building. Temporarily remount tmpfs-based /tmp in these cases.
