### PR TITLE
[fix] postfix: edit the correct main.cf

### DIFF
--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -80,6 +80,8 @@ EO_TRUSTED_HOSTS
 configure_postfix_main_cf()
 {
 	local _main_cf="$ZFS_DATA_MNT/postfix/etc/main.cf"
+	export MAIL_CONFIG="/data/etc"  # postconf needs this
+
 	if [ -f "$_main_cf" ]; then
 		tell_status "preserving $_main_cf"
 		return


### PR DESCRIPTION
### Changes proposed in this pull request:
- postconf does not know about the configuration path we have set in rc.conf. `export MAIL_CONFIG=/data/etc` before running postconf.
