### PR TITLE
rspamd: bind controller on all addresses

### DIFF
--- a/provision/rspamd.sh
+++ b/provision/rspamd.sh
@@ -255,6 +255,7 @@ configure_controller()
 	_pass=$(jexec vpopmail /usr/local/vpopmail/bin/vuserinfo -C "postmaster@${TOASTER_MAIL_DOMAIN}")
 
 	store_config "$RSPAMD_ETC/local.d/worker-controller.inc" <<EO_CONTROLLER
+bind_socket = "*:11334";
 password = "$(jexec stage rspamadm pw -p "$_pass")";
 secure_ip = $(get_jail_ip dovecot);
 secure_ip = $(get_jail_ip6 dovecot);


### PR DESCRIPTION
### Changes proposed in this pull request:
- rspamd: set `bind_socket = "*:11334"` in worker-controller.inc

Without it the controller inherits rspamd's default of `localhost:11334`,
which in a jail binds IPv6 only, so `backend www_rspamd` in `haproxy.sh` —
which connects over IPv4 — gets a 503. `configure_worker()` already sets
`bind_socket` explicitly for the normal worker; this makes the controller
consistent.

Existing installs need the line added to
`/data/rspamd/etc/local.d/worker-controller.inc` by hand, since
`store_config()` won't overwrite an existing file.

Fixes #691 

Checklist:
- [x] docs up-to-date
