### PR TITLE
add JAIL_DEVFS_RULESET

### DIFF
--- a/include/jail.sh
+++ b/include/jail.sh
@@ -204,6 +204,28 @@ get_pfrule_path()
 
 export JAIL_DEVFS_RULESET=${JAIL_DEVFS_RULESET:-4}
 
+# devfsrules_jail hides bpf, which p0f and dhcpd need
+export DEVFS_RULES=${DEVFS_RULES:-"/etc/devfs.rules"}
+export JAIL_DEVFS_RULESET_BPF=${JAIL_DEVFS_RULESET_BPF:-7}
+
+assure_devfs_bpf_ruleset()
+{
+	if grep -qs "devfsrules_jail_bpf=$JAIL_DEVFS_RULESET_BPF" "$DEVFS_RULES"; then
+		return 0
+	fi
+
+	tell_status "adding devfs ruleset $JAIL_DEVFS_RULESET_BPF to $DEVFS_RULES"
+	tee -a "$DEVFS_RULES" <<EO_DEVFS
+
+[devfsrules_jail_bpf=$JAIL_DEVFS_RULESET_BPF]
+add include \$devfsrules_jail
+add path 'bpf*' unhide
+EO_DEVFS
+
+	# the kernel only learns a ruleset when devfs(8) loads the file
+	service devfs restart
+}
+
 jail_is_running()
 {
 	jls -d -j "$1" name 2>/dev/null | grep -q "$1"

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -165,7 +165,7 @@ jail_conf_header()
 exec.start = "/bin/sh /etc/rc";
 exec.stop = "/bin/sh /etc/rc.shutdown";
 exec.clean;
-devfs_ruleset = 4;
+devfs_ruleset=$JAIL_DEVFS_RULESET;
 path = "$_path";
 interface = $JAIL_NET_INTERFACE;
 host.hostname = \$name;
@@ -201,6 +201,8 @@ get_pfrule_path()
 {
 	echo "$MT6_ETC/pfrule.sh"
 }
+
+export JAIL_DEVFS_RULESET=${JAIL_DEVFS_RULESET:-4}
 
 jail_is_running()
 {
@@ -383,7 +385,7 @@ $(safe_jailname "$1")	{$(get_safe_jail_path "$1")
 		host.hostname = \$name;
 		path = "$_path";
 		$(jail_conf_mount "$1")
-		devfs_ruleset = 4;
+		devfs_ruleset=$JAIL_DEVFS_RULESET;
 
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
 		${_IP6}${JAIL_CONF_EXTRA}

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -386,7 +386,7 @@ start_staged_jail()
 		exec.start="/bin/sh /etc/rc" \
 		exec.stop="/bin/sh /etc/rc.shutdown" \
 		$_mount \
-		devfs_ruleset=4 \
+		devfs_ruleset="$JAIL_DEVFS_RULESET" \
 		$JAIL_START_EXTRA
 
 	enable_bsd_cache

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -4,7 +4,7 @@ set -e -u
 
 . mail-toaster.sh
 
-export JAIL_DEVFS_RULESET=7
+export JAIL_DEVFS_RULESET="$JAIL_DEVFS_RULESET_BPF"
 export JAIL_START_EXTRA="allow.raw_sockets=1"
 export JAIL_CONF_EXTRA="
 		allow.raw_sockets;"
@@ -93,6 +93,7 @@ test_dhcpd()
 
 base_snapshot_exists || exit
 create_staged_fs dhcp
+assure_devfs_bpf_ruleset
 start_staged_jail dhcp
 install_dhcpd
 configure_dhcpd

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -4,10 +4,9 @@ set -e -u
 
 . mail-toaster.sh
 
-export JAIL_START_EXTRA="devfs_ruleset=7
-		allow.raw_sockets=1"
+export JAIL_DEVFS_RULESET=7
+export JAIL_START_EXTRA="allow.raw_sockets=1"
 export JAIL_CONF_EXTRA="
-		devfs_ruleset = 7;
 		allow.raw_sockets;"
 export JAIL_FSTAB=""
 

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -7,9 +7,9 @@ set -e
 service_config haraka
 export TOASTER_HARAKA_VERSION=${TOASTER_HARAKA_VERSION:-""}
 
-export JAIL_START_EXTRA="devfs_ruleset=7"
-export JAIL_CONF_EXTRA="
-		devfs_ruleset = 7;"
+export JAIL_DEVFS_RULESET=7
+export JAIL_START_EXTRA=""
+export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
 
 HARAKA_CONF="$(get_jail_data haraka)/config"

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -7,7 +7,7 @@ set -e
 service_config haraka
 export TOASTER_HARAKA_VERSION=${TOASTER_HARAKA_VERSION:-""}
 
-export JAIL_DEVFS_RULESET=7
+export JAIL_DEVFS_RULESET="$JAIL_DEVFS_RULESET_BPF"
 export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
@@ -67,25 +67,6 @@ install_geoip_dbs()
 	fstab_add_mount haraka "$(get_jail_data geoip)/db" "$ZFS_JAIL_MNT/haraka/usr/local/share/GeoIP"
 
 	haraka_enable_plugin geoip
-}
-
-add_devfs_rule()
-{
-	if grep -qs devfsrules_jail_bpf /etc/devfs.rules; then
-		tell_status "devfs BPF ruleset already present"
-		return
-	fi
-
-	tell_status "installing devfs ruleset for p0f"
-	tee -a /etc/devfs.rules <<EO_DEVFS
-[devfsrules_jail_bpf=7]
-add include \$devfsrules_hide_all
-add include \$devfsrules_unhide_basic
-add include \$devfsrules_unhide_login
-add path zfs unhide
-add path 'bpf*' unhide
-EO_DEVFS
-
 }
 
 install_p0f()
@@ -748,7 +729,7 @@ preinstall_checks() {
 preinstall_checks
 create_staged_fs haraka
 mkdir -p "$STAGE_MNT/usr/local/share/GeoIP"
-add_devfs_rule
+assure_devfs_bpf_ruleset
 start_staged_jail haraka
 install_haraka
 configure_haraka

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -147,11 +147,13 @@ devfs_setup() {
   store_config() { cat -; }
 }
 
-@test "JAIL_DEVFS_RULESET - defaults when a jail asks for nothing" {
+@test "JAIL_DEVFS_RULESET - defaults to devfsrules_jail when a jail asks for nothing" {
   devfs_setup
+  unset JAIL_DEVFS_RULESET
+  load '../../include/jail.sh'
   run add_jail_conf_d mysql
   assert_success
-  assert_output --partial "devfs_ruleset=5;"
+  assert_output --partial "devfs_ruleset=4;"
 }
 
 @test "JAIL_DEVFS_RULESET - a jail can ask for another ruleset" {
@@ -180,6 +182,42 @@ devfs_setup() {
   export JAIL_DEVFS_RULESET=7
   run jail_conf_header mysql
   assert_output --partial "devfs_ruleset=7;"
+}
+
+@test "assure_devfs_bpf_ruleset - creates the ruleset when absent" {
+  export DEVFS_RULES="$BATS_TEST_TMPDIR/devfs.rules"
+  : > "$DEVFS_RULES"
+  tell_status() { :; }
+  service() { echo "service $*" >> "$BATS_TEST_TMPDIR/svc"; }
+
+  assure_devfs_bpf_ruleset > /dev/null
+
+  run cat "$DEVFS_RULES"
+  assert_output --partial "[devfsrules_jail_bpf=7]"
+  assert_output --partial "add include \$devfsrules_jail"
+  assert_output --partial "add path 'bpf*' unhide"
+
+  run cat "$BATS_TEST_TMPDIR/svc"
+  assert_output "service devfs restart"
+}
+
+@test "assure_devfs_bpf_ruleset - is a no-op when already present" {
+  export DEVFS_RULES="$BATS_TEST_TMPDIR/devfs.rules"
+  printf '%s\n' "[devfsrules_jail_bpf=7]" "add path 'bpf*' unhide" > "$DEVFS_RULES"
+  local _before; _before=$(cat "$DEVFS_RULES")
+  tell_status() { :; }
+  service() { echo "restarted" > "$BATS_TEST_TMPDIR/svc"; }
+
+  run assure_devfs_bpf_ruleset
+  assert_success
+  [ "$(cat "$DEVFS_RULES")" = "$_before" ]
+  [ ! -f "$BATS_TEST_TMPDIR/svc" ]
+}
+
+@test "assure_devfs_bpf_ruleset - the jails needing bpf ask for that ruleset" {
+  run grep -h "^export JAIL_DEVFS_RULESET" provision/haraka.sh provision/dhcp.sh
+  assert_success
+  assert_equal "$(echo "$output" | grep -c JAIL_DEVFS_RULESET_BPF)" "2"
 }
 
 # --- migrate_jail_conf: repoint an edited conf ---

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -138,6 +138,50 @@ setup() {
   assert_output "/etc/mail-toaster/pfrule.sh"
 }
 
+# --- JAIL_DEVFS_RULESET ---
+
+devfs_setup() {
+  export ZFS_DATA_MNT="/data" MT6_ETC="/etc/mail-toaster"
+  dec_to_hex() { if [ "$1" -eq 4 ]; then echo "4"; fi; }
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  store_config() { cat -; }
+}
+
+@test "JAIL_DEVFS_RULESET - defaults when a jail asks for nothing" {
+  devfs_setup
+  run add_jail_conf_d mysql
+  assert_success
+  assert_output --partial "devfs_ruleset=5;"
+}
+
+@test "JAIL_DEVFS_RULESET - a jail can ask for another ruleset" {
+  devfs_setup
+  export JAIL_DEVFS_RULESET=7
+  run add_jail_conf_d mysql
+  assert_success
+  assert_output --partial "devfs_ruleset=7;"
+}
+
+# the old override put a second devfs_ruleset in JAIL_CONF_EXTRA, which won
+# only by being emitted later
+@test "JAIL_DEVFS_RULESET - the conf declares it exactly once" {
+  devfs_setup
+  export JAIL_DEVFS_RULESET=7 JAIL_CONF_EXTRA="
+		allow.raw_sockets;"
+
+  run add_jail_conf_d dhcp
+  assert_success
+  assert_equal "$(echo "$output" | grep -c devfs_ruleset)" "1"
+  assert_output --partial "allow.raw_sockets;"
+}
+
+@test "JAIL_DEVFS_RULESET - jail_conf_header follows it too" {
+  devfs_setup
+  export JAIL_DEVFS_RULESET=7
+  run jail_conf_header mysql
+  assert_output --partial "devfs_ruleset=7;"
+}
+
 # --- migrate_jail_conf: repoint an edited conf ---
 
 mjc_setup() {

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -520,6 +520,21 @@ unmounted_paths() {
   assert_output --partial "git clone https://github.com/freebsd/freebsd-ports.git"
 }
 
+@test "start_staged_jail - the stage jail gets the jail's own ruleset" {
+  export ZFS_JAIL_MNT="$BATS_TEST_TMPDIR/jails" MT6_ETC="$BATS_TEST_TMPDIR/etc"
+  export STAGE_MNT="$ZFS_JAIL_MNT/stage" JAIL_NET_INTERFACE=lo1
+  export JAIL_DEVFS_RULESET=7 JAIL_START_EXTRA=""
+  tell_status() { :; }
+  jail() { echo "$@"; }
+  enable_bsd_cache() { :; }
+  pkg() { :; }
+
+  run start_staged_jail haraka
+  assert_success
+  assert_output --partial "devfs_ruleset=7"
+  assert_equal "$(echo "$output" | grep -c devfs_ruleset)" "1"
+}
+
 # --- moving control files out of the jail's data volume, on rebuild ---
 
 host_etc_setup() {

--- a/test/provision.bats
+++ b/test/provision.bats
@@ -131,9 +131,27 @@ _no_start_required() {
   assert_output --partial "enforce_statfs=1"
 }
 
-@test "haraka exports devfs_ruleset in JAIL_START_EXTRA" {
-  run grep "^export JAIL_START_EXTRA" provision/haraka.sh
-  assert_output --partial "devfs_ruleset"
+# the ruleset has to exist before the stage jail asks for it
+@test "jails needing bpf create the ruleset themselves" {
+  for _s in provision/haraka.sh provision/dhcp.sh; do
+    run grep -n "assure_devfs_bpf_ruleset" "$_s"
+    assert_success
+    run sh -c "grep -n 'assure_devfs_bpf_ruleset\|start_staged_jail' $_s | tail -2 | head -1"
+    assert_output --partial "assure_devfs_bpf_ruleset"
+  done
+}
+
+@test "jails needing extra devices set JAIL_DEVFS_RULESET" {
+  for _s in provision/haraka.sh provision/dhcp.sh; do
+    run grep "^export JAIL_DEVFS_RULESET" "$_s"
+    assert_success
+  done
+}
+
+# a second assignment in JAIL_CONF_EXTRA would win only by being emitted later
+@test "no provision script smuggles devfs_ruleset through JAIL_*_EXTRA" {
+  run grep -l "JAIL_START_EXTRA=.*devfs_ruleset\|JAIL_CONF_EXTRA=.*devfs_ruleset" provision/*.sh
+  assert_output ""
 }
 
 # ---------------------------------------------------------------------------

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -215,5 +215,5 @@ sysctl()   { echo "1073741824"; }  # ~1 GB; keeps phishing checks disabled
 # sysrc()    { :; }
 rspamadm() { echo "stub-rspamadm-hash"; }
 chown()    { :; }  # non-root CI environments can't chown
-add_devfs_rule()           { :; }
+assure_devfs_bpf_ruleset() { :; }
 stage_enable_quotas()      { :; }


### PR DESCRIPTION
This is a followup for #701 which correctly reduced the jails devfs ruleset to 4, but didn't provide a means for jails to declare their need for another ruleset.