### PR TITLE
[fix] mt: avoid truncating long PUBLIC_NIC names

### DIFF
--- a/include/network.sh
+++ b/include/network.sh
@@ -7,9 +7,9 @@ get_public_facing_nic()
 	export PUBLIC_NIC
 
 	if [ "$_ver" = 'ipv6' ]; then
-		PUBLIC_NIC=$(netstat -rn | grep default | awk '{ print $4 }' | tail -n1)
+		PUBLIC_NIC=$(netstat -rnW | awk '/^default/ { print $6 }' | tail -n1)
 	else
-		PUBLIC_NIC=$(netstat -rn | grep default | awk '{ print $4 }' | head -n1)
+		PUBLIC_NIC=$(netstat -rnW | awk '/^default/ { print $6 }' | head -n1)
 	fi
 
 	if [ -z "$PUBLIC_NIC" ]; then


### PR DESCRIPTION
### Changes proposed in this pull request:
- If the name of the default host NIC is too long, don't let netstat truncate it, e.g.: `e74b_nested_mt6` would have been truncated to `e74b_nested_`.
