### PR TITLE
include/mta: enable_dma: restore SMARTHOST $TOASTER_MSA changed to vpopmail earlier

### DIFF
--- a/include/mta.sh
+++ b/include/mta.sh
@@ -114,7 +114,7 @@ EO_MAILER_CONF
 	tell_status "configuring dma"
 	echo "editing $_base/etc/dma/dma.conf"
 	tee "$_base/etc/dma/dma.conf" <<EO_DMA_CONF
-SMARTHOST vpopmail
+SMARTHOST $TOASTER_MSA
 MAILNAME $TOASTER_HOSTNAME
 NULLCLIENT
 EO_DMA_CONF


### PR DESCRIPTION
### Changes proposed in this pull request:
- It's just a proposal, I am not sure about your reasons for this change as I don't use vpopmail.
