### PR TITLE
Tests

### DIFF
--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -253,7 +253,7 @@ fstab_add_mount() {
 
 create_staged_fs()
 {
-	cleanup_staged_fs "$1"
+	cleanup_staged_fs
 
 	tell_status "stage jail filesystem setup"
 	echo "zfs clone $BASE_SNAP $ZFS_JAIL_VOL/stage"

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -169,7 +169,10 @@ sed_inplace() {
 
 stage_unmount()
 {
-	for _fs in $(mount | awk -v re="^$STAGE_MNT/" '$3 ~ re { print $3 }' | sort -ru); do
+	# an empty STAGE_MNT would match every mountpoint on the host
+	[ -n "$STAGE_MNT" ] || fatal_err "stage_unmount: STAGE_MNT is unset"
+
+	for _fs in $(mount | awk -v p="$STAGE_MNT/" 'index($3, p) == 1 { print $3 }' | sort -ru); do
 		echo "umount $_fs"
 		umount "$_fs"
 	done
@@ -179,7 +182,7 @@ cleanup_staged_fs()
 {
 	tell_status "stage cleanup"
 	stop_jail stage
-	stage_unmount "$1"
+	stage_unmount
 	zfs_destroy_fs "$ZFS_JAIL_VOL/stage" -f
 }
 
@@ -355,7 +358,7 @@ promote_staged_jail()
 	tell_status "promoting jail $1"
 	stop_jail stage
 	stage_clear_caches
-	stage_unmount "$1"
+	stage_unmount
 	ipcrm -W
 
 	rename_staged_to_ready "$1"

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -327,3 +327,72 @@ setup() {
 
   rm -rf "$tmpdir"
 }
+
+# stage_unmount test fixtures: 'mount' and 'umount' are stubbed so the pipeline
+# can be exercised off FreeBSD. unmounted_paths echoes only what got unmounted,
+# in the order stage_unmount tried it.
+fake_mount() {
+  mount() {
+    cat <<EOF
+$ZFS_JAIL_VOL/stage on $STAGE_MNT (zfs, local, nfsv4acls)
+devfs on $STAGE_MNT/dev (devfs)
+$ZFS_DATA_MNT/ports on $STAGE_MNT/usr/ports (nullfs, local)
+$ZFS_DATA_MNT/distfiles on $STAGE_MNT/usr/ports/distfiles (nullfs, local)
+tmpfs on $STAGE_MNT/tmp (tmpfs, local)
+$ZFS_DATA_MNT/other on ${STAGE_MNT}-other/data (nullfs, local)
+$ZFS_DATA_MNT/dovecot on $ZFS_JAIL_MNT/dovecot/stagefiles (nullfs, local)
+EOF
+  }
+  umount() { :; }
+}
+
+unmounted_paths() {
+  stage_unmount | awk '/^umount /{ print $2 }'
+}
+
+@test "stage_unmount unmounts nested mounts before their parents" {
+  fake_mount
+  run unmounted_paths
+  assert_success
+  assert_line --index 0 "$STAGE_MNT/usr/ports/distfiles"
+  assert_line --index 1 "$STAGE_MNT/usr/ports"
+}
+
+@test "stage_unmount unmounts each mountpoint once" {
+  fake_mount
+  run unmounted_paths
+  assert_success
+  assert_equal "${#lines[@]}" 4
+}
+
+@test "stage_unmount unmounts the stage devfs" {
+  fake_mount
+  run unmounted_paths
+  assert_success
+  assert_line "$STAGE_MNT/dev"
+}
+
+@test "stage_unmount leaves the stage root mounted" {
+  fake_mount
+  run unmounted_paths
+  assert_success
+  refute_line "$STAGE_MNT"
+}
+
+@test "stage_unmount ignores mounts outside the stage" {
+  fake_mount
+  run unmounted_paths
+  assert_success
+  # 'stage' as a substring elsewhere in the mount line is not a stage mount
+  refute_line "${STAGE_MNT}-other/data"
+  refute_line "$ZFS_JAIL_MNT/dovecot/stagefiles"
+}
+
+@test "stage_unmount refuses to run with STAGE_MNT unset" {
+  fake_mount
+  STAGE_MNT=
+  run stage_unmount
+  assert_failure
+  assert_output --partial "STAGE_MNT is unset"
+  refute_output --partial "umount /"
+}


### PR DESCRIPTION
- mt.sh: STAGE_MNT guard + literal prefix match via index() 
- mt.sh: remove dead args when calling stage_unmount
- test/mt.bats:330 — six stage_unmount tests
- mt: remove dead arg to cleanup_staged_fs
