### PR TITLE
rspamd: Use TOASTER_MSA for SMTP DMARC reports instead of hardcoded haraka

### DIFF
--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -83,7 +83,7 @@ configure_dmarc()
 		email = "$TOASTER_ADMIN_EMAIL";
 		# uncomment this when the reports are working
 		override_address = "$TOASTER_ADMIN_EMAIL";
-		smtp = "$(get_jail_ip haraka)";
+		smtp = "$(get_jail_ip "$TOASTER_MTA")";
 	}
 EO_DMARC
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
- rspamd: Use TOASTER_MSA for SMTP DMARC reports instead of hardcoded haraka.