### PR TITLE
vpopmail: use assure_ports_tree

### DIFF
--- a/include/vpopmail.sh
+++ b/include/vpopmail.sh
@@ -64,6 +64,7 @@ vpopmail_port_fixups() {
 
 install_vpopmail_port()
 {
+	assure_ports_tree
 	install_vpopmail_deps
 
 	if [ "$TOASTER_MYSQL" = "1" ]; then


### PR DESCRIPTION
### Changes proposed in this pull request:
- Use `assure_port_tree` to produce a friendly error message when ports are not available.
