### PR TITLE
mt: route jail data paths through get_jail_data()

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,10 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-08
 
+- mt: fail early with instructions when /usr/ports is empty
+- mt: route jail data paths through get_jail_data()
+- postfix, sphinxsearch, mailman: correct /data paths missing the jail name
+- rsnapshot, borg: call tell_status, not tell-status
 - haproxy: bind per address family the host has, drop `v4v6`
 - config: mv config into ./conf.d/
 - config: split service portions into $service.conf files

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 - mt: fail early with instructions when /usr/ports is empty
 - mt: route jail data paths through get_jail_data()
+- mt: use $STAGE_MNT instead of re-deriving it from $ZFS_JAIL_MNT
 - postfix, sphinxsearch, mailman: correct /data paths missing the jail name
 - rsnapshot, borg: call tell_status, not tell-status
 - haproxy: bind per address family the host has, drop `v4v6`

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 - mt: use $STAGE_MNT instead of re-deriving it from $ZFS_JAIL_MNT
 - postfix, sphinxsearch, mailman: correct /data paths missing the jail name
 - rsnapshot, borg: call tell_status, not tell-status
+- borg: unquote the ssh key glob so cp copies the keys
 - haproxy: bind per address family the host has, drop `v4v6`
 - config: mv config into ./conf.d/
 - config: split service portions into $service.conf files

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -95,7 +95,8 @@ configure_mta_pf_rdr()
 		_ports="${_ports:+$_ports }465 587"
 	fi
 
-	local _pf_etc="$ZFS_DATA_MNT/$_jail/etc/pf.conf.d" _conf
+	local _conf _pf_etc
+	_pf_etc="$(get_jail_data "$_jail")/etc/pf.conf.d"
 
 	if [ -z "$_ports" ]; then
 		for _conf in "$_pf_etc/rdr.conf" "$_pf_etc/filter.conf"; do
@@ -122,7 +123,8 @@ EO_PF_FILTER
 configure_pf_jail_table()
 {
 	local _jail="$1"
-	local _pf_etc="$ZFS_DATA_MNT/$_jail/etc/pf.conf.d"
+	local _pf_etc
+	_pf_etc="$(get_jail_data "$_jail")/etc/pf.conf.d"
 
 	get_public_ip4
 	get_public_ip6
@@ -286,7 +288,7 @@ add_jail_conf()
 
 	tell_status "adding $1 to /etc/jail.conf"
 	echo "$1	{$(get_safe_jail_path "$1")
-		mount.fstab = \"$ZFS_DATA_MNT/$1/etc/fstab\";
+		mount.fstab = \"$(get_jail_data "$1")/etc/fstab\";
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
 		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");${JAIL_CONF_EXTRA}
 	}" | tee -a /etc/jail.conf

--- a/include/nginx.sh
+++ b/include/nginx.sh
@@ -63,7 +63,8 @@ configure_nginx_server_d()
 	local _jail="$1"
 	local _server_name="${2:-$_jail}"
 
-	local _server_d="$ZFS_DATA_MNT/$_jail/etc/nginx/server.d"
+	local _server_d
+	_server_d="$(get_jail_data "$_jail")/etc/nginx/server.d"
 	if [ ! -d "$_server_d" ]; then mkdir -p "$_server_d" || exit 1; fi
 
 	local _server_conf="$_server_d/$_server_name.conf"
@@ -108,7 +109,8 @@ configure_nginx()
 		exit 1
 	fi
 
-	local _etcdir="$ZFS_DATA_MNT/$1/etc/nginx"
+	local _etcdir
+	_etcdir="$(get_jail_data "$1")/etc/nginx"
 	if [ ! -d "$_etcdir" ]; then mkdir -p "$_etcdir" || exit 1; fi
 
 	stage_sysrc nginx_flags='-c /data/etc/nginx/nginx.conf'

--- a/include/util.sh
+++ b/include/util.sh
@@ -203,11 +203,11 @@ nameserver $(get_jail_ip dns)
 nameserver $(get_jail_ip6 dns)
 EO_RESOLV
 
-	local _repo_dir="$ZFS_JAIL_MNT/stage/usr/local/etc/pkg/repos"
+	local _repo_dir="$STAGE_MNT/usr/local/etc/pkg/repos"
 	if [ ! -d "$_repo_dir" ]; then mkdir -p "$_repo_dir"; fi
 
 	local _repo_name="FreeBSD-ports"
-	if [ "$(freebsd_major "$ZFS_JAIL_MNT/stage")" -lt "15" ]; then _repo_name="FreeBSD"; fi
+	if [ "$(freebsd_major "$STAGE_MNT")" -lt "15" ]; then _repo_name="FreeBSD"; fi
 
 	store_config "$_repo_dir/FreeBSD.conf" <<EO_PKG_CONF
 $_repo_name: {
@@ -226,8 +226,8 @@ EO_PKG_MT6
 	sed_inplace \
 		-e '/^#VULNXML_SITE/ s/^#//' \
 		-e '/^VULNXML_SITE/ s/vuxml.freebsd.org/vulnxml/' \
-		"$ZFS_JAIL_MNT/stage/usr/local/etc/pkg.conf"
+		"$STAGE_MNT/usr/local/etc/pkg.conf"
 
 	sed_inplace -e '/^ServerName/ s/update.FreeBSD.org/freebsd-update/' \
-		"$ZFS_JAIL_MNT/stage/etc/freebsd-update.conf"
+		"$STAGE_MNT/etc/freebsd-update.conf"
 }

--- a/include/vpopmail.sh
+++ b/include/vpopmail.sh
@@ -25,12 +25,15 @@ install_vpopmail_source()
 
 	tell_status "installing vpopmail from sources"
 
-	if [ ! -d "$ZFS_DATA_MNT/vpopmail/src" ]; then
-		mkdir "$ZFS_DATA_MNT/vpopmail/src" || exit 1
+	local _data
+	_data="$(get_jail_data vpopmail)"
+
+	if [ ! -d "$_data/src" ]; then
+		mkdir "$_data/src" || exit 1
 	fi
 
-	if [ ! -d "$ZFS_DATA_MNT/vpopmail/src/vpopmail" ]; then
-		git clone https://github.com/brunonymous/vpopmail.git "$ZFS_DATA_MNT/vpopmail/src/vpopmail" || exit 1
+	if [ ! -d "$_data/src/vpopmail" ]; then
+		git clone https://github.com/brunonymous/vpopmail.git "$_data/src/vpopmail" || exit 1
 	fi
 
 	_conf_args="--disable-users-big-dir --enable-logging=y --enable-md5-passwords --disable-sha512-passwords"
@@ -133,7 +136,8 @@ install_qmail()
 
 	for _cdir in control users
 	do
-		local _vmdir="$ZFS_DATA_MNT/vpopmail/home/qmail-${_cdir}"
+		local _vmdir
+		_vmdir="$(get_jail_data vpopmail)/home/qmail-${_cdir}"
 		if [ ! -d "$_vmdir" ]; then
 			tell_status "creating $_vmdir"
 			mkdir -p "$_vmdir" || exit
@@ -153,7 +157,7 @@ install_qmail()
 	mkdir -p "$STAGE_MNT/usr/local/etc/rc.d"
 
 	tell_status "setting qmail hostname to $TOASTER_HOSTNAME"
-	echo "$TOASTER_HOSTNAME" > "$ZFS_DATA_MNT/vpopmail/home/qmail-control/me"
+	echo "$TOASTER_HOSTNAME" > "$(get_jail_data vpopmail)/home/qmail-control/me"
 
 	if grep -qs ^mail_qmail_ "$ZFS_JAIL_MNT/vpopmail/etc/make.conf"; then
 		tell_status "copying qmail port options from existing vpopmail jail"

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -216,8 +216,8 @@ install_fstab()
 
 	# ports build under /tmp/portbuild (WRKDIRPREFIX, set in provision/base.sh),
 	# which noexec breaks. Only the stage builds ports; the promoted jail keeps noexec.
-	sed -e "s|[[:space:]]$ZFS_JAIL_MNT/$1| $ZFS_JAIL_MNT/stage|" \
-		-e "\|[[:space:]]$ZFS_JAIL_MNT/stage/tmp[[:space:]]| s|,noexec||" \
+	sed -e "s|[[:space:]]$ZFS_JAIL_MNT/$1| $STAGE_MNT|" \
+		-e "\|[[:space:]]$STAGE_MNT/tmp[[:space:]]| s|,noexec||" \
 		"$_fstab" > \
 		"$_fstab.stage" || exit 1
 
@@ -263,9 +263,9 @@ create_staged_fs()
 	echo "zfs clone $BASE_SNAP $ZFS_JAIL_VOL/stage"
 	zfs clone "$BASE_SNAP" "$ZFS_JAIL_VOL/stage" || exit 1
 
-	if [ ! -d "$ZFS_JAIL_MNT/stage/data" ]; then
-		tell_status "creating $ZFS_JAIL_MNT/stage/data"
-		mkdir "$ZFS_JAIL_MNT/stage/data" || exit 1
+	if [ ! -d "$STAGE_MNT/data" ]; then
+		tell_status "creating $STAGE_MNT/data"
+		mkdir "$STAGE_MNT/data" || exit 1
 	fi
 
 	stage_sysrc hostname="$1"

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -188,9 +188,9 @@ cleanup_staged_fs()
 
 install_fstab()
 {
-	_data_mount="$ZFS_DATA_MNT/$1"
+	_data_mount="$(get_jail_data "$1")"
 	_jail_mount="$ZFS_JAIL_MNT/$1"
-	_fstab="$ZFS_DATA_MNT/$1/etc/fstab"
+	_fstab="$(get_jail_data "$1")/etc/fstab"
 
 	if [ ! -d "$_data_mount/etc" ]; then
 		mkdir "$_data_mount/etc" || exit 1
@@ -226,10 +226,10 @@ install_fstab()
 	echo "/var/cache/pkg     $STAGE_MNT/var/cache/pkg   nullfs rw  0  0" | tee -a "$_fstab.stage"
 
 	# copy staged fstab into place for jail shutdown
-	if [ ! -d "$ZFS_DATA_MNT/stage/etc" ]; then
-		mkdir -p "$ZFS_DATA_MNT/stage/etc" || exit 1
+	if [ ! -d "$(get_jail_data stage)/etc" ]; then
+		mkdir -p "$(get_jail_data stage)/etc" || exit 1
 	fi
-	cp "$_fstab.stage" "$ZFS_DATA_MNT/stage/etc/fstab" || exit 1
+	cp "$_fstab.stage" "$(get_jail_data stage)/etc/fstab" || exit 1
 }
 
 fstab_add_mount() {
@@ -243,7 +243,8 @@ fstab_add_mount() {
 	local mount_point="$3"
 	local fs_type="${4:-nullfs}"
 	local opts="${5:-rw}"
-	local fstab="$ZFS_DATA_MNT/$jail_name/etc/fstab"
+	local fstab
+	fstab="$(get_jail_data "$jail_name")/etc/fstab"
 
 	for _file in "$fstab" "${fstab}.stage"; do
 		if ! grep -qs "^$fs_path" "$_file"; then
@@ -393,9 +394,27 @@ stage_pkg_install()
 	pkg -j "$SAFE_NAME" install -y "$@"
 }
 
+# /usr/ports is nullfs mounted into the staged jail from the host, so it is the
+# host's tree that a port build needs, and an unpopulated one fails deep inside
+# make(1) with nothing pointing at the cause.
+assure_ports_tree()
+{
+	local _ports=${1:-"/usr/ports"}
+
+	if [ -f "$_ports/Makefile" ]; then return; fi
+
+	fatal_err "$_ports is not a populated ports tree. Fill it with either:
+
+    pkg install -y gitup && gitup ports
+
+    pkg install -y git-lite && git clone https://github.com/freebsd/freebsd-ports.git $_ports"
+}
+
 stage_port_install()
 {
 	# $1 is the port directory (eg: mail/dovecot)
+
+	assure_ports_tree
 
 	stage_pkg_install pkgconf portconfig
 
@@ -633,7 +652,8 @@ provision_skeleton()
 	mt6-fetch provision "skel.sh"
 	sed -e "s/_skel/_$2/g" -e "s/ skel/ $2/g" provision/skel.sh > "provision/$2.sh"
 
-	local _ucl="$ZFS_DATA_MNT/dns/unbound.conf.local"
+	local _ucl
+	_ucl="$(get_jail_data dns)/unbound.conf.local"
 	if ! grep -qs "$2" "$_ucl"; then
 		tell_status "adding DNS for $2"
 		tee -a "$_ucl" <<EO_UB_CONF

--- a/provision/borg.sh
+++ b/provision/borg.sh
@@ -25,23 +25,25 @@ EO_RSNAP
 		fi
 	done
 
+	local _data
+	_data="$(get_jail_data borg)"
 	for d in etc snaps
 	do
-		if [ ! -d "$(get_jail_data borg)/$d" ]; then
-			mkdir "$(get_jail_data borg)/$d"
+		if [ ! -d "$_data/$d" ]; then
+			mkdir "$_data/$d"
 		fi
 	done
 
-	if [ ! -f "$(get_jail_data borg)/etc/borg.conf" ]; then
-		tell_status "installing default $(get_jail_data borg)/etc/borg.conf"
-		cp "$STAGE_MNT/usr/local/etc/borg.conf.default" "$(get_jail_data borg)/etc/borg.conf"
+	if [ ! -f "$_data/etc/borg.conf" ]; then
+		tell_status "installing default $_data/etc/borg.conf"
+		cp "$STAGE_MNT/usr/local/etc/borg.conf.default" "$_data/etc/borg.conf"
 	fi
 
-	if [ -d "$(get_jail_data borg)/ssh" ]; then
+	if [ -d "$_data/ssh" ]; then
 		if [ ! -d "$STAGE_MNT/root/.ssh" ]; then
 			umask 0077; mkdir "$STAGE_MNT/root/.ssh"; umask 0022;
 		fi
-		cp "$(get_jail_data borg)/ssh/*" "$STAGE_MNT/root/.ssh"
+		cp "$_data/ssh/*" "$STAGE_MNT/root/.ssh"
 	fi
 }
 

--- a/provision/borg.sh
+++ b/provision/borg.sh
@@ -27,6 +27,7 @@ EO_RSNAP
 
 	local _data
 	_data="$(get_jail_data borg)"
+
 	for d in etc snaps
 	do
 		if [ ! -d "$_data/$d" ]; then
@@ -43,7 +44,7 @@ EO_RSNAP
 		if [ ! -d "$STAGE_MNT/root/.ssh" ]; then
 			umask 0077; mkdir "$STAGE_MNT/root/.ssh"; umask 0022;
 		fi
-		cp "$_data/ssh/*" "$STAGE_MNT/root/.ssh"
+		cp "$_data/ssh/"* "$STAGE_MNT/root/.ssh/"
 	fi
 }
 

--- a/provision/borg.sh
+++ b/provision/borg.sh
@@ -27,21 +27,21 @@ EO_RSNAP
 
 	for d in etc snaps
 	do
-		if [ ! -d "$ZFS_DATA_MNT/borg/$d" ]; then
-			mkdir "$ZFS_DATA_MNT/borg/$d"
+		if [ ! -d "$(get_jail_data borg)/$d" ]; then
+			mkdir "$(get_jail_data borg)/$d"
 		fi
 	done
 
-	if [ ! -f "$ZFS_DATA_MNT/borg/etc/borg.conf" ]; then
-		tell-status "installing default $ZFS_DATA_MNT/etc/borg.conf"
-		cp "$STAGE_MNT/usr/local/etc/borg.conf.default" "$ZFS_DATA_MNT/borg/etc/borg.conf"
+	if [ ! -f "$(get_jail_data borg)/etc/borg.conf" ]; then
+		tell_status "installing default $(get_jail_data borg)/etc/borg.conf"
+		cp "$STAGE_MNT/usr/local/etc/borg.conf.default" "$(get_jail_data borg)/etc/borg.conf"
 	fi
 
-	if [ -d "$ZFS_DATA_MNT/borg/ssh" ]; then
+	if [ -d "$(get_jail_data borg)/ssh" ]; then
 		if [ ! -d "$STAGE_MNT/root/.ssh" ]; then
 			umask 0077; mkdir "$STAGE_MNT/root/.ssh"; umask 0022;
 		fi
-		cp "$ZFS_DATA_MNT/borg/ssh/*" "$STAGE_MNT/root/.ssh"
+		cp "$(get_jail_data borg)/ssh/*" "$STAGE_MNT/root/.ssh"
 	fi
 }
 

--- a/provision/bsd_cache.sh
+++ b/provision/bsd_cache.sh
@@ -83,7 +83,8 @@ install_bsd_cache()
 
 create_cachedir()
 {
-	local _cachedir="$ZFS_DATA_MNT/bsd_cache/cache"
+	local _cachedir
+	_cachedir="$(get_jail_data bsd_cache)/cache"
 	if [ -d "$_cachedir" ]; then return; fi
 
 	tell_status "creating $_cachedir"

--- a/provision/centos.sh
+++ b/provision/centos.sh
@@ -34,9 +34,9 @@ install_centos()
 base_snapshot_exists || exit 1
 create_staged_fs centos
 for _fs in dev proc sys tmp home; do
-	mkdir -p "$ZFS_JAIL_MNT/stage/compat/linux/$_fs"
+	mkdir -p "$STAGE_MNT/compat/linux/$_fs"
 done
-chmod 777 "$ZFS_JAIL_MNT/stage/compat/linux/tmp"
+chmod 777 "$STAGE_MNT/compat/linux/tmp"
 start_staged_jail centos
 install_centos
 promote_staged_jail centos

--- a/provision/certbot.sh
+++ b/provision/certbot.sh
@@ -170,7 +170,8 @@ install_deploy_scripts()
 
 update_haproxy_ssld()
 {
-	local _haconf="$ZFS_DATA_MNT/haproxy/etc/haproxy.conf"
+	local _haconf
+	_haconf="$(get_jail_data haproxy)/etc/haproxy.conf"
 	if ! grep -q 'ssl crt /etc' "$_haconf"; then
 		# already updated
 		return
@@ -188,7 +189,8 @@ configure_certbot()
 
 	tell_status "configuring Certbot"
 
-	local _HTTPDIR="$ZFS_DATA_MNT/webmail"
+	local _HTTPDIR
+	_HTTPDIR="$(get_jail_data webmail)"
 	local _certbot="/usr/local/bin/certbot"
 	if $_certbot certonly --webroot-path "$_HTTPDIR" -d "$TOASTER_HOSTNAME"; then
 		update_haproxy_ssld

--- a/provision/clamav.sh
+++ b/provision/clamav.sh
@@ -134,8 +134,8 @@ install_clamav_unofficial()
 	fi
 
 	for f in EMAIL_Cryptowall.yar antidebug_antivm.yar; do
-		if [ -f "$ZFS_DATA_MNT/clamav/$f" ]; then
-			rm "$ZFS_DATA_MNT/clamav/$f"
+		if [ -f "$(get_jail_data clamav)/$f" ]; then
+			rm "$(get_jail_data clamav)/$f"
 		fi
 	done
 
@@ -162,14 +162,14 @@ install_clamav_nrpe()
 		-e 's|clamd_cmd -V|clamd_cmd --datadir=/data/db -V|' \
 		"$STAGE_MNT/usr/local/libexec/nagios/check_clamav"
 
-	fetch -m -o "$ZFS_DATA_MNT/clamav/check_clamav_signatures" \
+	fetch -m -o "$(get_jail_data clamav)/check_clamav_signatures" \
 		https://raw.githubusercontent.com/tommarshall/nagios-check-clamav-signatures/master/check_clamav_signatures
 	sed_inplace \
 		-e 's|^#!/usr/bin/env bash|#!/usr/local/bin/bash\
 PATH="$PATH:/usr/local/bin"|' \
 		-e '/^CLAM_LIB_DIR/ s|=.*$|=/data/db|' \
-		"$ZFS_DATA_MNT/clamav/check_clamav_signatures"
-	chmod 755 "$ZFS_DATA_MNT/clamav/check_clamav_signatures"
+		"$(get_jail_data clamav)/check_clamav_signatures"
+	chmod 755 "$(get_jail_data clamav)/check_clamav_signatures"
 
 	if [ -f /usr/local/etc/nrpe.cfg ]; then
 		if ! grep -q 'command[check_clamav' /usr/local/etc/nrpe.cfg; then
@@ -295,7 +295,7 @@ start_clamav()
 
 migrate_clamav_dbs()
 {
-	if [ ! -f "$ZFS_DATA_MNT/clamav/daily.cld" ]; then
+	if [ ! -f "$(get_jail_data clamav)/daily.cld" ]; then
 		# no clamav dbs or already migrated
 		return
 	fi
@@ -311,16 +311,16 @@ migrate_clamav_dbs()
 	"
 	bsddialog --yesno "$_confirm_msg" 13 70
 
-	if [ ! -d "$ZFS_DATA_MNT/clamav/db" ]; then
-		mkdir "$ZFS_DATA_MNT/clamav/db"
+	if [ ! -d "$(get_jail_data clamav)/db" ]; then
+		mkdir "$(get_jail_data clamav)/db"
 	fi
 
 	service jail stop clamav
 
 	for _suffix in cdb cld cvd dat fp ftm hsb ldb ndb yara; do
-		for _db in "$ZFS_DATA_MNT"/clamav/*."$_suffix"; do
-			echo "mv $_db $ZFS_DATA_MNT/clamav/db/"
-			mv "$_db" "$ZFS_DATA_MNT/clamav/db/"
+		for _db in "$(get_jail_data clamav)"/*."$_suffix"; do
+			echo "mv $_db $(get_jail_data clamav)/db/"
+			mv "$_db" "$(get_jail_data clamav)/db/"
 		done
 	done
 }

--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -6,7 +6,8 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB="$ZFS_DATA_MNT/dcc/db		$ZFS_JAIL_MNT/dcc/var/db/dcc nullfs	rw	0	0"
+export JAIL_FSTAB
+JAIL_FSTAB="$(get_jail_data dcc)/db		$ZFS_JAIL_MNT/dcc/var/db/dcc nullfs	rw	0	0"
 
 install_dcc_cleanup()
 {
@@ -63,7 +64,7 @@ configure_dcc()
 		-e "/^DCCIFD_ARGS/ s/-SList-ID\"/-SList-ID -p*,1025,$JAIL_NET_PREFIX.0\/24\"/" \
 		"$STAGE_MNT/var/db/dcc/dcc_conf"
 
-	_pf_etc="$ZFS_DATA_MNT/dcc/etc/pf.conf.d"
+	_pf_etc="$(get_jail_data dcc)/etc/pf.conf.d"
 
 	configure_pf_jail_table dcc
 
@@ -99,7 +100,7 @@ test_dcc()
 preflight()
 {
 	for _d in etc db log; do
-		_path="$ZFS_DATA_MNT/dcc/$_d"
+		_path="$(get_jail_data dcc)/$_d"
 		[ -d "$_path" ] || mkdir "$_path"
 	done
 

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -30,22 +30,22 @@ configure_dhcpd()
 	stage_sysrc dhcpd_rootdir="/data/db"	# directory to run in
 	echo "configured"
 
-	_pf_etc="$ZFS_DATA_MNT/dhcp/etc/pf.conf.d"
+	_pf_etc="$(get_jail_data dhcp)/etc/pf.conf.d"
 	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
 rdr inet  proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip  dhcp)
 rdr inet6 proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip6 dhcp)
 EO_PF_RDR
 
-	if [ ! -d "$ZFS_DATA_MNT/dhcp/etc" ]; then
-		mkdir -p "$ZFS_DATA_MNT/dhcp/etc"
+	if [ ! -d "$(get_jail_data dhcp)/etc" ]; then
+		mkdir -p "$(get_jail_data dhcp)/etc"
 	fi
 
-	if [ ! -d "$ZFS_DATA_MNT/dhcp/db" ]; then
-		mkdir -p "$ZFS_DATA_MNT/dhcp/db"
+	if [ ! -d "$(get_jail_data dhcp)/db" ]; then
+		mkdir -p "$(get_jail_data dhcp)/db"
 	fi
 
 	get_public_ip4
-	store_config "$ZFS_DATA_MNT/dhcp/etc/dhcpd.conf" <<EO_DHCP
+	store_config "$(get_jail_data dhcp)/etc/dhcpd.conf" <<EO_DHCP
 option domain-name "$TOASTER_MAIL_DOMAIN";
 # option domain-name-servers $PUBLIC_IP4;
 

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -5,10 +5,11 @@ set -e
 . mail-toaster.sh
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
+export JAIL_CONF_EXTRA
+JAIL_CONF_EXTRA="
 		allow.raw_sockets;
-		exec.poststart = \"$ZFS_DATA_MNT/dns/etc/rc.d/poststart.sh\";
-		exec.prestop = \"$ZFS_DATA_MNT/dns/etc/rc.d/prestop.sh\";
+		exec.poststart = \"$(get_jail_data dns)/etc/rc.d/poststart.sh\";
+		exec.prestop = \"$(get_jail_data dns)/etc/rc.d/prestop.sh\";
 "
 export JAIL_FSTAB=""
 
@@ -68,7 +69,7 @@ install_access_conf()
 		tell_status "no public IPv4 found, omitting its access-control entry"
 	fi
 
-	store_config "$ZFS_DATA_MNT/dns/access.conf" <<EO_UNBOUND_ACCESS
+	store_config "$(get_jail_data dns)/access.conf" <<EO_UNBOUND_ACCESS
 
 	   access-control: 0.0.0.0/0 refuse
 	   access-control: 127.0.0.0/8 allow
@@ -81,7 +82,7 @@ EO_UNBOUND_ACCESS
 
 install_forward_conf()
 {
-	store_config "$ZFS_DATA_MNT/dns/forward.conf" "update" <<EO_UNBOUND_FORWARD
+	store_config "$(get_jail_data dns)/forward.conf" "update" <<EO_UNBOUND_FORWARD
 # Comparison Table: Forward vs Stub Zones
 # | Feature         | Forward Zone                    | Stub Zone                      |
 # | :-------------- | :------------------------------ | :----------------------------- |
@@ -102,7 +103,7 @@ EO_UNBOUND_FORWARD
 
 install_stub_conf()
 {
-	store_config "$ZFS_DATA_MNT/dns/stub.conf" "update" <<EO_UNBOUND_STUB
+	store_config "$(get_jail_data dns)/stub.conf" "update" <<EO_UNBOUND_STUB
 # Comparison Table: Forward vs Stub Zones
 # | Feature         | Forward Zone                    | Stub Zone                      |
 # | :-------------- | :------------------------------ | :----------------------------- |
@@ -121,7 +122,7 @@ EO_UNBOUND_STUB
 
 install_local_conf()
 {
-	store_config "$ZFS_DATA_MNT/dns/mt6-local.conf" "overwrite" <<EO_UNBOUND
+	store_config "$(get_jail_data dns)/mt6-local.conf" "overwrite" <<EO_UNBOUND
 	   $UNBOUND_LOCAL
 
 	   $(get_mt6_data)
@@ -163,16 +164,16 @@ include: "/data/stub.conf" \
 
 enable_control()
 {
-	if [ -d "$ZFS_DATA_MNT/dns/control" ]; then
+	if [ -d "$(get_jail_data dns)/control" ]; then
 		tell_status "preserving unbound-control"
 		return
 	fi
 
-	tell_status "creating $ZFS_DATA_MNT/dns/control"
-	mkdir "$ZFS_DATA_MNT/dns/control"
+	tell_status "creating $(get_jail_data dns)/control"
+	mkdir "$(get_jail_data dns)/control"
 
 	tell_status "configuring unbound-control"
-	store_config "$ZFS_DATA_MNT/dns/control.conf" "update" <<EO_CONTROL_CONF
+	store_config "$(get_jail_data dns)/control.conf" "update" <<EO_CONTROL_CONF
 		control-enable: yes
 		control-interface: 0.0.0.0
 
@@ -199,10 +200,10 @@ configure_unbound()
 	cp "$UNBOUND_DIR/unbound.conf.sample" "$UNBOUND_DIR/unbound.conf"
 	if [ -f 'unbound.conf.local' ]; then
 		tell_status "moving unbound.conf.local to data volume"
-		mv unbound.conf.local "$ZFS_DATA_MNT/dns/"
+		mv unbound.conf.local "$(get_jail_data dns)/"
 	fi
 
-	_ub_local_conf="$ZFS_DATA_MNT/dns/unbound.conf.local"
+	_ub_local_conf="$(get_jail_data dns)/unbound.conf.local"
 	if [ ! -f "$_ub_local_conf" ]; then
 		store_config "$_ub_local_conf" <<EO_UB_LOCAL_CONF
 
@@ -249,7 +250,7 @@ test_unbound()
 	echo "nameserver $(get_jail_ip dns)" | tee "$STAGE_MNT/etc/resolv.conf"
 	echo "it worked."
 
-	if [ -f "$ZFS_DATA_MNT/dns/unbound.conf" ]; then
+	if [ -f "$(get_jail_data dns)/unbound.conf" ]; then
 		stage_sysrc unbound_config=/data/unbound.conf
 	fi
 }
@@ -261,12 +262,12 @@ switch_host_resolver()
 		truncate -s 0 /etc/resolvconf.conf
 	fi
 
-	store_exec "$ZFS_DATA_MNT/dns/etc/rc.d/poststart.sh" <<EO_POSTSTART
+	store_exec "$(get_jail_data dns)/etc/rc.d/poststart.sh" <<EO_POSTSTART
 #!/bin/sh
 echo "nameserver $(get_jail_ip dns) $(get_jail_ip6 dns)" | /sbin/resolvconf -a lo1.dns -m 0
 EO_POSTSTART
 
-	store_exec "$ZFS_DATA_MNT/dns/etc/rc.d/prestop.sh" <<EO_PRESTOP
+	store_exec "$(get_jail_data dns)/etc/rc.d/prestop.sh" <<EO_PRESTOP
 #!/bin/sh
 /sbin/resolvconf -d lo1.dns
 EO_PRESTOP

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -6,7 +6,8 @@ set -e -u
 
 export JAIL_START_EXTRA="allow.sysvipc=1"
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/dovecot/usr/local/vpopmail nullfs rw 0 0"
+export JAIL_FSTAB
+JAIL_FSTAB="$(get_jail_data vpopmail)/home $ZFS_JAIL_MNT/dovecot/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail
 mt6-include mua
@@ -42,7 +43,8 @@ install_dovecot()
 }
 
 configure_dovecot_local_conf() {
-	local _localconf="$ZFS_DATA_MNT/dovecot/etc/local.conf"
+	local _localconf
+	_localconf="$(get_jail_data dovecot)/etc/local.conf"
 
 	local _listen='listen = *'
 	get_public_ip6
@@ -223,7 +225,8 @@ EO_DOVECOT_LOCAL
 
 configure_dovecot_sql_conf()
 {
-	local _localconf="$ZFS_DATA_MNT/dovecot/etc/local.conf"
+	local _localconf
+	_localconf="$(get_jail_data dovecot)/etc/local.conf"
 	if grep -q -E 'driver[[:space:]]*=[[:space:]]*sql' $_localconf; then
 		tell_status "passdb conversion to SQL already complete"
 	else
@@ -242,15 +245,16 @@ configure_dovecot_sql_conf()
  }/sg' /data/etc/local.conf
 	fi
 
-	_localconf="$ZFS_DATA_MNT/dovecot/etc/dovecot-sql.conf.ext"
+	_localconf="$(get_jail_data dovecot)/etc/dovecot-sql.conf.ext"
 	if grep -q -E 'driver[[:space:]]*=[[:space:]]mysql' $_localconf; then
 		tell_status "SQL configured."
 	else
 		tell_status "configuring SQL"
-		local _sqlconf="$ZFS_DATA_MNT/dovecot/etc/dovecot-sql.conf.ext"
+		local _sqlconf
+		_sqlconf="$(get_jail_data dovecot)/etc/dovecot-sql.conf.ext"
 
 		# shellcheck disable=SC2034
-		_vpass=$(grep -v ^# "$ZFS_DATA_MNT/vpopmail/home/etc/vpopmail.mysql" | head -n1 | cut -f4 -d'|')
+		_vpass=$(grep -v ^# "$(get_jail_data vpopmail)/home/etc/vpopmail.mysql" | head -n1 | cut -f4 -d'|')
 
 		store_config "$_sqlconf" "overwrite" <<EO_DOVECOT_SQL
   driver = mysql
@@ -285,7 +289,8 @@ EO_DOVECOT_SQL
 
 configure_example_config()
 {
-	local _dcdir="$ZFS_DATA_MNT/dovecot/etc"
+	local _dcdir
+	_dcdir="$(get_jail_data dovecot)/etc"
 
 	if [ -f "$_dcdir/dovecot.conf" ]; then
 		tell_status "dovecot config files already present"
@@ -301,7 +306,8 @@ configure_example_config()
 
 configure_system_auth()
 {
-	local _authconf="$ZFS_DATA_MNT/dovecot/etc/conf.d/10-auth.conf"
+	local _authconf
+	_authconf="$(get_jail_data dovecot)/etc/conf.d/10-auth.conf"
 	if ! grep -qs '^!include auth\-system' "$_authconf"; then
 		tell_status "system auth already disabled"
 		return
@@ -315,7 +321,8 @@ configure_system_auth()
 
 configure_vsz_limit()
 {
-	local _master="$ZFS_DATA_MNT/dovecot/etc/conf.d/10-master.conf"
+	local _master
+	_master="$(get_jail_data dovecot)/etc/conf.d/10-master.conf"
 	if grep -q ^default_vsz_limit "$_master"; then
 		tell_status "vsz_limit already configured"
 		return
@@ -329,7 +336,8 @@ configure_vsz_limit()
 
 configure_tls_certs()
 {
-	local _sslconf="$ZFS_DATA_MNT/dovecot/etc/conf.d/10-ssl.conf"
+	local _sslconf
+	_sslconf="$(get_jail_data dovecot)/etc/conf.d/10-ssl.conf"
 	if grep -qs ^ssl_cert "$_sslconf"; then
 		tell_status "removing ssl_cert from 10-ssl.conf"
 		sed_inplace \
@@ -338,7 +346,8 @@ configure_tls_certs()
 			"$_sslconf"
 	fi
 
-	local _localconf="$ZFS_DATA_MNT/dovecot/etc/local.conf"
+	local _localconf
+	_localconf="$(get_jail_data dovecot)/etc/local.conf"
 	if grep -qs dovecot.pem "$_localconf"; then
 		sed_inplace \
 			-e "/^ssl_cert/ s/dovecot/${TOASTER_MAIL_DOMAIN}/" \
@@ -346,10 +355,11 @@ configure_tls_certs()
 			"$_localconf"
 	fi
 
-	local _ssldir="$ZFS_DATA_MNT/dovecot/etc/tls"
-	if [ ! -d "$_ssldir" ] && [ -d "$ZFS_DATA_MNT/dovecot/etc/ssl" ]; then
+	local _ssldir
+	_ssldir="$(get_jail_data dovecot)/etc/tls"
+	if [ ! -d "$_ssldir" ] && [ -d "$(get_jail_data dovecot)/etc/ssl" ]; then
 		tell_status "Renaming /data/etc/ssl to /data/etc/tls"
-		mv "$ZFS_DATA_MNT/dovecot/etc/ssl" "$_ssldir"
+		mv "$(get_jail_data dovecot)/etc/ssl" "$_ssldir"
 	fi
 	if [ ! -d "$_ssldir/certs" ]; then
 		# shellcheck disable=SC2174
@@ -483,10 +493,10 @@ configure_sieve_learn_spamassassin()
 		return
 	fi
 
-	if [ ! -x "$ZFS_DATA_MNT/dovecot/bin/spamc" ]; then
+	if [ ! -x "$(get_jail_data dovecot)/bin/spamc" ]; then
 		tell_status "copying spamc into /data/bin"
 		cp "$ZFS_JAIL_MNT/spamassassin/usr/local/bin/spamc" \
-			"$ZFS_DATA_MNT/dovecot/bin/spamc"
+			"$(get_jail_data dovecot)/bin/spamc"
 	fi
 
 	tell_status "creating learn-ham-sa.sh"
@@ -525,7 +535,8 @@ configure_sieve()
 		mkdir "$SIEVE_DIR"
 	fi
 
-	local _lc="$ZFS_DATA_MNT/dovecot/etc/local.conf"
+	local _lc
+	_lc="$(get_jail_data dovecot)/etc/local.conf"
 	if [ -f "$_lc" ] && ! grep -q sieve "$_lc"; then
 		tell_status "sieve not configured. Update local.conf and reinstall dovecot to enable"
 		return
@@ -540,7 +551,7 @@ configure_sieve()
 
 configure_dovecot_pf()
 {
-	_pf_etc="$ZFS_DATA_MNT/dovecot/etc/pf.conf.d"
+	_pf_etc="$(get_jail_data dovecot)/etc/pf.conf.d"
 
 	store_config "$_pf_etc/insecure_mua.table" <<EO_PF_INSECURE
 # RFC 1918 Private IP blocks
@@ -572,7 +583,7 @@ EO_PF_FILTER
 
 configure_dovecot_lastauth()
 {
-	store_exec "$ZFS_DATA_MNT/dovecot/bin/lastauth.sh" <<EO_LASTAUTH
+	store_exec "$(get_jail_data dovecot)/bin/lastauth.sh" <<EO_LASTAUTH
 #!/bin/sh
 
 set -e
@@ -586,12 +597,12 @@ echo "UPDATE vpopmail.lastauth SET timestamp=UNIX_TIMESTAMP(now()), remote_ip='\
 exec "\$@"
 EO_LASTAUTH
 
-	_mycnf="$ZFS_DATA_MNT/dovecot/etc/.my.cnf"
+	_mycnf="$(get_jail_data dovecot)/etc/.my.cnf"
 	store_config "$_mycnf" "overwrite" <<EO_DOVECOT_MY
 [client]
 host=mysql
 user=vpopmail
-password=$(grep -v ^# "$ZFS_DATA_MNT/vpopmail/home/etc/vpopmail.mysql" | head -n1 | cut -f4 -d'|')
+password=$(grep -v ^# "$(get_jail_data vpopmail)/home/etc/vpopmail.mysql" | head -n1 | cut -f4 -d'|')
 database=vpopmail
 EO_DOVECOT_MY
 
@@ -602,7 +613,8 @@ EO_DOVECOT_MY
 configure_dovecot()
 {
 	for _d in etc bin; do
-		local _dcdir="$ZFS_DATA_MNT/dovecot/${_d}"
+		local _dcdir
+		_dcdir="$(get_jail_data dovecot)/${_d}"
 
 		if [ ! -d "$_dcdir" ]; then
 			tell_status "creating $_dcdir"

--- a/provision/geoip.sh
+++ b/provision/geoip.sh
@@ -84,9 +84,9 @@ geoip_periodic()
 
 configure_geoip()
 {
-	if [ -f "$ZFS_DATA_MNT/geoip/GeoIP.conf" ]; then
+	if [ -f "$(get_jail_data geoip)/GeoIP.conf" ]; then
 		tell_status "installing GeoIP.conf"
-		cp "$ZFS_DATA_MNT/geoip/GeoIP.conf" "$STAGE_MNT/usr/local/etc"
+		cp "$(get_jail_data geoip)/GeoIP.conf" "$STAGE_MNT/usr/local/etc"
 	else
 		sed_inplace \
 			-e "/^AccountID/ s/YOUR_ACCOUNT_ID_HERE/$MAXMIND_ACCOUNT_ID/" \
@@ -121,7 +121,7 @@ test_geoip()
 
 migrate_geoip_dbs()
 {
-	if [ ! -f "$ZFS_DATA_MNT/geoip/GeoLite2-Country.mmdb" ]; then
+	if [ ! -f "$(get_jail_data geoip)/GeoLite2-Country.mmdb" ]; then
 		# no geoip data or data already migrated
 		return
 	fi
@@ -145,13 +145,13 @@ migrate_geoip_dbs()
 	service jail stop geoip spamassassin haraka
 
 	for _d in etc db; do
-		_path="$ZFS_DATA_MNT/geoip/$_d"
+		_path="$(get_jail_data geoip)/$_d"
 		[ -d "$_path" ] || mkdir "$_path"
 	done
 
 	for _suffix in mmdb dat; do
-		for _db in "$ZFS_DATA_MNT"/geoip/*."$_suffix"; do
-			mv "$_db" "$ZFS_DATA_MNT/geoip/db/"
+		for _db in "$(get_jail_data geoip)"/*."$_suffix"; do
+			mv "$_db" "$(get_jail_data geoip)/db/"
 		done
 	done
 }

--- a/provision/git.sh
+++ b/provision/git.sh
@@ -75,7 +75,7 @@ configure_nginx_server()
 
 configure_pf()
 {
-	_pf_etc="$ZFS_DATA_MNT/git/etc/pf.conf.d"
+	_pf_etc="$(get_jail_data git)/etc/pf.conf.d"
 
 	store_config "$_pf_etc/rdr.conf" <<EO_GIT_RDR
 int_ip4 = "$(get_jail_ip git)"

--- a/provision/haproxy.sh
+++ b/provision/haproxy.sh
@@ -70,7 +70,8 @@ haproxy_binds()
 
 configure_haproxy_dot_conf()
 {
-	local _data_cf="$ZFS_DATA_MNT/haproxy/etc/haproxy.conf"
+	local _data_cf
+	_data_cf="$(get_jail_data haproxy)/etc/haproxy.conf"
 
 	store_config "$_data_cf" <<EO_HAPROXY_CONF
 global
@@ -390,7 +391,8 @@ EO_OCSP
 
 configure_haproxy_tls()
 {
-	local _tls_dir="$ZFS_DATA_MNT/haproxy/etc/tls.d"
+	local _tls_dir
+	_tls_dir="$(get_jail_data haproxy)/etc/tls.d"
 	if [ ! -d "$_tls_dir" ]; then
 		tell_status "creating $_tls_dir"
 		mkdir -p "$_tls_dir"
@@ -407,9 +409,9 @@ configure_haproxy_tls()
 
 configure_haproxy()
 {
-	if [ ! -d "$ZFS_DATA_MNT/haproxy/etc" ]; then
+	if [ ! -d "$(get_jail_data haproxy)/etc" ]; then
 		tell_status "creating /data/etc"
-		mkdir -p "$ZFS_DATA_MNT/haproxy/etc"
+		mkdir -p "$(get_jail_data haproxy)/etc"
 	fi
 
 	configure_haproxy_dot_conf
@@ -419,7 +421,7 @@ configure_haproxy()
 		mkdir "$STAGE_MNT/var/run/haproxy"
 	fi
 
-	_pf_etc="$ZFS_DATA_MNT/haproxy/etc/pf.conf.d"
+	_pf_etc="$(get_jail_data haproxy)/etc/pf.conf.d"
 	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
 rdr inet  proto tcp from any to <ext_ip4> port { 80 443 } -> $(get_jail_ip haproxy)
 rdr inet6 proto tcp from any to <ext_ip6> port { 80 443 } -> $(get_jail_ip6 haproxy)

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -48,7 +48,7 @@ install_geoip_dbs()
 		return
 	fi
 
-	mount_nullfs "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/stage/usr/local/share/GeoIP"
+	mount_nullfs "$(get_jail_data geoip)/db" "$STAGE_MNT/usr/local/share/GeoIP"
 
 	fstab_add_mount haraka "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP"
 

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -12,7 +12,7 @@ export JAIL_CONF_EXTRA="
 		devfs_ruleset = 7;"
 export JAIL_FSTAB=""
 
-HARAKA_CONF="$ZFS_DATA_MNT/haraka/config"
+HARAKA_CONF="$(get_jail_data haraka)/config"
 
 install_haraka()
 {
@@ -48,9 +48,9 @@ install_geoip_dbs()
 		return
 	fi
 
-	mount_nullfs "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/stage/usr/local/share/GeoIP"
+	mount_nullfs "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/stage/usr/local/share/GeoIP"
 
-	fstab_add_mount haraka "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP"
+	fstab_add_mount haraka "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP"
 
 	if ! grep -qs ^geoip "$HARAKA_CONF/plugins"; then
 		tell_status "enabling Haraka geoip plugin"
@@ -128,7 +128,8 @@ always_ok=true" | tee -a "$HARAKA_CONF/syslog.ini"
 	fi
 
 	# log to the data volume so mail logs survive a re-provision
-	local _logdir="$ZFS_DATA_MNT/haraka/log"
+	local _logdir
+	_logdir="$(get_jail_data haraka)/log"
 	if [ ! -d "$_logdir" ]; then
 		tell_status "creating log dir $_logdir"
 		mkdir -p "$_logdir"
@@ -247,7 +248,7 @@ tmpdir=/data/avg/spool
 	if zfs_filesystem_exists "$ZFS_DATA_VOL/avg"; then
 		tell_status "adding avg data FS to Haraka jail"
 		JAIL_FSTAB="$JAIL_FSTAB
-$ZFS_DATA_MNT/avg   $ZFS_JAIL_MNT/haraka/data/avg nullfs rw 0 0"
+$(get_jail_data avg)   $ZFS_JAIL_MNT/haraka/data/avg nullfs rw 0 0"
 
 		if ! grep -qs spool "$HARAKA_CONF/avg.ini"; then
 			tell_status "update tmpdir in avg.ini"

--- a/provision/letsencrypt.sh
+++ b/provision/letsencrypt.sh
@@ -552,12 +552,13 @@ install_deploy_scripts()
 
 update_haproxy_ssld()
 {
-	if [ ! -d "$ZFS_DATA_MNT/haproxy" ]; then
+	if [ ! -d "$(get_jail_data haproxy)" ]; then
 		# haproxy not installed, nothing to do
 		return
 	fi
 
-	local _haconf="$ZFS_DATA_MNT/haproxy/etc/haproxy.conf"
+	local _haconf
+	_haconf="$(get_jail_data haproxy)/etc/haproxy.conf"
 	if ! grep -q 'ssl crt /etc' "$_haconf"; then
 		# already updated
 		return
@@ -575,7 +576,8 @@ configure_letsencrypt()
 
 	tell_status "configuring acme.sh"
 
-	local _HTTPDIR="$ZFS_DATA_MNT/webmail/htdocs"
+	local _HTTPDIR
+	_HTTPDIR="$(get_jail_data webmail)/htdocs"
 
 	acme.sh --set-default-ca --server letsencrypt
 

--- a/provision/mail_dmarc.sh
+++ b/provision/mail_dmarc.sh
@@ -34,7 +34,8 @@ EO_DMARC
 
 install_dmarc_config()
 {
-	local _data_cf="$ZFS_DATA_MNT/mail_dmarc/mail-dmarc.ini"
+	local _data_cf
+	_data_cf="$(get_jail_data mail_dmarc)/mail-dmarc.ini"
 	if [ -f "$_data_cf" ]; then
 		tell_status "preserving $_data_cf"
 	else

--- a/provision/mailman.sh
+++ b/provision/mailman.sh
@@ -6,7 +6,7 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
 
-_dkim_private_key="$ZFS_DATA_MNT/mailman/dkim/$TOASTER_MAIL_DOMAIN.private"
+_dkim_private_key="$(get_jail_data mailman)/dkim/$TOASTER_MAIL_DOMAIN.private"
 _has_dkim=""
 if [ -f "$_dkim_private_key" ]; then _has_dkim=1; fi
 
@@ -29,7 +29,7 @@ install_mailman()
 	stage_exec pip install postorius hyperkitty mailman-hyperkitty whoosh mailmanclient mailman-web || exit
 
 	_mmhk_pkg="mailman-hyperkitty-1.2.1.tar.gz"
-	if [ ! -d "$ZFS_DATA_MNT/$_mmhk_pkg" ]; then
+	if [ ! -f "$(get_jail_data mailman)/$_mmhk_pkg" ]; then
 		tell_status "installing mailman-hyperkitty"
 		stage_exec fetch -o /data -m "https://files.pythonhosted.org/packages/41/77/352f7f8d1843cd7217d5dffce54fabdfdb403e78870db781c4859a8e9e35/$_mmhk_pkg"
 		stage_exec tar -C /data -xvf "/data/$_mmhk_pkg"
@@ -102,7 +102,7 @@ configure_postfix()
 	stage_exec postconf -e 'local_recipient_maps=hash:/usr/local/mailman/data/postfix_lmtp'
 	stage_exec postconf -e 'relay_domains=hash:/usr/local/mailman/data/postfix_domains'
 
-	if [ -f "$ZFS_DATA_MNT/etc/sasl_passwd" ]; then
+	if [ -f "$(get_jail_data mailman)/etc/sasl_passwd" ]; then
 		stage_exec postmap /data/etc/sasl_passwd
 		stage_exec postconf -e 'smtp_sasl_auth_enable = yes'
 		stage_exec postconf -e 'smtp_sasl_password_maps = hash:/data/etc/sasl_passwd'
@@ -115,9 +115,9 @@ configure_postfix()
 
 	for _f in master main
 	do
-		if [ -f "$ZFS_DATA_MNT/postfix/etc/$_f.cf" ]; then
+		if [ -f "$(get_jail_data postfix)/etc/$_f.cf" ]; then
 			tell_status "preserving /usr/local/etc/postfix/$_f.cf"
-			cp "$ZFS_DATA_MNT/postfix/etc/$_f.cf" "$STAGE_MNT/usr/local/etc/postfix/"
+			cp "$(get_jail_data postfix)/etc/$_f.cf" "$STAGE_MNT/usr/local/etc/postfix/"
 		fi
 	done
 

--- a/provision/mediawiki.sh
+++ b/provision/mediawiki.sh
@@ -97,9 +97,9 @@ configure_mediawiki()
 	configure_nginx mediawiki
 	configure_nginx_server
 
-	if [ -f "$ZFS_DATA_MNT/mediawiki/LocalSettings.php" ]; then
+	if [ -f "$(get_jail_data mediawiki)/LocalSettings.php" ]; then
 		tell_status "installing LocalSettings.php"
-		cp "$ZFS_DATA_MNT/mediawiki/LocalSettings.php" \
+		cp "$(get_jail_data mediawiki)/LocalSettings.php" \
 			"$STAGE_MNT/usr/local/www/mediawiki/" || exit
 	else
 		tell_status "no LocalSettings.php found in /data"

--- a/provision/minecraft.sh
+++ b/provision/minecraft.sh
@@ -3,9 +3,10 @@
 . mail-toaster.sh || exit
 
 export JAIL_START_EXTRA=""
-export JAIL_CONF_EXTRA="
-		mount += \"$ZFS_DATA_MNT/minecraft/etc \$path/usr/local/etc/minecraft-server nullfs rw 0 0\";
-		mount += \"$ZFS_DATA_MNT/minecraft/db \$path/var/db/minecraft-server nullfs rw 0 0\";"
+export JAIL_CONF_EXTRA
+JAIL_CONF_EXTRA="
+		mount += \"$(get_jail_data minecraft)/etc \$path/usr/local/etc/minecraft-server nullfs rw 0 0\";
+		mount += \"$(get_jail_data minecraft)/db \$path/var/db/minecraft-server nullfs rw 0 0\";"
 export JAIL_FSTAB=""
 
 install_minecraft()
@@ -26,11 +27,11 @@ games_minecraft-server_UNSET=STANDALONE'
 configure_minecraft()
 {
 	tell_status "configuring minecraft"
-	if [ ! -d "$ZFS_DATA_MNT/minecraft/etc" ]; then
-		mkdir "$ZFS_DATA_MNT/minecraft/etc"
+	if [ ! -d "$(get_jail_data minecraft)/etc" ]; then
+		mkdir "$(get_jail_data minecraft)/etc"
 	fi
-	if [ ! -d "$ZFS_DATA_MNT/minecraft/db" ]; then
-		mkdir "$ZFS_DATA_MNT/minecraft/db"
+	if [ ! -d "$(get_jail_data minecraft)/db" ]; then
+		mkdir "$(get_jail_data minecraft)/db"
 	fi
 
 	# stage_exec /usr/local/bin/minecraft-server

--- a/provision/munin.sh
+++ b/provision/munin.sh
@@ -89,8 +89,8 @@ configure_munin()
 
 	tell_status "configuring munin"
 
-	if [ ! -d "$ZFS_DATA_MNT/munin/etc" ]; then
-		mkdir "$ZFS_DATA_MNT/munin/etc"
+	if [ ! -d "$(get_jail_data munin)/etc" ]; then
+		mkdir "$(get_jail_data munin)/etc"
 	fi
 	if [ -d "$STAGE_MNT/data/etc/munin" ]; then
 		rm -r "$STAGE_MNT/usr/local/etc/munin"
@@ -99,9 +99,9 @@ configure_munin()
 	fi
 	stage_exec ln -s /data/etc/munin /usr/local/etc/munin
 
-	if [ ! -d "$ZFS_DATA_MNT/munin/var/munin" ]; then
-		mkdir -p "$ZFS_DATA_MNT/munin/var/munin"
-		chown -R 842:842 "$ZFS_DATA_MNT/munin/var/munin"
+	if [ ! -d "$(get_jail_data munin)/var/munin" ]; then
+		mkdir -p "$(get_jail_data munin)/var/munin"
+		chown -R 842:842 "$(get_jail_data munin)/var/munin"
 	fi
 
 	if ! grep -qs ^#graph_strategy "$STAGE_MNT/data/etc/munin/munin.conf" ; then

--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -64,7 +64,8 @@ EO_MY_CNF
 
 configure_mysql_keys()
 {
-	local _dbdir="$ZFS_DATA_MNT/mysql/db"
+	local _dbdir
+	_dbdir="$(get_jail_data mysql)/db"
 
 	if [ ! -f "$_dbdir/private_key.pem" ]; then
 		tell_status "enabling sha256_password support"
@@ -147,7 +148,8 @@ configure_mysql()
 	stage_sysrc mysql_dbdir="/data/db"
 	stage_sysrc mysql_optfile="/data/etc/extra.cnf"
 
-	local _dbdir="$ZFS_DATA_MNT/mysql/db"
+	local _dbdir
+	_dbdir="$(get_jail_data mysql)/db"
 
 	local _my_cnf="$STAGE_MNT/data/etc/extra.cnf"
 	store_config "$_my_cnf" <<EO_MY_CNF
@@ -195,7 +197,7 @@ test_mysql()
 
 migrate_mysql_dbs()
 {
-	if [ -f "$ZFS_DATA_MNT/mysql/mysql.err" ]; then
+	if [ -f "$(get_jail_data mysql)/mysql.err" ]; then
 		echo "
 	HALT: mysql data migration required.
 
@@ -247,7 +249,8 @@ check_mysql_native_passwords()
 	# but leaves it disabled by default. Setting mysql_native_password=ON in
 	# [mysqld] re-enables it, so the upgrade is safe even with accounts that
 	# still use the plugin.
-	local _extra_cnf="$ZFS_DATA_MNT/mysql/etc/extra.cnf"
+	local _extra_cnf
+	_extra_cnf="$(get_jail_data mysql)/etc/extra.cnf"
 	if [ -f "$_extra_cnf" ] && awk '
 		/^[[:space:]]*\[mysqld\][[:space:]]*$/ { in_section = 1; next }
 		/^[[:space:]]*\[/                      { in_section = 0 }

--- a/provision/postfix.sh
+++ b/provision/postfix.sh
@@ -8,7 +8,7 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
 
-_dkim_private_key="$ZFS_DATA_MNT/postfix/dkim/$TOASTER_MAIL_DOMAIN.private"
+_dkim_private_key="$(get_jail_data postfix)/dkim/$TOASTER_MAIL_DOMAIN.private"
 
 install_postfix()
 {
@@ -84,10 +84,11 @@ EO_TRUSTED_HOSTS
 
 configure_tls_certs()
 {
-	local _ssldir="$ZFS_DATA_MNT/postfix/etc/tls"
-	if [ ! -d "$_ssldir" ] && [ -d "$ZFS_DATA_MNT/postfix/etc/ssl" ]; then
+	local _ssldir
+	_ssldir="$(get_jail_data postfix)/etc/tls"
+	if [ ! -d "$_ssldir" ] && [ -d "$(get_jail_data postfix)/etc/ssl" ]; then
 		tell_status "Renaming /data/etc/ssl to /data/etc/tls"
-		mv "$ZFS_DATA_MNT/postfix/etc/ssl" "$_ssldir"
+		mv "$(get_jail_data postfix)/etc/ssl" "$_ssldir"
 	fi
 
 	# shellcheck disable=SC2174
@@ -108,7 +109,8 @@ configure_tls_certs()
 
 configure_postfix_main_cf()
 {
-	local _main_cf="$ZFS_DATA_MNT/postfix/etc/main.cf"
+	local _main_cf
+	_main_cf="$(get_jail_data postfix)/etc/main.cf"
 	local _ssldir="/data/etc/tls"
 	export MAIL_CONFIG="/data/etc"  # postconf needs this
 
@@ -143,13 +145,13 @@ configure_postfix_main_cf()
 	stage_exec postconf -e 'lmtp_tls_security_level = may'
 	stage_exec postconf -e "mynetworks = ${JAIL_NET_PREFIX}.0${JAIL_NET_MASK}"
 
-	if [ -f "$ZFS_DATA_MNT/postfix/etc/sasl_passwd" ]; then
+	if [ -f "$(get_jail_data postfix)/etc/sasl_passwd" ]; then
 		stage_exec postmap /data/etc/sasl_passwd
 		stage_exec postconf -e 'smtp_sasl_auth_enable = yes'
 		stage_exec postconf -e 'smtp_sasl_password_maps = hash:/data/etc/sasl_passwd'
 	fi
 
-	if [ -f "$ZFS_DATA_MNT/postfix/etc/transport" ]; then
+	if [ -f "$(get_jail_data postfix)/etc/transport" ]; then
 		stage_exec postmap /data/etc/transport
 		stage_exec postconf -e 'transport_maps = hash:/data/etc/transport'
 	fi
@@ -180,7 +182,8 @@ enable_postfix_submission()
 
 configure_postfix_master_cf()
 {
-	local _master_cf="$ZFS_DATA_MNT/postfix/etc/master.cf"
+	local _master_cf
+	_master_cf="$(get_jail_data postfix)/etc/master.cf"
 	if [ -f "$_master_cf" ]; then
 		tell_status "preserving $_master_cf"
 	else
@@ -199,7 +202,7 @@ configure_postfix()
 	stage_sysrc postfix_enable=YES
 	stage_sysrc postfix_flags="-c /data/etc"
 
-	if [ -e "$ZFS_DATA_MNT/spool" ]; then
+	if [ -e "$(get_jail_data postfix)/spool" ]; then
 		stage_sysrc postfix_pidfile=/data/spool/pid/master.pid
 	fi
 
@@ -234,7 +237,7 @@ start_postfix()
 	if [ -f "$_dkim_private_key" ]; then
 		stage_exec service milter-opendkim start
 	fi
-	if [ -f "$ZFS_DATA_MNT/postfix/spool/pid/master.pid" ]; then
+	if [ -f "$(get_jail_data postfix)/spool/pid/master.pid" ]; then
 		jexec postfix service postfix stop
 	fi
 	stage_exec service postfix start

--- a/provision/rainloop.sh
+++ b/provision/rainloop.sh
@@ -67,7 +67,8 @@ configure_nginx_server()
 
 install_default_ini()
 {
-	local _rlconfdir="$ZFS_DATA_MNT/rainloop/_data_/_default_"
+	local _rlconfdir
+	_rlconfdir="$(get_jail_data rainloop)/_data_/_default_"
 	local _dini="$_rlconfdir/domains/default.ini"
 	if [ -f "$_dini" ]; then
 		tell_status "preserving default.ini"
@@ -124,7 +125,7 @@ configure_rainloop()
 	install_default_ini
 
 	# for persistent data storage
-	chown -R 80:80 "$ZFS_DATA_MNT/rainloop/"
+	chown -R 80:80 "$(get_jail_data rainloop)/"
 }
 
 start_rainloop()

--- a/provision/roundcube.sh
+++ b/provision/roundcube.sh
@@ -94,7 +94,8 @@ were already applied by hand, record the version with:
 
 migrate_roundcube_nginx_conf()
 {
-	local _conf="$ZFS_DATA_MNT/roundcube/etc/nginx/server.d/roundcube.conf"
+	local _conf
+	_conf="$(get_jail_data roundcube)/etc/nginx/server.d/roundcube.conf"
 
 	if [ ! -f "$_conf" ] || grep -q public_html "$_conf"; then return; fi
 
@@ -107,7 +108,7 @@ migrate_roundcube_nginx_conf()
 install_roundcube_plugins()
 {
 	local _rc_plugins="contextmenu html5_notifier larry"
-	if [ -d "$ZFS_DATA_MNT/spamassassin/etc" ]; then
+	if [ -d "$(get_jail_data spamassassin)/etc" ]; then
 		_rc_plugins="$_rc_plugins sauserprefs"
 	fi
 
@@ -191,7 +192,8 @@ EO_RC_LOCAL
 
 install_logo()
 {
-	local _logo_path="$ZFS_DATA_MNT/roundcube/logo.svg"
+	local _logo_path
+	_logo_path="$(get_jail_data roundcube)/logo.svg"
 	if [ ! -f "$_logo_path" ]; then
 		tell_status "PRO TIP: populate $_logo_path"
 		return;
@@ -229,7 +231,7 @@ configure_roundcube_plugins()
 		-e "/'password_vpopmaild_host'/s/localhost/vpopmail/" \
 		"$STAGE_MNT/usr/local/www/roundcube/plugins/password/config.inc.php"
 
-	if [ -d "$ZFS_DATA_MNT/spamassassin/etc" ]; then
+	if [ -d "$(get_jail_data spamassassin)/etc" ]; then
 
 		if [ ! -f "$STAGE_MNT/usr/local/www/roundcube/plugins/sauserprefs/config.inc.php" ] &&
 		   [   -f "$STAGE_MNT/usr/local/www/roundcube/plugins/sauserprefs/config.inc.php.dist" ]; then
@@ -239,7 +241,7 @@ configure_roundcube_plugins()
 		fi
 
 		local _sapass
-		_sapass=$(grep user_scores_sql_password "$ZFS_DATA_MNT/spamassassin/etc/sql.cf" | awk '{ print $2 }')
+		_sapass=$(grep user_scores_sql_password "$(get_jail_data spamassassin)/etc/sql.cf" | awk '{ print $2 }')
 		if [ -n "$_sapass" ]; then
 			tell_status "configure the SA UserPrefs plugin"
 			sed_inplace \
@@ -314,7 +316,7 @@ EO_RC_ADD
 			-e "/^\$config\['db_dsnw'/ s/= .*/= 'sqlite:\/\/\/\/data\/sqlite.db?mode=0646';/" \
 			"$_stage_cfg"
 
-		if [ ! -f "$ZFS_DATA_MNT/roundcube/sqlite.db" ]; then
+		if [ ! -f "$(get_jail_data roundcube)/sqlite.db" ]; then
 			mkdir -p "$STAGE_MNT/data"
 			chown 80:80 "$STAGE_MNT/data"
 			roundcube_init_db

--- a/provision/rsnapshot.sh
+++ b/provision/rsnapshot.sh
@@ -29,21 +29,21 @@ EO_RSNAP
 
 	for d in etc snaps
 	do
-		if [ ! -d "$ZFS_DATA_MNT/rsnapshot/$d" ]; then
-			mkdir "$ZFS_DATA_MNT/rsnapshot/$d"
+		if [ ! -d "$(get_jail_data rsnapshot)/$d" ]; then
+			mkdir "$(get_jail_data rsnapshot)/$d"
 		fi
 	done
 
-	if [ ! -f "$ZFS_DATA_MNT/rsnapshot/etc/rsnapshot.conf" ]; then
-		tell-status "installing default $ZFS_DATA_MNT/etc/rsnapshot.conf"
-		cp "$STAGE_MNT/usr/local/etc/rsnapshot.conf.default" "$ZFS_DATA_MNT/rsnapshot/etc/rsnapshot.conf"
+	if [ ! -f "$(get_jail_data rsnapshot)/etc/rsnapshot.conf" ]; then
+		tell_status "installing default $(get_jail_data rsnapshot)/etc/rsnapshot.conf"
+		cp "$STAGE_MNT/usr/local/etc/rsnapshot.conf.default" "$(get_jail_data rsnapshot)/etc/rsnapshot.conf"
 	fi
 
-	if [ -d "$ZFS_DATA_MNT/rsnapshot/ssh" ]; then
+	if [ -d "$(get_jail_data rsnapshot)/ssh" ]; then
 		if [ ! -d "$STAGE_MNT/root/.ssh" ]; then
 			umask 0077; mkdir "$STAGE_MNT/root/.ssh"; umask 0022;
 		fi
-		cp "$ZFS_DATA_MNT/rsnapshot/ssh/"* "$STAGE_MNT/root/.ssh/"
+		cp "$(get_jail_data rsnapshot)/ssh/"* "$STAGE_MNT/root/.ssh/"
 	fi
 }
 

--- a/provision/smf.sh
+++ b/provision/smf.sh
@@ -72,9 +72,9 @@ configure_smf()
 	configure_nginx smf
 	configure_nginx_server
 
-	if [ -f "$ZFS_DATA_MNT/smf/Settings.php" ]; then
+	if [ -f "$(get_jail_data smf)/Settings.php" ]; then
 		tell_status "preserving Settings.php"
-		cp "$ZFS_DATA_MNT/smf/Settings.php" "$STAGE_MNT/usr/local/www/smf/" || exit
+		cp "$(get_jail_data smf)/Settings.php" "$STAGE_MNT/usr/local/www/smf/" || exit
 	elif [ -f "$ZFS_JAIL_MNT/smf/usr/local/www/smf/Settings.php" ]; then
 		preserve_file smf /usr/local/www/smf/Settings.php
 	else

--- a/provision/snappymail.sh
+++ b/provision/snappymail.sh
@@ -87,7 +87,8 @@ configure_nginx_server()
 
 install_default_json()
 {
-	local _rlconfdir="$ZFS_DATA_MNT/snappymail/_data_/_default_"
+	local _rlconfdir
+	_rlconfdir="$(get_jail_data snappymail)/_data_/_default_"
 	if [ ! -d "$_rlconfdir/domains" ]; then
 		tell_status "creating default/domains dir"
 		mkdir -p "$_rlconfdir/domains"
@@ -189,7 +190,8 @@ EO_INCLUDE
 
 set_application_path()
 {
-	local _appini="$ZFS_DATA_MNT/snappymail/_data_/_default_/domains/default.json"
+	local _appini
+	_appini="$(get_jail_data snappymail)/_data_/_default_/domains/default.json"
 
 	if [ ! -f "$_appini" ]; then
 		echo "missing $_appini"
@@ -235,7 +237,7 @@ configure_snappymail()
 	install_default_json
 
 	# for persistent data storage
-	chown -R 80:80 "$ZFS_DATA_MNT/snappymail/"
+	chown -R 80:80 "$(get_jail_data snappymail)/"
 
 	#configure_admin_password
 }

--- a/provision/spamassassin.sh
+++ b/provision/spamassassin.sh
@@ -8,7 +8,8 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
 if zfs_filesystem_exists "$ZFS_DATA_VOL/geoip"; then
-	export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0"
+	export JAIL_FSTAB
+	JAIL_FSTAB="$(get_jail_data geoip)/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0"
 fi
 
 mt6-include mysql
@@ -50,7 +51,7 @@ install_spamassassin_port()
 
 install_spamassassin_data_fs()
 {
-	for _d in $ZFS_DATA_MNT/spamassassin/etc $ZFS_DATA_MNT/spamassassin/var $STAGE_MNT/usr/local/etc/mail; do
+	for _d in $(get_jail_data spamassassin)/etc $(get_jail_data spamassassin)/var $STAGE_MNT/usr/local/etc/mail; do
 		if [ ! -d "$_d" ]; then
 			tell_status "creating $_d"
 			mkdir "$_d"
@@ -148,7 +149,7 @@ configure_geoip()
 		return
 	fi
 
-	fstab_add_mount spamassassin "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP"
+	fstab_add_mount spamassassin "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP"
 
 	tell_status "GeoIP present, enabling RelayCountry plugin"
 	store_config "$_relay_pre" "overwrite" <<EO_RELAY_COUNTRY
@@ -160,7 +161,7 @@ EO_RELAY_COUNTRY
 
 configure_spamassassin()
 {
-	_sa_etc="$ZFS_DATA_MNT/spamassassin/etc"
+	_sa_etc="$(get_jail_data spamassassin)/etc"
 
 	if [ ! -f "$_sa_etc/local.pre" ]; then
 		tell_status "installing local.pre"

--- a/provision/sphinxsearch.sh
+++ b/provision/sphinxsearch.sh
@@ -20,7 +20,8 @@ install_sphinxsearch()
 
 configure_sphinxsearch()
 {
-  local _dbdir="$ZFS_DATA_MNT/db"
+  local _dbdir
+  _dbdir="$(get_jail_data sphinxsearch)/db"
   if [ ! -d "$_dbdir" ]; then
     mkdir -p "$_dbdir" || exit
   fi

--- a/provision/sqwebmail.sh
+++ b/provision/sqwebmail.sh
@@ -4,7 +4,8 @@
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/sqwebmail/usr/local/vpopmail nullfs rw 0 0"
+export JAIL_FSTAB
+JAIL_FSTAB="$(get_jail_data vpopmail)/home $ZFS_JAIL_MNT/sqwebmail/usr/local/vpopmail nullfs rw 0 0"
 
 mt6-include vpopmail
 

--- a/provision/stalwart.sh
+++ b/provision/stalwart.sh
@@ -17,13 +17,14 @@ export JAIL_START_EXTRA="allow.mount
 "
 export JAIL_CONF_EXTRA='
 		allow.raw_sockets;'
-export JAIL_FSTAB="
+export JAIL_FSTAB
+JAIL_FSTAB="
 devfs     $ZFS_JAIL_MNT/stalwart/compat/linux/dev     devfs     rw,late  0 0
 tmpfs     $ZFS_JAIL_MNT/stalwart/compat/linux/dev/shm tmpfs     rw,late,size=1g,mode=1777  0 0
 fdescfs   $ZFS_JAIL_MNT/stalwart/compat/linux/dev/fd  fdescfs   rw,late,linrdlnk 0 0
 linprocfs $ZFS_JAIL_MNT/stalwart/compat/linux/proc    linprocfs rw,late  0 0
 linsysfs  $ZFS_JAIL_MNT/stalwart/compat/linux/sys     linsysfs  rw,late  0 0
-$ZFS_DATA_MNT/stalwart/linux $ZFS_JAIL_MNT/stalwart/compat/linux/stalwart nullfs rw,late 0,0
+$(get_jail_data stalwart)/linux $ZFS_JAIL_MNT/stalwart/compat/linux/stalwart nullfs rw,late 0,0
 #/tmp      $ZFS_JAIL_MNT/stalwart/compat/linux/tmp     nullfs    rw,late  0 0
 #/home     $ZFS_JAIL_MNT/stalwart/compat/linux/home    nullfs    rw,late  0 0"
 
@@ -223,7 +224,7 @@ test_stalwart()
 
 base_snapshot_exists
 create_staged_fs stalwart
-mkdir -p "$ZFS_DATA_MNT/stalwart/linux"
+mkdir -p "$(get_jail_data stalwart)/linux"
 for _d in dev/shm dev/fd proc sys stalwart; do
 	mkdir -p "$STAGE_MNT/compat/linux/$_d"
 done

--- a/provision/tinydns.sh
+++ b/provision/tinydns.sh
@@ -21,7 +21,7 @@ configure_tinydns()
 
 configure_tinydns_data()
 {
-	_data_root="$ZFS_DATA_MNT/tinydns/root"
+	_data_root="$(get_jail_data tinydns)/root"
 	if [ -d "$_data_root" ]; then
 		tell_status "tinydns data already configured"
 		return
@@ -46,7 +46,7 @@ test_tinydns()
 	echo "tinydns is running."
 
 	local _fqdn="www.example.com"
-	if ! grep -qs "$_fqdn" "$ZFS_DATA_MNT/tinydns/root/data"; then
+	if ! grep -qs "$_fqdn" "$(get_jail_data tinydns)/root/data"; then
 		_fqdn="$TOASTER_HOSTNAME"
 	fi
 
@@ -63,11 +63,11 @@ test_tinydns()
 	stage_exec service svscan stop
 	for d in tinydns axfrdns tinydns-v6 axfrdns-v6
 	do
-		if [ -d "$ZFS_DATA_MNT/tinydns/service/$d" ]; then
+		if [ -d "$(get_jail_data tinydns)/service/$d" ]; then
 			tell_status "preserving $d service definition"
 		else
 			tell_status "moving $d from staging to production"
-			mv "$STAGE_MNT/var/service/$d" "$ZFS_DATA_MNT/tinydns/service/"
+			mv "$STAGE_MNT/var/service/$d" "$(get_jail_data tinydns)/service/"
 		fi
 	done
 	stage_sysrc svscan_servicedir="/data/service"

--- a/provision/ubuntu.sh
+++ b/provision/ubuntu.sh
@@ -35,9 +35,9 @@ install_ubuntu()
 base_snapshot_exists
 create_staged_fs ubuntu
 for _fs in dev proc sys tmp home; do
-	mkdir -p "$ZFS_JAIL_MNT/stage/compat/linux/$_fs"
+	mkdir -p "$STAGE_MNT/compat/linux/$_fs"
 done
-chmod 777 "$ZFS_JAIL_MNT/stage/compat/linux/tmp"
+chmod 777 "$STAGE_MNT/compat/linux/tmp"
 start_staged_jail ubuntu
 install_ubuntu
 promote_staged_jail ubuntu

--- a/provision/unifi.sh
+++ b/provision/unifi.sh
@@ -9,8 +9,9 @@ export UNIFI_MONGODB_DSN=${UNIFI_MONGODB_DSN:-""}
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB="fdescfs	$ZFS_JAIL_MNT/unifi/dev/fd	fdescfs	rw	0	0
-$ZFS_DATA_MNT/unifi/java	$ZFS_JAIL_MNT/unifi/usr/local/share/java	nullfs	rw	0	0
+export JAIL_FSTAB
+JAIL_FSTAB="fdescfs	$ZFS_JAIL_MNT/unifi/dev/fd	fdescfs	rw	0	0
+$(get_jail_data unifi)/java	$ZFS_JAIL_MNT/unifi/usr/local/share/java	nullfs	rw	0	0
 proc	$ZFS_JAIL_MNT/unifi/proc	procfs	rw	0	0"
 
 mt6-include network
@@ -43,8 +44,8 @@ create_unifi_mountpoints()
 
 	mkdir -p "$STAGE_MNT/usr/local/share/java"
 
-	if [ ! -d "$ZFS_DATA_MNT/unifi/java" ]; then
-		mkdir "$ZFS_DATA_MNT/unifi/java"
+	if [ ! -d "$(get_jail_data unifi)/java" ]; then
+		mkdir "$(get_jail_data unifi)/java"
 	fi
 }
 

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -9,7 +9,8 @@ export TOASTER_VQADMIN=${TOASTER_VQADMIN:-"0"}
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB="$ZFS_DATA_MNT/vpopmail/home $ZFS_JAIL_MNT/vpopmail/usr/local/vpopmail nullfs rw 0 0"
+export JAIL_FSTAB
+JAIL_FSTAB="$(get_jail_data vpopmail)/home $ZFS_JAIL_MNT/vpopmail/usr/local/vpopmail nullfs rw 0 0"
 
 export VPOPMAIL_OPTIONS_SET=""
 export VPOPMAIL_OPTIONS_UNSET="ROAMING PGSQL LDAP ORACLE SYBASE"
@@ -144,8 +145,8 @@ mail_qmailadmin_UNSET=CATCHALL CRACKLIB DOMAIN_AUTOFILL IDX_SQL SPAM_DETECTION S
 	fi
 
 	for _d in htdocs cgi-bin; do
-		if [ ! -d "$ZFS_DATA_MNT/vpopmail/$_d" ]; then
-			mkdir "$ZFS_DATA_MNT/vpopmail/$_d"
+		if [ ! -d "$(get_jail_data vpopmail)/$_d" ]; then
+			mkdir "$(get_jail_data vpopmail)/$_d"
 		fi
 	done
 
@@ -340,7 +341,7 @@ test_vpopmail()
 
 migrate_vpopmail_home()
 {
-	if [ ! -d "$ZFS_DATA_MNT/vpopmail/domains" ]; then
+	if [ ! -d "$(get_jail_data vpopmail)/domains" ]; then
 		# no vpopmail data or data already migrated
 		return
 	fi
@@ -391,16 +392,16 @@ migrate_vpopmail_home()
 	# service jail stop dovecot vpopmail
 
 	# for _d in bin domains include qmail-control doc etc lib qmail-users; do
-	# 	echo "mv $ZFS_DATA_MNT/vpopmail/$_d $ZFS_DATA_MNT/vpopmail/home/"
-	# 	mv "$ZFS_DATA_MNT/vpopmail/$_d" "$ZFS_DATA_MNT/vpopmail/home/"
+	# 	echo "mv $(get_jail_data vpopmail)/$_d $(get_jail_data vpopmail)/home/"
+	# 	mv "$(get_jail_data vpopmail)/$_d" "$(get_jail_data vpopmail)/home/"
 	# done
 
-	# if [ ! -d "$ZFS_DATA_MNT/vpopmail/etc" ]; then
-	# 	mkdir "$ZFS_DATA_MNT/vpopmail/etc"
+	# if [ ! -d "$(get_jail_data vpopmail)/etc" ]; then
+	# 	mkdir "$(get_jail_data vpopmail)/etc"
 	# fi
 
-	# if [ -d "$ZFS_DATA_MNT/vpopmail/home/etc/pf.conf.d" ]; then
-	# 	mv "$ZFS_DATA_MNT/vpopmail/home/etc/pf.conf.d" "$ZFS_DATA_MNT/vpopmail/etc/"
+	# if [ -d "$(get_jail_data vpopmail)/home/etc/pf.conf.d" ]; then
+	# 	mv "$(get_jail_data vpopmail)/home/etc/pf.conf.d" "$(get_jail_data vpopmail)/etc/"
 	# fi
 
 	# # TODO: patch fstab mounts in /etc/jail.conf
@@ -413,8 +414,8 @@ base_snapshot_exists || exit 1
 create_staged_fs vpopmail
 
 mkdir -p "$STAGE_MNT/usr/local/vpopmail" \
-	"$ZFS_DATA_MNT/vpopmail/home" \
-	"$ZFS_DATA_MNT/vpopmail/etc"
+	"$(get_jail_data vpopmail)/home" \
+	"$(get_jail_data vpopmail)/etc"
 
 start_staged_jail vpopmail
 install_vpopmail

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -387,25 +387,6 @@ migrate_vpopmail_home()
 		   service jail start vpopmail dovecot
 
 	'
-	exit
-
-	# service jail stop dovecot vpopmail
-
-	# for _d in bin domains include qmail-control doc etc lib qmail-users; do
-	# 	echo "mv $(get_jail_data vpopmail)/$_d $(get_jail_data vpopmail)/home/"
-	# 	mv "$(get_jail_data vpopmail)/$_d" "$(get_jail_data vpopmail)/home/"
-	# done
-
-	# if [ ! -d "$(get_jail_data vpopmail)/etc" ]; then
-	# 	mkdir "$(get_jail_data vpopmail)/etc"
-	# fi
-
-	# if [ -d "$(get_jail_data vpopmail)/home/etc/pf.conf.d" ]; then
-	# 	mv "$(get_jail_data vpopmail)/home/etc/pf.conf.d" "$(get_jail_data vpopmail)/etc/"
-	# fi
-
-	# # TODO: patch fstab mounts in /etc/jail.conf
-	# service jail start dovecot vpopmail
 }
 
 tell_settings VPOPMAIL

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -94,7 +94,7 @@ configure_nginx_server()
 	configure_nginx_server_port_80
 	configure_nginx_server_port_443
 
-	store_config "$ZFS_DATA_MNT/webmail/etc/nginx/webmail.conf" "overwrite" <<EO_WEBMAIL_INCLUDE
+	store_config "$(get_jail_data webmail)/etc/nginx/webmail.conf" "overwrite" <<EO_WEBMAIL_INCLUDE
 		proxy_set_header X-Forwarded-For \$remote_addr;
 		proxy_set_header X-Forwarded-Proto \$scheme;
 		proxy_set_header Host \$host;
@@ -289,7 +289,8 @@ EO_WEBMAIL_INCLUDE
 
 configure_nginx_auth()
 {
-	local _etc="$ZFS_DATA_MNT/webmail/etc/nginx"
+	local _etc
+	_etc="$(get_jail_data webmail)/etc/nginx"
 
 	store_config "$_etc/protected.conf" <<'EO_PROTECTED'
 # Routes that include this file require a valid login unless the client IP
@@ -344,8 +345,10 @@ configure_nginx_acme()
 {
 	if [ "$TOASTER_NGINX_ACME" != "1" ]; then return; fi
 
-	local _conf="$ZFS_DATA_MNT/webmail/etc/nginx/nginx.conf"
-	local _acme_conf="$ZFS_DATA_MNT/webmail/etc/nginx/server.d/acme.conf"
+	local _conf
+	_conf="$(get_jail_data webmail)/etc/nginx/nginx.conf"
+	local _acme_conf
+	_acme_conf="$(get_jail_data webmail)/etc/nginx/server.d/acme.conf"
 
 	if [ -f "$_acme_conf" ]; then
 		tell_status "preserving $_acme_conf"
@@ -356,7 +359,7 @@ configure_nginx_acme()
 
 	sed_inplace -e '/ngx_http_acme_module.so/ s/^# //;' "$_conf"
 
-	mkdir -p "$ZFS_DATA_MNT/webmail/etc/acme/letsencrypt"
+	mkdir -p "$(get_jail_data webmail)/etc/acme/letsencrypt"
 
 	store_config "$_acme_conf" <<EO_NGINX_ACME
 	resolver $(get_jail_ip dns) valid=60s;
@@ -381,7 +384,7 @@ install_webmail()
 
 configure_webmail_pf()
 {
-	_pf_etc="$ZFS_DATA_MNT/webmail/etc/pf.conf.d"
+	_pf_etc="$(get_jail_data webmail)/etc/pf.conf.d"
 
 	if [ "$TOASTER_WEBMAIL_PROXY" = "nginx" ]; then
 		store_config "$_pf_etc/rdr.conf" <<EO_WEBMAIL_RDR
@@ -412,7 +415,7 @@ configure_webmail()
 
 	configure_webmail_pf
 
-	_data="$ZFS_DATA_MNT/webmail"
+	_data="$(get_jail_data webmail)"
 	_htdocs="$_data/htdocs"
 	if [ ! -d "$_htdocs/img" ]; then mkdir -p "$_htdocs/img"; fi
 

--- a/provision/whmcs.sh
+++ b/provision/whmcs.sh
@@ -6,7 +6,8 @@ set -e
 
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
-export JAIL_FSTAB="$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP nullfs rw 0 0"
+export JAIL_FSTAB
+JAIL_FSTAB="$(get_jail_data geoip)/db $ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP nullfs rw 0 0"
 
 mt6-include php
 mt6-include nginx
@@ -83,7 +84,7 @@ EO_CRONTAB
 
 	configure_whmcs_nginx
 
-	fstab_add_mount whmcs "$ZFS_DATA_MNT/geoip/db" "$ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP"
+	fstab_add_mount whmcs "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/whmcs/usr/local/share/GeoIP"
 }
 
 start_whmcs()

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -358,7 +358,8 @@ configure_zonemta_admin()
 
 configure_pf()
 {
-	local _pf_etc="$ZFS_DATA_MNT/wildduck/etc/pf.conf.d"
+	local _pf_etc
+	_pf_etc="$(get_jail_data wildduck)/etc/pf.conf.d"
 
 	get_public_ip4
 	get_public_ip6
@@ -405,7 +406,8 @@ EO_FILTER
 configure_haraka()
 {
 	tell_status "configuring Haraka"
-	local _cfg="$ZFS_DATA_MNT/wildduck/haraka/config"
+	local _cfg
+	_cfg="$(get_jail_data wildduck)/haraka/config"
 
 	tell_status "installing $_cfg/clamd.ini"
 	cat <<EO_CLAM > "$_cfg/clamd.ini"
@@ -497,7 +499,7 @@ EO_RSPAMD
 			-e "/host:/ s/'127.0.0.1'/redis/" \
 			-e "/db:/ s/3/9/" \
 			-e "/mongodb:/ s/127.0.0.1/$(get_jail_ip mongodb)/" \
-			"$ZFS_DATA_MNT/wildduck/haraka/plugins/wildduck/config/wildduck.yaml" \
+			"$(get_jail_data wildduck)/haraka/plugins/wildduck/config/wildduck.yaml" \
 			> "$_cfg/wildduck.yaml"
 			# -e "/secret: / s/secret value/$TODO/" \
 			# -e "/loopSecret: / s/secret value/$TODO/" \

--- a/provision/wordpress.sh
+++ b/provision/wordpress.sh
@@ -66,7 +66,8 @@ configure_nginx_server()
 
 configure_wp_config()
 {
-	local _local_content="$ZFS_DATA_MNT/wordpress/content"
+	local _local_content
+	_local_content="$(get_jail_data wordpress)/content"
 	local _wp_install="$ZFS_JAIL_MNT/wordpress/usr/local/www/wordpress"
 	local _wp_stage="$STAGE_MNT/usr/local/www/wordpress"
 

--- a/test/include/nginx.bats
+++ b/test/include/nginx.bats
@@ -9,6 +9,15 @@ setup() {
 mt6-include() { :; }
 tell_status() { :; }
 
+# faithful copy of include/jail.sh get_jail_data
+get_jail_data() {
+  if [ "$1" = "base" ]; then
+    echo "$BASE_MNT/data"
+  else
+    echo "$ZFS_DATA_MNT/$1"
+  fi
+}
+
 # faithful copy of include/util.sh store_config: always writes <file>.mt6,
 # installs the live file only when absent (or on overwrite/append)
 store_config() {

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -493,3 +493,24 @@ unmounted_paths() {
   assert_output --partial "STAGE_MNT is unset"
   refute_output --partial "umount /"
 }
+
+@test "assure_ports_tree accepts a populated tree" {
+  local _ports; _ports=$(mktemp -d)
+  touch "$_ports/Makefile"
+  run assure_ports_tree "$_ports"
+  assert_success
+}
+
+@test "assure_ports_tree rejects an unpopulated tree" {
+  local _ports; _ports=$(mktemp -d)
+  run assure_ports_tree "$_ports"
+  assert_failure
+  assert_output --partial "$_ports"
+}
+
+@test "assure_ports_tree names both ways to populate the tree" {
+  local _ports; _ports=$(mktemp -d)
+  run assure_ports_tree "$_ports"
+  assert_output --partial "gitup ports"
+  assert_output --partial "git clone https://github.com/freebsd/freebsd-ports.git"
+}

--- a/test/provision.bats
+++ b/test/provision.bats
@@ -141,7 +141,7 @@ _no_start_required() {
 # ---------------------------------------------------------------------------
 
 @test "dovecot mounts vpopmail home in JAIL_FSTAB" {
-  run grep "^export JAIL_FSTAB" provision/dovecot.sh
+  run grep "JAIL_FSTAB=.*vpopmail" provision/dovecot.sh
   assert_output --partial "vpopmail"
 }
 
@@ -235,7 +235,7 @@ EOF
 }
 
 @test "dcc mounts dcc db in JAIL_FSTAB" {
-  run grep "^export JAIL_FSTAB" provision/dcc.sh
+  run grep "JAIL_FSTAB=.*dcc" provision/dcc.sh
   assert_output --partial "dcc"
 }
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- mt: route jail data paths through get_jail_data()
  - get_jail_data already exists, so use it more
- mt: fail early with instructions when /usr/ports is empty
- postfix, sphinxsearch, mailman: correct /data paths missing the jail name
- rsnapshot, borg: call tell_status, not tell-status
