### PR TITLE
mt: set devfs_ruleset to 0 when MT6 is jailed

### DIFF
--- a/include/jail.sh
+++ b/include/jail.sh
@@ -197,6 +197,7 @@ get_pfrule_path()
 	echo "$MT6_ETC/pfrule.sh"
 }
 
+[ "$(sysctl -n security.jail.jailed)" != 1 ] || JAIL_DEVFS_RULESET=0
 export JAIL_DEVFS_RULESET=${JAIL_DEVFS_RULESET:-4}
 
 export DEVFS_RULES=${DEVFS_RULES:-"/etc/devfs.rules"}

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -371,6 +371,8 @@ start_staged_jail()
 
 	tell_status "stage jail $_name startup"
 
+	[ "$(sysctl -n security.jail.jailed)" != 1 ] || JAIL_DEVFS_RULESET=0
+
 	# shellcheck disable=2086
 	jail -c \
 		name=stage \

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -676,7 +676,7 @@ configure_haraka()
 	configure_haraka_http
 	configure_haraka_tls
 	configure_haraka_dkim
-	configure_haraka_p0f
+	[ "$(sysctl -n security.jail.jailed)" = 1 ] || configure_haraka_p0f
 	configure_haraka_spamassassin
 	configure_haraka_rspamd
 	configure_haraka_clamav


### PR DESCRIPTION
### Changes proposed in this pull request:
- Set devfs_ruleset to 0 when MT6 is itself jailed.
- Disable p0f in Haraka when MT6 is itself jailed.

This allows to run most provisioning tasks successfully (in a VNET jail with a jailed ZFS dataset). Making them actually work is another problem, but I find it's good enough for testing.

