### PR TITLE
mt: jail.conf.d entries update when unedited

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,9 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-08
 
+- mt: store_config keeps a dated backup of updated configs
+- mt: jail.conf.d entries update when unedited, report when they don't
+- mt: report a jail.conf left behind by a path change
 - mt: add get_jail_host_etc, naming the control files the host reads per jail
 - base: mount.devfs instead of an fstab, drop its unused pf rules
 - mt: fail early with instructions when /usr/ports is empty

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -323,6 +323,11 @@ add_jail_conf()
 
 add_jail_conf_d()
 {
+	local _jail_ip; _jail_ip=$(get_jail_ip "$1")
+	if [ -z "$_jail_ip" ]; then
+		fatal_err "can't determine IP for $1"
+	fi
+
 	# configure IPv6 if the system has an external/public IPv6 address
 	local _IP6=""
 	get_public_ip6

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -276,6 +276,20 @@ jail_conf_mount()
 	echo "mount.fstab = \"$(get_jail_host_etc "$1")/fstab\";"
 }
 
+warn_stale_jail_conf()
+{
+	local _jail="$1"
+	local _conf="$2"
+
+	local _mount; _mount=$(jail_conf_mount "$_jail")
+	if grep -qsF "$_mount" "$_conf"; then return; fi
+
+	tell_status "WARNING: $_conf is out of date"
+	echo "  $_jail should declare: $_mount"
+	echo "  edit $_conf, or delete the $_jail entry and run this script again"
+	echo
+}
+
 add_jail_conf()
 {
 	local _jail_ip; _jail_ip=$(get_jail_ip "$1");
@@ -295,6 +309,7 @@ add_jail_conf()
 
 	if grep -q "^$1\\>" /etc/jail.conf; then
 		tell_status "preserving $1 config in /etc/jail.conf"
+		warn_stale_jail_conf "$1" /etc/jail.conf
 		return
 	fi
 
@@ -326,7 +341,9 @@ add_jail_conf_d()
 		exec.poststop = \"$(get_jail_host_etc "$1")/pf.conf.d/pfrule.sh unload\";"
 	fi
 
-	store_config "/etc/jail.conf.d/$(safe_jailname "$1").conf" <<EO_JAIL_RC
+	local _conf; _conf="/etc/jail.conf.d/$(safe_jailname "$1").conf"
+
+	store_config "$_conf" "update" <<EO_JAIL_RC
 $(safe_jailname "$1")	{$(get_safe_jail_path "$1")
 		host.hostname = \$name;
 		path = "$_path";
@@ -341,6 +358,8 @@ $(safe_jailname "$1")	{$(get_safe_jail_path "$1")
 		exec.stop = "/bin/sh /etc/rc.shutdown";$_pf_exec
 	}
 EO_JAIL_RC
+
+	warn_stale_jail_conf "$1" "$_conf"
 }
 
 add_automount()

--- a/include/util.sh
+++ b/include/util.sh
@@ -40,6 +40,17 @@ _file_mode()
 	esac
 }
 
+backup_config()
+{
+	if [ ! -f "$1" ]; then return; fi
+
+	local _backup; _backup="$1.$(date +%Y.%m.%d)"
+	if [ -f "$_backup" ]; then return; fi
+
+	tell_status "backing up $1 to $_backup"
+	cp -p "$1" "$_backup"
+}
+
 store_config()
 {
 	# $1 - path to config file, $2 - operation, STDIN is file contents
@@ -75,6 +86,7 @@ store_config()
 		# pristine. Excluded deliberately rather than by falling through.
 		cat "$_shadow" >> "$1"
 	elif [ "$_operation" = "update" ] && [ -n "$_pristine" ]; then
+		backup_config "$1"
 		tell_status "updating unmodified $1"
 		cp "$_shadow" "$1"
 	else

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -169,6 +169,14 @@ setup() {
   assert_output --partial "out of date"
 }
 
+@test "add_jail_conf_d - resolves its own ip4.addr when called directly" {
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  store_config() { cat -; }
+
+  run add_jail_conf_d mysql
+  assert_output --partial "ip4.addr = lo1|172.16.15.4;"
+}
+
 @test "add_jail_conf_d - asks store_config to update an unedited config" {
   get_public_ip6() { export PUBLIC_IP6=""; }
   store_config() { echo "operation=${2:-none}"; cat - > /dev/null; }

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -133,6 +133,50 @@ setup() {
   assert_output "/data/dovecot/etc"
 }
 
+@test "warn_stale_jail_conf - silent when the mount line is current" {
+  export ZFS_DATA_MNT="/data"
+  local _conf="$BATS_TEST_TMPDIR/dovecot.conf"
+  printf 'dovecot {\n\tmount.fstab = "/data/dovecot/etc/fstab";\n}\n' > "$_conf"
+
+  run warn_stale_jail_conf dovecot "$_conf"
+  assert_success
+  assert_output ""
+}
+
+@test "warn_stale_jail_conf - warns when the mount line is outdated" {
+  export ZFS_DATA_MNT="/data"
+  local _conf="$BATS_TEST_TMPDIR/dovecot.conf"
+  printf 'dovecot {\n\tmount.fstab = "/data/dovecot/host-etc/fstab";\n}\n' > "$_conf"
+
+  run warn_stale_jail_conf dovecot "$_conf"
+  assert_output --partial "out of date"
+  assert_output --partial 'mount.fstab = "/data/dovecot/etc/fstab";'
+}
+
+@test "warn_stale_jail_conf - flags a base entry still declaring an fstab" {
+  export ZFS_DATA_MNT="/data"
+  local _conf="$BATS_TEST_TMPDIR/base.conf"
+  printf 'base {\n\tmount.fstab = "/jails/base-14.4-RELEASE/data/etc/fstab";\n}\n' > "$_conf"
+
+  run warn_stale_jail_conf base "$_conf"
+  assert_output --partial "out of date"
+  assert_output --partial "mount.devfs;"
+}
+
+@test "warn_stale_jail_conf - warns when the config is missing entirely" {
+  export ZFS_DATA_MNT="/data"
+  run warn_stale_jail_conf dovecot "$BATS_TEST_TMPDIR/absent.conf"
+  assert_output --partial "out of date"
+}
+
+@test "add_jail_conf_d - asks store_config to update an unedited config" {
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  store_config() { echo "operation=${2:-none}"; cat - > /dev/null; }
+
+  run add_jail_conf_d mysql
+  assert_output --partial "operation=update"
+}
+
 @test "add_jail_conf_d - base mounts devfs rather than an fstab" {
   get_public_ip6() { export PUBLIC_IP6=""; }
   store_config() { cat -; }

--- a/test/include/util.bats
+++ b/test/include/util.bats
@@ -163,7 +163,7 @@ setup() {
   echo "v1" | store_config "$tmpfile"
   echo "v2" | store_config "$tmpfile" "update"
 
-  run cat "$tmpfile.$(date +%Y.%m.%d)"
+  run cat "$tmpfile".2*
   assert_output "v1"
 
   rm -rf "$tmpdir"
@@ -177,7 +177,8 @@ setup() {
   echo "hand edited" > "$tmpfile"
   echo "v2" | store_config "$tmpfile" "overwrite"
 
-  [ ! -f "$tmpfile.$(date +%Y.%m.%d)" ]
+  run ls "$tmpdir"
+  refute_output --partial "app.conf.2"
 
   rm -rf "$tmpdir"
 }
@@ -188,7 +189,8 @@ setup() {
 
   echo "v1" | store_config "$tmpfile"
 
-  [ ! -f "$tmpfile.$(date +%Y.%m.%d)" ]
+  run ls "$tmpdir"
+  refute_output --partial "app.conf.2"
 
   rm -rf "$tmpdir"
 }
@@ -201,7 +203,7 @@ setup() {
   echo "v2" | store_config "$tmpfile" "update"
   echo "v3" | store_config "$tmpfile" "update"
 
-  run cat "$tmpfile.$(date +%Y.%m.%d)"
+  run cat "$tmpfile".2*
   assert_output "v1"
 
   rm -rf "$tmpdir"
@@ -215,7 +217,8 @@ setup() {
   echo "hand edited" > "$tmpfile"
   echo "v2" | store_config "$tmpfile" "update"
 
-  [ ! -f "$tmpfile.$(date +%Y.%m.%d)" ]
+  run ls "$tmpdir"
+  refute_output --partial "app.conf.2"
 
   rm -rf "$tmpdir"
 }

--- a/test/include/util.bats
+++ b/test/include/util.bats
@@ -156,6 +156,70 @@ setup() {
   rm -rf "$tmpdir"
 }
 
+@test "store_config - update backs up what it replaces" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/app.conf"
+
+  echo "v1" | store_config "$tmpfile"
+  echo "v2" | store_config "$tmpfile" "update"
+
+  run cat "$tmpfile.$(date +%Y.%m.%d)"
+  assert_output "v1"
+
+  rm -rf "$tmpdir"
+}
+
+@test "store_config - overwrite backs nothing up" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/app.conf"
+
+  echo "v1" | store_config "$tmpfile"
+  echo "hand edited" > "$tmpfile"
+  echo "v2" | store_config "$tmpfile" "overwrite"
+
+  [ ! -f "$tmpfile.$(date +%Y.%m.%d)" ]
+
+  rm -rf "$tmpdir"
+}
+
+@test "store_config - a first install has nothing to back up" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/app.conf"
+
+  echo "v1" | store_config "$tmpfile"
+
+  [ ! -f "$tmpfile.$(date +%Y.%m.%d)" ]
+
+  rm -rf "$tmpdir"
+}
+
+@test "store_config - the day's first backup survives later runs" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/app.conf"
+
+  echo "v1" | store_config "$tmpfile"
+  echo "v2" | store_config "$tmpfile" "update"
+  echo "v3" | store_config "$tmpfile" "update"
+
+  run cat "$tmpfile.$(date +%Y.%m.%d)"
+  assert_output "v1"
+
+  rm -rf "$tmpdir"
+}
+
+@test "store_config - preserving a file backs nothing up" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local tmpfile="$tmpdir/app.conf"
+
+  echo "v1" | store_config "$tmpfile"
+  echo "hand edited" > "$tmpfile"
+  echo "v2" | store_config "$tmpfile" "update"
+
+  [ ! -f "$tmpfile.$(date +%Y.%m.%d)" ]
+
+  rm -rf "$tmpdir"
+}
+
 @test "store_config - update preserves a file the admin edited" {
   local tmpdir; tmpdir=$(mktemp -d)
   local tmpfile="$tmpdir/app.conf"

--- a/test/provision.bats
+++ b/test/provision.bats
@@ -157,13 +157,6 @@ _no_start_required() {
 }
 
 # ---------------------------------------------------------------------------
-# store_config "update" reinstalls over an unedited config. That turns a bad
-# generation from harmless into destructive, so an update template must not
-# interpolate anything queried at runtime -- a failed lookup would clobber a
-# working config with a degraded one. Static values are fine; they cannot fail.
-# ---------------------------------------------------------------------------
-
-# ---------------------------------------------------------------------------
 # A setting only one jail reads belongs in that jail's provision script, where
 # its default reaches installs whose conf.d file predates it. The generated
 # mail-toaster.conf is for settings that apply toaster-wide.
@@ -203,36 +196,6 @@ _config_declared_settings() {
   [ "$failed" -eq 0 ]
 }
 
-_update_templates_with_runtime_values() {
-  awk '
-    /store_config .*"update".*<</ {
-      term = $0
-      sub(/^.*<<-?/, "", term)
-      gsub(/["'"'"' \t]/, "", term)
-      inblock = 1
-      next
-    }
-    inblock && $0 ~ "^[ \t]*"term"[ \t]*$" { inblock = 0; next }
-    inblock && (/\$\(/ || /\$PUBLIC_IP/) { print FILENAME ":" FNR ": " $0 }
-  ' "$@"
-}
-
-@test "store_config update templates interpolate no runtime-queried values" {
-  run _update_templates_with_runtime_values provision/*.sh include/*.sh
-  assert_success
-  assert_output ""
-}
-
-@test "the update-template guard actually detects a runtime value" {
-  local _probe="$BATS_TEST_TMPDIR/probe.sh"
-  cat > "$_probe" <<'EOF'
-store_config "$ZFS_DATA_MNT/x/bad.conf" "update" <<EO_BAD
-address: $(get_jail_ip dns)
-EO_BAD
-EOF
-  run _update_templates_with_runtime_values "$_probe"
-  assert_output --partial "get_jail_ip dns"
-}
 
 @test "dcc mounts dcc db in JAIL_FSTAB" {
   run grep "JAIL_FSTAB=.*dcc" provision/dcc.sh


### PR DESCRIPTION
- mt: jail.conf.d entries update when unedited and report if not updated (due to local mods)
- mt: store_config keeps a dated backup of updated configs
- mt: report a jail.conf left behind by a path change

This is another substantial change extracted from PR #695 as its own PR.