### PR TITLE
feat(pfrule): take the jail name as an argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: git submodule update --init --recursive
     - name: bats test
       run: |
-        ./test/bats/bin/bats test/*.bats test/include/*.bats test/provision/*.bats
+        ./test/bats/bin/bats test/*.bats test/include/*.bats test/provision/*.bats test/contrib/*.bats
 
   freebsd:
     runs-on: ubuntu-latest

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,10 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-08
 
+- pfrule: accept the jail name as an argument, decouple from $0
+- pfrule: PFRULE_ETC names the rule directory outright
+- pfrule: validate the operation, refuse a jail this copy does not serve
+- test: run test/contrib/*.bats in CI and test/run.sh
 - haraka: enable watch and p0f by append
 - mta: install dma when absent, ssmtp is now opt-in
 - mta: write dma.conf beside the installed dma, base or port

--- a/Changes.md
+++ b/Changes.md
@@ -5,9 +5,10 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-08
 
+- pfrule: run pfctl arguments directly
 - pfrule: accept the jail name as an argument, decouple from $0
-- pfrule: PFRULE_ETC names the rule directory outright
-- pfrule: validate the operation, refuse a jail this copy does not serve
+- pfrule: PFRULE_ETC names the rule directory outright, and must exist
+- pfrule: validate the operation and jail name
 - test: run test/contrib/*.bats in CI and test/run.sh
 - haraka: enable watch and p0f by append
 - mta: install dma when absent, ssmtp is now opt-in

--- a/contrib/pfrule.sh
+++ b/contrib/pfrule.sh
@@ -37,7 +37,8 @@ for _arg in "$@"; do
     case "$_arg" in
         -n) PREVIEW="-n" ;;
         -*) usage ;;
-        *)  JAIL_NAME="$_arg" ;;
+        *)  if [ -n "$JAIL_NAME" ]; then usage; fi
+            JAIL_NAME="$_arg" ;;
     esac
 done
 
@@ -69,6 +70,20 @@ if [ -z "$JAIL_NAME" ]; then
     exit 1
 fi
 
+# the name becomes a pf anchor, so hold it to what pfctl(8) will accept
+case "$JAIL_NAME" in
+    *[!A-Za-z0-9_.-]*)
+        echo "$0: invalid jail name '$JAIL_NAME'" >&2
+        exit 1 ;;
+esac
+
+# an unreadable PFRULE_ETC would leave every glob empty, so load and unload
+# would both report success having touched no firewall state at all
+if [ -n "${PFRULE_ETC:-}" ] && [ ! -d "$PFRULE_ETC" ]; then
+    echo "$0: PFRULE_ETC is not a directory: $PFRULE_ETC" >&2
+    exit 1
+fi
+
 if ! ETC_PATH="$(resolve_etc_path)"; then
     echo "$0: no rule directory for jail '$JAIL_NAME'" >&2
     exit 1
@@ -94,7 +109,7 @@ load_tables() {
         if [ -n "$_hit" ]; then
             echo "WARN: table $_table_name appears to ALSO exist in $_hit"
         fi
-        do_cmd "pfctl -t $_table_name -T replace -f $_f"
+        do_cmd pfctl -t "$_table_name" -T replace -f "$_f"
     done
 }
 
@@ -102,23 +117,22 @@ flush_tables() {
     for _f in "$ETC_PATH"/*.table; do
         [ -f "$_f" ] || continue
         _table_name=$(basename "$_f" .table)
-        do_cmd "pfctl -t $_table_name -T flush"
+        do_cmd pfctl -t "$_table_name" -T flush
     done
 }
 
 do_cmd() {
     if [ "$PREVIEW" = "-n" ]; then
-        echo "$1"
+        echo "$*"
     else
-        eval "$1"
+        "$@"
     fi
 }
 
 flush() {
     case "$1" in
-        "nat"   ) do_cmd "$2 -F nat"   ;;
-        "rdr"   ) do_cmd "$2 -F nat"   ;;
-        "filter") do_cmd "$2 -F rules" ;;
+        nat|rdr ) do_cmd pfctl -a "$2" -F nat   ;;
+        filter  ) do_cmd pfctl -a "$2" -F rules ;;
     esac
 }
 
@@ -131,11 +145,9 @@ for _anchor in binat nat rdr filter; do
     _f="$ETC_PATH/$_anchor.conf"
     [ -f "$_f" ] || continue
 
-    _pfctl="pfctl -a $_anchor/$JAIL_NAME"
-
     case "$OPERATION" in
-        "load"   ) do_cmd "$_pfctl -f $_f" ;;
-        "unload" ) flush "$_anchor" "$_pfctl" ;;
+        "load"   ) do_cmd pfctl -a "$_anchor/$JAIL_NAME" -f "$_f" ;;
+        "unload" ) flush "$_anchor" "$_anchor/$JAIL_NAME" ;;
     esac
 done
 

--- a/contrib/pfrule.sh
+++ b/contrib/pfrule.sh
@@ -8,26 +8,80 @@ set -eu
 #
 # Use pfctl to load and unload PF rules into named anchors from config
 # files. See https://github.com/msimerson/Mail-Toaster-6/wiki/PF
+#
+#   pfrule.sh load|unload [jail] [-n]
+#
+# Naming the jail decouples the anchor name from the install location, so one
+# copy can serve every jail. Omit it and the jail name comes from $0
 
-ETC_PATH="$(dirname -- "$( readlink -f -- "$0"; )";)"
-JAIL_NAME=$(basename "$(dirname "$(dirname "$ETC_PATH")")")
-OPERATION=${1:-""}
-PREVIEW=${2:-""}
+SELF_DIR="$(dirname -- "$( readlink -f -- "$0"; )";)"
 
 usage() {
-    echo "   usage: $0 [ load | unload ] [-n]"
+    echo "   usage: $0 [ load | unload ] [jail] [-n]"
+    echo " "
+    echo "   jail   name of the jail whose anchors to manage."
+    echo "          Omit when pfrule lives in the jail's own rule directory."
+    echo "   -n     preview, print the pfctl commands instead of running them"
     echo " "
     exit 1
 }
 
+case "${1:-}" in
+    load|unload) OPERATION="$1"; shift ;;
+    *)           usage ;;
+esac
+
+JAIL_NAME=""
+PREVIEW=""
+for _arg in "$@"; do
+    case "$_arg" in
+        -n) PREVIEW="-n" ;;
+        -*) usage ;;
+        *)  JAIL_NAME="$_arg" ;;
+    esac
+done
+
+# a per-jail copy lives at <data>/<jail>/etc/pf.conf.d/pfrule.sh
+jail_name_from_path() {
+    basename "$(dirname "$(dirname "$SELF_DIR")")"
+}
+
+resolve_etc_path() {
+    if [ -n "${PFRULE_ETC:-}" ]; then
+        echo "$PFRULE_ETC"
+        return 0
+    fi
+
+    if [ "$(jail_name_from_path)" = "$JAIL_NAME" ]; then
+        echo "$SELF_DIR"
+        return 0
+    fi
+
+    return 1
+}
+
+if [ -z "$JAIL_NAME" ]; then
+    JAIL_NAME="$(jail_name_from_path)"
+fi
+
+if [ -z "$JAIL_NAME" ]; then
+    echo "$0: cannot determine the jail name, pass it as an argument" >&2
+    exit 1
+fi
+
+if ! ETC_PATH="$(resolve_etc_path)"; then
+    echo "$0: no rule directory for jail '$JAIL_NAME'" >&2
+    exit 1
+fi
+
 cleanup() {
-    if [ -f allow.conf ]; then
-        if [ -f filter.conf ]; then
-            echo "mv allow.conf allow.bak"
-            mv allow.conf allow.bak
+    if [ -f "$ETC_PATH/allow.conf" ]; then
+        if [ -f "$ETC_PATH/filter.conf" ]; then
+            echo "mv $ETC_PATH/allow.conf $ETC_PATH/allow.bak"
+            mv "$ETC_PATH/allow.conf" "$ETC_PATH/allow.bak"
         else
-            echo "mv allow.conf filter.conf"
-            mv allow.conf filter.conf
+            echo "mv $ETC_PATH/allow.conf $ETC_PATH/filter.conf"
+            mv "$ETC_PATH/allow.conf" "$ETC_PATH/filter.conf"
         fi
     fi
 }
@@ -82,7 +136,6 @@ for _anchor in binat nat rdr filter; do
     case "$OPERATION" in
         "load"   ) do_cmd "$_pfctl -f $_f" ;;
         "unload" ) flush "$_anchor" "$_pfctl" ;;
-        *        ) usage ;;
     esac
 done
 

--- a/test/contrib/pfrule.bats
+++ b/test/contrib/pfrule.bats
@@ -117,6 +117,95 @@ install_legacy() {
   assert_output --partial "usage:"
 }
 
+@test "a second jail argument is rejected, not silently preferred" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load dovecot haraka -n
+  assert_failure
+  assert_output --partial "usage:"
+}
+
+@test "a jail name with shell metacharacters is rejected" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load 'dovecot;id' -n
+  assert_failure
+  assert_output --partial "invalid jail name"
+}
+
+@test "a jail name with whitespace is rejected" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load 'two words' -n
+  assert_failure
+  assert_output --partial "invalid jail name"
+}
+
+@test "jail names MT6 actually uses are accepted" {
+  mkrules "$ROOT/rules"
+  local _p; _p=$(install_legacy dovecot)
+
+  for _n in mail_dmarc bhyve-ubuntu php7 bsd_cache; do
+    PFRULE_ETC="$ROOT/rules" run "$_p" unload "$_n" -n
+    assert_success
+    assert_output --partial "pfctl -a rdr/$_n -F nat"
+  done
+}
+
+# --- $ETC_PATH is writable by the jail whose rules it holds ---
+
+# No .conf here on purpose: an anchor file makes pfctl run and fail first, and
+# set -e would end the script before the tables are reached.
+# The marker is relative because a filename cannot hold a path separator.
+@test "a rule filename cannot reach a shell" {
+  local _dir="$ROOT/data/dovecot/etc/pf.conf.d"
+  mkdir -p "$_dir"
+  cp "$PFRULE" "$_dir/"
+  touch "$_dir/x\$(touch pwned).table"
+
+  cd "$ROOT"
+  run "$_dir/pfrule.sh" unload
+  [ ! -f "$ROOT/pwned" ]
+}
+
+@test "a rule filename with a semicolon runs no second command" {
+  local _dir="$ROOT/data/dovecot/etc/pf.conf.d"
+  mkdir -p "$_dir"
+  cp "$PFRULE" "$_dir/"
+  touch "$_dir/x;touch pwned;.table"
+
+  cd "$ROOT"
+  run "$_dir/pfrule.sh" unload
+  [ ! -f "$ROOT/pwned" ]
+}
+
+@test "a rule filename with spaces stays one pfctl argument" {
+  local _dir="$ROOT/data/dovecot/etc/pf.conf.d"
+  mkdir -p "$_dir"
+  cp "$PFRULE" "$_dir/"
+  printf '10.0.0.1\n' > "$_dir/two words.table"
+
+  run "$_dir/pfrule.sh" unload -n
+  assert_success
+  assert_output --partial "pfctl -t two words -T flush"
+}
+
+# --- PFRULE_ETC has to name a real directory ---
+
+@test "a PFRULE_ETC that does not exist is an error, not a silent no-op" {
+  local _p; _p=$(install_legacy dovecot)
+
+  PFRULE_ETC="$ROOT/nowhere" run "$_p" load dovecot -n
+  assert_failure
+  assert_output --partial "PFRULE_ETC is not a directory"
+}
+
+@test "a PFRULE_ETC naming a file is an error" {
+  local _p; _p=$(install_legacy dovecot)
+  touch "$ROOT/afile"
+
+  PFRULE_ETC="$ROOT/afile" run "$_p" unload dovecot -n
+  assert_failure
+  assert_output --partial "PFRULE_ETC is not a directory"
+}
+
 # --- anchors present and absent ---
 
 @test "only the anchors with a .conf are touched" {

--- a/test/contrib/pfrule.bats
+++ b/test/contrib/pfrule.bats
@@ -11,6 +11,10 @@ setup() {
   # one too, or /var vs /private/var breaks the comparison on macOS
   mkdir -p "$BATS_TEST_TMPDIR/root"
   ROOT="$(cd "$BATS_TEST_TMPDIR/root" && pwd -P)"
+
+  # the tests that omit -n really do execute; keep them off the host firewall
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export PFCTL_LOG="$ROOT/pfctl.log"
 }
 
 mkrules() {
@@ -151,8 +155,7 @@ install_legacy() {
 
 # --- $ETC_PATH is writable by the jail whose rules it holds ---
 
-# No .conf here on purpose: an anchor file makes pfctl run and fail first, and
-# set -e would end the script before the tables are reached.
+# These omit -n so the execution path runs for real against the pfctl stub.
 # The marker is relative because a filename cannot hold a path separator.
 @test "a rule filename cannot reach a shell" {
   local _dir="$ROOT/data/dovecot/etc/pf.conf.d"
@@ -162,7 +165,11 @@ install_legacy() {
 
   cd "$ROOT"
   run "$_dir/pfrule.sh" unload
+  assert_success
   [ ! -f "$ROOT/pwned" ]
+  # the table really was processed, so the absence above means something
+  run grep -c '^-T$' "$PFCTL_LOG"
+  assert_output "1"
 }
 
 @test "a rule filename with a semicolon runs no second command" {
@@ -173,6 +180,7 @@ install_legacy() {
 
   cd "$ROOT"
   run "$_dir/pfrule.sh" unload
+  assert_success
   [ ! -f "$ROOT/pwned" ]
 }
 
@@ -182,9 +190,19 @@ install_legacy() {
   cp "$PFRULE" "$_dir/"
   printf '10.0.0.1\n' > "$_dir/two words.table"
 
-  run "$_dir/pfrule.sh" unload -n
+  run "$_dir/pfrule.sh" unload
   assert_success
-  assert_output --partial "pfctl -t two words -T flush"
+  run grep -c '^two words$' "$PFCTL_LOG"
+  assert_output "1"
+}
+
+@test "the anchor reaches pfctl as one argument" {
+  local _p; _p=$(install_legacy dovecot)
+
+  run "$_p" load
+  assert_success
+  run grep -c '^rdr/dovecot$' "$PFCTL_LOG"
+  assert_output "1"
 }
 
 # --- PFRULE_ETC has to name a real directory ---

--- a/test/contrib/pfrule.bats
+++ b/test/contrib/pfrule.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# contrib/pfrule.sh resolves its rule directory across the layouts MT6 has
+# used. Every test runs with -n so pfctl is printed, never executed.
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  PFRULE="$BATS_TEST_DIRNAME/../../contrib/pfrule.sh"
+  # pfrule.sh readlink -f's its own path, so the fixture has to be the resolved
+  # one too, or /var vs /private/var breaks the comparison on macOS
+  mkdir -p "$BATS_TEST_TMPDIR/root"
+  ROOT="$(cd "$BATS_TEST_TMPDIR/root" && pwd -P)"
+}
+
+mkrules() {
+  mkdir -p "$1"
+  printf 'rdr pass inet proto tcp to port 25\n' > "$1/rdr.conf"
+  printf '10.0.0.1\n' > "$1/known.table"
+}
+
+# <data>/<jail>/etc/pf.conf.d/pfrule.sh, the layout before the host-etc move
+install_legacy() {
+  local _dir="$ROOT/data/$1/etc/pf.conf.d"
+  mkrules "$_dir"
+  cp "$PFRULE" "$_dir/"
+  echo "$_dir/pfrule.sh"
+}
+
+# --- legacy invocation, no jail argument ---
+
+@test "legacy - derives the jail name from its own path" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load -n
+  assert_success
+  assert_output --partial "pfctl -a rdr/dovecot -f"
+}
+
+@test "legacy - loads tables before anchors" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load -n
+  assert_line --index 0 --partial "pfctl -t known -T replace"
+  assert_line --index 1 --partial "pfctl -a rdr/dovecot"
+}
+
+@test "legacy - unload flushes the anchor and the tables" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" unload -n
+  assert_success
+  assert_output --partial "pfctl -a rdr/dovecot -F nat"
+  assert_output --partial "pfctl -t known -T flush"
+}
+
+@test "legacy - a per-jail copy still answers to its own jail name" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load dovecot -n
+  assert_success
+  assert_output --partial "pfctl -a rdr/dovecot -f"
+}
+
+@test "legacy - a per-jail copy refuses another jail's name" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load haraka -n
+  assert_failure
+  assert_output --partial "no rule directory for jail 'haraka'"
+}
+
+# --- PFRULE_ETC, the hook a future layout hangs off ---
+
+@test "PFRULE_ETC overrides the directory derived from \$0" {
+  local _p; _p=$(install_legacy dovecot)
+  mkrules "$ROOT/elsewhere"
+
+  PFRULE_ETC="$ROOT/elsewhere" run "$_p" load dovecot -n
+  assert_success
+  assert_output --partial "$ROOT/elsewhere/rdr.conf"
+  refute_output --partial "/data/dovecot/"
+}
+
+@test "PFRULE_ETC lets the anchor be named for a jail this copy does not own" {
+  local _p; _p=$(install_legacy dovecot)
+  mkrules "$ROOT/elsewhere"
+
+  PFRULE_ETC="$ROOT/elsewhere" run "$_p" unload mail_dmarc -n
+  assert_success
+  assert_output --partial "pfctl -a rdr/mail_dmarc -F nat"
+}
+
+# --- argument handling ---
+
+@test "argument order - -n may precede the jail name" {
+  local _p; _p=$(install_legacy dovecot)
+
+  run "$_p" load -n dovecot
+  assert_success
+  assert_output --partial "pfctl -a rdr/dovecot"
+}
+
+@test "an unknown operation exits non-zero with usage" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" bogus
+  assert_failure
+  assert_output --partial "usage:"
+}
+
+@test "no arguments exits non-zero with usage" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p"
+  assert_failure
+  assert_output --partial "usage:"
+}
+
+@test "an unknown flag exits non-zero with usage" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load dovecot -x
+  assert_failure
+  assert_output --partial "usage:"
+}
+
+# --- anchors present and absent ---
+
+@test "only the anchors with a .conf are touched" {
+  local _p; _p=$(install_legacy dovecot)
+  run "$_p" load -n
+  assert_success
+  assert_output --partial "rdr/dovecot"
+  refute_output --partial "binat/dovecot"
+  refute_output --partial "filter/dovecot"
+}
+
+@test "a rule directory with no files is a no-op, not an error" {
+  local _dir="$ROOT/data/quiet/etc/pf.conf.d"
+  mkdir -p "$_dir"
+  cp "$PFRULE" "$_dir/"
+
+  run "$_dir/pfrule.sh" load -n
+  assert_success
+  refute_output --partial "pfctl"
+}
+
+# --- cleanup() renames relative to the rule dir, not the cwd ---
+
+@test "cleanup - allow.conf becomes filter.conf in the rule directory" {
+  local _p; _p=$(install_legacy dovecot)
+  local _dir="$ROOT/data/dovecot/etc/pf.conf.d"
+  printf 'pass in\n' > "$_dir/allow.conf"
+
+  run "$_p" load -n
+  assert_success
+  [ ! -f "$_dir/allow.conf" ]
+  [ -f "$_dir/filter.conf" ]
+}
+
+@test "cleanup - allow.conf becomes allow.bak when filter.conf exists" {
+  local _p; _p=$(install_legacy dovecot)
+  local _dir="$ROOT/data/dovecot/etc/pf.conf.d"
+  printf 'pass in\n'  > "$_dir/allow.conf"
+  printf 'block in\n' > "$_dir/filter.conf"
+
+  run "$_p" load -n
+  assert_success
+  [ -f "$_dir/allow.bak" ]
+  run cat "$_dir/filter.conf"
+  assert_output "block in"
+}
+
+@test "cleanup - does not touch the working directory" {
+  local _p; _p=$(install_legacy dovecot)
+  printf 'pass in\n' > "$ROOT/allow.conf"
+
+  cd "$ROOT"
+  run "$_p" load -n
+  assert_success
+  [ -f "$ROOT/allow.conf" ]
+  [ ! -f "$ROOT/filter.conf" ]
+}

--- a/test/contrib/stubs/pfctl
+++ b/test/contrib/stubs/pfctl
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Stand-in for pfctl(8) so the tests that deliberately omit -n exercise command
+# execution without touching the host firewall. Records argv one argument per
+# line in $PFCTL_LOG, which is how a test asserts that a name containing spaces
+# arrived as a single argument.
+
+if [ -n "${PFCTL_LOG:-}" ]; then
+    for _arg in "$@"; do
+        printf '%s\n' "$_arg" >> "$PFCTL_LOG"
+    done
+    printf -- '--\n' >> "$PFCTL_LOG"
+fi
+
+exit 0

--- a/test/run.sh
+++ b/test/run.sh
@@ -20,3 +20,4 @@ shellcheck provision/*.sh
 bats test/*.bats
 bats test/include/*.bats
 bats test/provision/*.bats
+bats test/contrib/*.bats


### PR DESCRIPTION
- pfrule: accept the jail name as an argument, decouple from $0
- pfrule: PFRULE_ETC names the rule directory outright
- pfrule: validate the operation, refuse a jail this copy does not serve
- test: run test/contrib/*.bats in CI and test/run.sh
- pfrule: fixes cleanup(), which renamed allow.conf relative to the cwd "/"
- makes an unknown operation exit non-zero instead of silently doing nothing.
