### PR TITLE
[hardening] base: no /etc/hosts from the host system; dns: install minimal /etc/hosts

### DIFF
--- a/include/network.sh
+++ b/include/network.sh
@@ -97,3 +97,11 @@ install_acme_sh()
 /usr/local/sbin/acme.sh --cron
 EO_ACME_CRON
 }
+
+install_minimal_hosts()
+{
+	store_config "$STAGE_MNT/etc/hosts" "append" <<EO_HOSTS
+$(get_jail_ip syslog) syslog
+$(get_jail_ip bsd_cache) pkg vulnxml freebsd-update
+EO_HOSTS
+}

--- a/include/network.sh
+++ b/include/network.sh
@@ -101,6 +101,7 @@ EO_ACME_CRON
 install_minimal_hosts()
 {
 	store_config "$STAGE_MNT/etc/hosts" "append" <<EO_HOSTS
+$(get_jail_ip dns) dns
 $(get_jail_ip syslog) syslog
 $(get_jail_ip bsd_cache) pkg vulnxml freebsd-update
 EO_HOSTS

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -199,9 +199,6 @@ configure_base()
 	tell_status "setting base jail timezone (to hosts)"
 	cp /etc/localtime "$BASE_MNT/etc"
 
-	tell_status "installing $BASE_MNT/etc/hosts"
-	cp /etc/hosts "$BASE_MNT/etc"
-
 	configure_make_conf
 
 	tell_status "adding base rc.conf settings"

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -275,6 +275,7 @@ EO_PRESTOP
 
 base_snapshot_exists || exit 1
 create_staged_fs dns
+install_minimal_hosts
 start_staged_jail dns
 install_unbound
 configure_unbound

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -118,6 +118,7 @@ get_public_ip6()           { :; }
 get_public_facing_nic()    { :; }
 install_pfrule()           { :; }
 install_acme_sh()          { :; }
+install_minimal_hosts()    { :; }
 
 # Config / util
 sed_inplace()              { sed -i.bak "$@"; }


### PR DESCRIPTION
### Changes proposed in this pull request:
- Don't copy /etc/hosts from the host system into the base jail, there may be private info there.
- Install a minimal /etc/hosts into the dns jail.

The other jails I use are working well with this setup, but I am not sure about the ones I don't use.
