### PR TITLE
snappymail: fix nginx root and /snappymail prefix handling

### DIFF
--- a/provision/snappymail.sh
+++ b/provision/snappymail.sh
@@ -59,15 +59,17 @@ configure_nginx_server()
 		add_header X-Frame-Options "SAMEORIGIN" always;
 		fastcgi_hide_header X-Powered-By;
 
+		location = /snappymail { return 301 /snappymail/; }
+
 		location /snappymail/ {
-			root   /usr/local/www/snappymail;
+			root   /usr/local/www;
 			index  index.php;
-			try_files $uri index.php?$query_string;
+			try_files $uri $uri/ /snappymail/index.php?$query_string;
 		}
 
 		location ~ \.php$ {
-			root           /usr/local/www/snappymail;
-			try_files $uri $uri/ /index.php?$query_string;
+			root           /usr/local/www;
+			try_files $uri /snappymail/index.php?$query_string;
 			fastcgi_split_path_info ^(.+\.php)(.*)$;
 			fastcgi_keep_conn on;
 			include        /usr/local/etc/nginx/fastcgi_params;
@@ -76,7 +78,7 @@ configure_nginx_server()
 			fastcgi_pass   php;
 		}
 
-		location ^~ /data {
+		location ^~ /snappymail/data {
 			deny all;
 		}
 '


### PR DESCRIPTION
### Changes proposed in this pull request:
- snappymail: redirect /snappymail to /snappymail/ so the bare path doesn't fall through to nginx's default root
- snappymail: correct document root — haproxy does not strip the /snappymail prefix (unlike roundcube and rainloop), so root must be /usr/local/www
- snappymail: scope the data deny rule to /snappymail/data, which is the URI that actually arrives

With `root /usr/local/www`, both paths resolve: `/snappymail/` →
`/usr/local/www/snappymail/index.php`, and assets built from
`app_path = "/snappymail"` → `/snappymail/snappymail/v/<ver>/static/...` →
`/usr/local/www/snappymail/snappymail/v/...`.

Note for existing installs: `store_config()` won't overwrite an existing
`snappymail.conf`, so this only helps fresh deploys. `roundcube.sh` handles
that case with `migrate_roundcube_nginx_conf()` — happy to add an equivalent
here if you want it, though moving people's configs felt like your call.

Fixes #689 

Checklist:
- [x] docs up-to-date
