### PR TITLE
mta: remove rdr pass syntax so filters work

### DIFF
--- a/include/jail.sh
+++ b/include/jail.sh
@@ -119,7 +119,7 @@ int_ip4 = "$(get_jail_ip "$_jail")"
 int_ip6 = "$(get_jail_ip6 "$_jail")"
 
 rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> \$int_ip4
-rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> \$int_ip6
+rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")
 EO_PF_RDR
 
 	store_config "$_pf_etc/filter.conf" <<EO_PF_FILTER

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -95,20 +95,36 @@ configure_mta_pf_rdr()
 		_ports="${_ports:+$_ports }465 587"
 	fi
 
-	local _rdr="$ZFS_DATA_MNT/$_jail/etc/pf.conf.d/rdr.conf"
+	local _pf_etc="$ZFS_DATA_MNT/$_jail/etc/pf.conf.d" _conf
 
 	if [ -z "$_ports" ]; then
-		if [ -f "$_rdr" ]; then
-			tell_status "removing mail port redirects from $_rdr"
-			rm -f "$_rdr"
-		fi
+		for _conf in "$_pf_etc/rdr.conf" "$_pf_etc/filter.conf"; do
+			if [ -f "$_conf" ]; then
+				tell_status "removing mail port redirects from $_conf"
+				rm -f "$_conf"
+			fi
+		done
 		return 0
 	fi
 
-	store_config "$_rdr" "overwrite" <<EO_PF
-rdr pass inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip  "$_jail")
-rdr pass inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")
-EO_PF
+	store_config "$_pf_etc/$_jail.table" <<EO_PF_INSECURE
+$PUBLIC_IP4
+$PUBLIC_IP6
+$(get_jail_ip "$_jail")
+$(get_jail_ip6 "$_jail")
+EO_PF_INSECURE
+
+	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
+int_ip4 = "$(get_jail_ip "$_jail")"
+int_ip6 = "$(get_jail_ip6 "$_jail")"
+
+rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> \$int_ip4
+rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> \$int_ip6
+EO_PF_RDR
+
+	store_config "$_pf_etc/filter.conf" <<EO_PF_FILTER
+pass in quick proto tcp from any to <$_jail> port { $_ports }
+EO_PF_FILTER
 }
 
 get_reverse_ip()

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -116,7 +116,7 @@ EO_PF_INSECURE
 
 	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
 int_ip6 = "$(get_jail_ip6 "$_jail")"
-rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> \$int_ip4
+rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip "$_jail")
 rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")
 EO_PF_RDR
 

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -115,7 +115,6 @@ $(get_jail_ip6 "$_jail")
 EO_PF_INSECURE
 
 	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
-int_ip6 = "$(get_jail_ip6 "$_jail")"
 rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip "$_jail")
 rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")
 EO_PF_RDR

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -117,7 +117,6 @@ EO_PF_INSECURE
 	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
 int_ip4 = "$(get_jail_ip "$_jail")"
 int_ip6 = "$(get_jail_ip6 "$_jail")"
-
 rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> \$int_ip4
 rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")
 EO_PF_RDR

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -115,7 +115,6 @@ $(get_jail_ip6 "$_jail")
 EO_PF_INSECURE
 
 	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
-int_ip4 = "$(get_jail_ip "$_jail")"
 int_ip6 = "$(get_jail_ip6 "$_jail")"
 rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> \$int_ip4
 rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")


### PR DESCRIPTION
### Changes proposed in this pull request:
- Replace `rdr pass` pf syntax with the original `rdr`.

I have traced the addition of `pass` to [this commit](https://github.com/msimerson/Mail-Toaster-6/pull/602/commits/1a4a55ef32d29d7938e300af2d18534582c3f94d). I am not sure about the purpose of the change and if it was intended to keep it in the final code. As I understand it, it redirects the traffic to jail straight away, so that no filter rules are working. And it may be a problem on some installations.
Am I wrong?