### PR TITLE
[hardening] mt: reduce devfs.ruleset to 4

### DIFF
--- a/include/jail.sh
+++ b/include/jail.sh
@@ -165,7 +165,7 @@ jail_conf_header()
 exec.start = "/bin/sh /etc/rc";
 exec.stop = "/bin/sh /etc/rc.shutdown";
 exec.clean;
-devfs_ruleset=5;
+devfs_ruleset=4;  # 5 gives vnet and non-vnet jails unneeded /dev/pf access
 path = "$_path";
 interface = $JAIL_NET_INTERFACE;
 host.hostname = \$name;
@@ -353,7 +353,7 @@ $(safe_jailname "$1")	{$(get_safe_jail_path "$1")
 		host.hostname = \$name;
 		path = "$_path";
 		$(jail_conf_mount "$1")
-		devfs_ruleset=5;
+		devfs_ruleset = 4;
 
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
 		${_IP6}${JAIL_CONF_EXTRA}

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -165,7 +165,7 @@ jail_conf_header()
 exec.start = "/bin/sh /etc/rc";
 exec.stop = "/bin/sh /etc/rc.shutdown";
 exec.clean;
-devfs_ruleset=4;  # 5 gives vnet and non-vnet jails unneeded /dev/pf access
+devfs_ruleset=4;
 path = "$_path";
 interface = $JAIL_NET_INTERFACE;
 host.hostname = \$name;

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -165,7 +165,7 @@ jail_conf_header()
 exec.start = "/bin/sh /etc/rc";
 exec.stop = "/bin/sh /etc/rc.shutdown";
 exec.clean;
-devfs_ruleset=4;
+devfs_ruleset = 4;
 path = "$_path";
 interface = $JAIL_NET_INTERFACE;
 host.hostname = \$name;

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -310,7 +310,7 @@ start_staged_jail()
 		exec.start="/bin/sh /etc/rc" \
 		exec.stop="/bin/sh /etc/rc.shutdown" \
 		$_mount \
-		devfs_ruleset=5 \
+		devfs_ruleset=4 \
 		$JAIL_START_EXTRA
 
 	enable_bsd_cache


### PR DESCRIPTION
### Changes proposed in this pull request:
- The switch to devfs_ruleset=5 has no visible use. Rollback to devfs_ruleset=4 and escalate privileges only for specific jails (none found) except haraka which already handles it with its own ruleset.
