### PR TITLE
postfix: Fix enable_postfix_submission with current master.cf version

### DIFF
--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -173,7 +173,7 @@ enable_postfix_submission()
 	tell_status "enabling postfix submission and submissions/smtps services"
 	awk '
 		/^#(submission|submissions|smtps)[[:space:]]/ { sub(/^#/, ""); in_block = 1; print; next }
-		in_block && /^#[[:space:]]/       { sub(/^#/, ""); print; next }
+		in_block && /^#[[:space:]]+-o/                { sub(/^#/, ""); print; next }
 		{ in_block = 0; print }
 	' "$_master_cf" > "$_master_cf.tmp" && mv "$_master_cf.tmp" "$_master_cf"
 }

--- a/test/provision/postfix.bats
+++ b/test/provision/postfix.bats
@@ -20,10 +20,20 @@ smtp      inet  n       -       n       -       -       smtpd
 #  -o syslog_name=postfix/submission
 #  -o smtpd_tls_security_level=encrypt
 #  -o smtpd_sasl_auth_enable=yes
+#     Instead of specifying complex smtpd_<xxx>_restrictions here,
+#     specify "smtpd_<xxx>_restrictions=$mua_<xxx>_restrictions"
+#     here, and specify mua_<xxx>_restrictions in main.cf (where
+#     "<xxx>" is "client", "helo", "sender", "relay", or "recipient").
+#  -o smtpd_client_restrictions=
 #smtps     inet  n       -       n       -       -       smtpd
 #  -o syslog_name=postfix/smtps
 #  -o smtpd_tls_wrappermode=yes
 #  -o smtpd_sasl_auth_enable=yes
+#     Instead of specifying complex smtpd_<xxx>_restrictions here,
+#     specify "smtpd_<xxx>_restrictions=$mua_<xxx>_restrictions"
+#     here, and specify mua_<xxx>_restrictions in main.cf (where
+#     "<xxx>" is "client", "helo", "sender", "relay", or "recipient").
+#  -o smtpd_client_restrictions=
 pickup    unix  n       -       n       60      1       pickup
 EOF
 
@@ -66,6 +76,14 @@ teardown() {
   assert_line "#smtp      inet  n       -       n       -       1       postscreen"
   assert_line "smtp      inet  n       -       n       -       -       smtpd"
   assert_line "pickup    unix  n       -       n       60      1       pickup"
+}
+
+@test "enable_postfix_submission leaves non-option text commented" {
+  enable_postfix_submission "$MASTER_CF"
+
+  run cat "$MASTER_CF"
+  assert_success
+  assert_line "#     Instead of specifying complex smtpd_<xxx>_restrictions here,"
 }
 
 @test "enable_postfix_submission is idempotent" {


### PR DESCRIPTION
### Changes proposed in this pull request:
- While uncommenting master.cf lines, leave non-option lines commented out.

The current master.cf version contains actual comment text in the middle of the section, cited in the test part of the patch.
