### PR TITLE
use local vars

### DIFF
--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -64,7 +64,7 @@ configure_dcc()
 		-e "/^DCCIFD_ARGS/ s/-SList-ID\"/-SList-ID -p*,1025,$JAIL_NET_PREFIX.0\/24\"/" \
 		"$STAGE_MNT/var/db/dcc/dcc_conf"
 
-	_pf_etc="$(get_jail_host_etc dcc)/pf.conf.d"
+	local _pf_etc; _pf_etc="$(get_jail_host_etc dcc)/pf.conf.d"
 
 	configure_pf_jail_table dcc
 

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -30,7 +30,7 @@ configure_dhcpd()
 	stage_sysrc dhcpd_rootdir="/data/db"	# directory to run in
 	echo "configured"
 
-	_pf_etc="$(get_jail_host_etc dhcp)/pf.conf.d"
+	local _pf_etc; _pf_etc="$(get_jail_host_etc dhcp)/pf.conf.d"
 	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
 rdr inet  proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip  dhcp)
 rdr inet6 proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip6 dhcp)

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -282,3 +282,7 @@ start_unbound
 test_unbound
 switch_host_resolver
 promote_staged_jail dns
+if [ -d "$(get_jail_data dns)/etc/rc.d" ]; then
+	tell_status "Finishing $(get_jail_host_etc dns)/rc.d migration"
+	rm -fr "$(get_jail_data dns)/etc/rc.d"
+fi

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -282,7 +282,3 @@ start_unbound
 test_unbound
 switch_host_resolver
 promote_staged_jail dns
-if [ -d "$(get_jail_data dns)/etc/rc.d" ]; then
-	tell_status "Finishing $(get_jail_host_etc dns)/rc.d migration"
-	rm -fr "$(get_jail_data dns)/etc/rc.d"
-fi

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -551,7 +551,7 @@ configure_sieve()
 
 configure_dovecot_pf()
 {
-	_pf_etc="$(get_jail_host_etc dovecot)/pf.conf.d"
+	local _pf_etc; _pf_etc="$(get_jail_host_etc dovecot)/pf.conf.d"
 
 	store_config "$_pf_etc/insecure_mua.table" <<EO_PF_INSECURE
 # RFC 1918 Private IP blocks

--- a/provision/git.sh
+++ b/provision/git.sh
@@ -75,7 +75,7 @@ configure_nginx_server()
 
 configure_pf()
 {
-	_pf_etc="$(get_jail_host_etc git)/pf.conf.d"
+	local _pf_etc; _pf_etc="$(get_jail_host_etc git)/pf.conf.d"
 
 	store_config "$_pf_etc/rdr.conf" <<EO_GIT_RDR
 int_ip4 = "$(get_jail_ip git)"

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -384,7 +384,7 @@ install_webmail()
 
 configure_webmail_pf()
 {
-	_pf_etc="$(get_jail_host_etc webmail)/pf.conf.d"
+	local _pf_etc; _pf_etc="$(get_jail_host_etc webmail)/pf.conf.d"
 
 	if [ "$TOASTER_WEBMAIL_PROXY" = "nginx" ]; then
 		store_config "$_pf_etc/rdr.conf" <<EO_WEBMAIL_RDR


### PR DESCRIPTION
### Changes proposed in this pull request:
- Store `fstab` and `pf.conf.d` for new jails in a location inaccessible from inside the jail.
- Use `get_jail_etc "$_jail"` to refer to this location. 
- Attempt to seamlessly migrate any older `pf.conf.d` content added by user.
