### PR TITLE
postfix: smtps has been renamed to submissions

### DIFF
--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -185,7 +185,7 @@ configure_postfix_master_cf()
 		tell_status "preserving $_master_cf"
 	else
 		tell_status "installing $_master_cf"
-		stage_exec install -m 0644 /usr/local/etc/postfix/master.cf /data/etc/master.cf
+		install -m 0644 "$STAGE_MNT/usr/local/etc/postfix/master.cf" "$_master_cf"
 
 		if [ "$TOASTER_MSA" = "postfix" ]; then
 			enable_postfix_submission "$_master_cf"

--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -170,9 +170,9 @@ enable_postfix_submission()
 {
 	local _master_cf="$1"
 
-	tell_status "enabling postfix submission and smtps services"
+	tell_status "enabling postfix submission and submissions/smtps services"
 	awk '
-		/^#(submission|smtps)[[:space:]]/ { sub(/^#/, ""); in_block = 1; print; next }
+		/^#(submission|submissions|smtps)[[:space:]]/ { sub(/^#/, ""); in_block = 1; print; next }
 		in_block && /^#[[:space:]]/       { sub(/^#/, ""); print; next }
 		{ in_block = 0; print }
 	' "$_master_cf" > "$_master_cf.tmp" && mv "$_master_cf.tmp" "$_master_cf"
@@ -186,10 +186,10 @@ configure_postfix_master_cf()
 	else
 		tell_status "installing $_master_cf"
 		stage_exec install -m 0644 /usr/local/etc/postfix/master.cf /data/etc/master.cf
-	fi
 
-	if [ "$TOASTER_MSA" = "postfix" ]; then
-		enable_postfix_submission "$_master_cf"
+		if [ "$TOASTER_MSA" = "postfix" ]; then
+			enable_postfix_submission "$_master_cf"
+		fi
 	fi
 }
 

--- a/test/provision/postfix.bats
+++ b/test/provision/postfix.bats
@@ -78,6 +78,8 @@ teardown() {
 
 @test "configure_postfix_master_cf enables submission when TOASTER_MSA=postfix" {
   export TOASTER_MSA="postfix"
+  mkdir -p "$STAGE_MNT/usr/local/etc/postfix"
+  mv "$MASTER_CF" "$STAGE_MNT/usr/local/etc/postfix"
   configure_postfix_master_cf
 
   run cat "$MASTER_CF"
@@ -87,6 +89,8 @@ teardown() {
 
 @test "configure_postfix_master_cf leaves submission disabled when TOASTER_MSA=haraka" {
   export TOASTER_MSA="haraka"
+  mkdir -p "$STAGE_MNT/usr/local/etc/postfix"
+  mv "$MASTER_CF" "$STAGE_MNT/usr/local/etc/postfix"
   configure_postfix_master_cf
 
   run cat "$MASTER_CF"


### PR DESCRIPTION
### Changes proposed in this pull request:
- Since Postfix 3.7, smtps has been renamed to submissions. Uncomment this entry properly. 
- Do it only on fresh install, don't edit user's master.cf.
