### PR TITLE
postfix: When TOASTER_MSA or TOASTER_MTA is postfix, identify as TOASTER_HOSTNAME

### DIFF
--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -93,7 +93,14 @@ configure_postfix_main_cf()
 	fi
 
 	stage_exec install -m 0644 /usr/local/etc/postfix/main.cf /data/etc/main.cf
-	stage_exec postconf -e "myhostname = postfix.$TOASTER_HOSTNAME"
+
+	if [ "$TOASTER_MTA" = postfix ] || [ "$TOASTER_MSA" = postfix ]; then
+		stage_exec postconf -e "myhostname = $TOASTER_HOSTNAME"
+		stage_exec postconf -e "myorigin = $TOASTER_MAIL_DOMAIN"
+	else
+		stage_exec postconf -e "myhostname = postfix.$TOASTER_HOSTNAME"
+	fi
+
 	stage_exec postconf -e 'smtp_tls_security_level = may'
 	stage_exec postconf -e 'smtpd_tls_security_level = may'
 	stage_exec postconf -e 'smtpd_tls_auth_only = yes'


### PR DESCRIPTION
### Changes proposed in this pull request:
- When TOASTER_MSA or TOASTER_MTA is postfix, set myhostname=TOASTER_HOSTNAME.
- Update myorigin accodingly.

Requires #676.