### PR TITLE
refactor(net): build clean on IPv4-only, v6-only, and dual-stack

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,10 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 - perf(test): source the assertion libraries once, scripts once per file
 - nginx: add nginx_listen(), emitting IPv4 and IPv6 listen directives
 - refactor(net): build clean on IPv4-only, v6-only, and dual-stack
+- jail: rename get_jail_ip to get_jail_ip4, get_jail_ip remains as an alias
+- host: pf.conf gains ext_if6, each family NATs on its own default route NIC
+- host: ntp rule covers every public NIC, not just the IPv4 one
+- host: ssh rate limit applies on every interface, jail and loopback sources exempt
 - linux jails: rc.d/linux mounts /compat/linux inside the jail
 - dma: create /var/spool/dma when the port has not
 - mt: jail control files move to /etc/mail-toaster/<jail>

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 - jail: rename get_jail_ip to get_jail_ip4
 - perf(test): source the assertion libraries once, scripts once per file
+- nginx: add nginx_listen(), emitting IPv4 and IPv6 listen directives
 - linux jails: rc.d/linux mounts /compat/linux inside the jail
 - dma: create /var/spool/dma when the port has not
 - mt: jail control files move to /etc/mail-toaster/<jail>

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 - jail: rename get_jail_ip to get_jail_ip4
 - perf(test): source the assertion libraries once, scripts once per file
 - nginx: add nginx_listen(), emitting IPv4 and IPv6 listen directives
+- refactor(net): build clean on IPv4-only, v6-only, and dual-stack
 - linux jails: rc.d/linux mounts /compat/linux inside the jail
 - dma: create /var/spool/dma when the port has not
 - mt: jail control files move to /etc/mail-toaster/<jail>

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -2,7 +2,7 @@
 
 safe_jailname()
 {
-	# constrain jail name chars to alpha-numeric and _
+	# constrain name chars to alpha-numeric and _
 	# shellcheck disable=SC2001
 	echo "$1" | sed -e 's/[^a-zA-Z0-9]/_/g'
 }
@@ -110,9 +110,14 @@ configure_mta_pf_rdr()
 
 	configure_pf_jail_table "$_jail"
 
+	local _rdr6=""
+	if jail_has_ip6; then
+		_rdr6="rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")"
+	fi
+
 	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
-rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip4 "$_jail")
-rdr inet6 proto tcp from any to <ext_ip6> port { $_ports } -> $(get_jail_ip6 "$_jail")
+rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip "$_jail")
+$_rdr6
 EO_PF_RDR
 
 	store_config "$_pf_etc/filter.conf" <<EO_PF_FILTER
@@ -126,15 +131,13 @@ configure_pf_jail_table()
 	local _pf_etc
 	_pf_etc="$(get_jail_host_etc "$_jail")/pf.conf.d"
 
-	get_public_ip4
-	get_public_ip6
-
-	store_config "$_pf_etc/$_jail.table" <<EO_PF_TABLE
-$PUBLIC_IP4
-$PUBLIC_IP6
-$(get_jail_ip4 "$_jail")
-$(get_jail_ip6 "$_jail")
-EO_PF_TABLE
+	# pfctl -T replace rejects the file over a blank line
+	{
+		has_public_ip4 && echo "$PUBLIC_IP4"
+		has_public_ip6 && echo "$PUBLIC_IP6"
+		get_jail_ip "$_jail"
+		jail_has_ip6 && get_jail_ip6 "$_jail"
+	} | store_config "$_pf_etc/$_jail.table" "update"
 }
 
 get_reverse_ip()
@@ -381,12 +384,19 @@ warn_stale_jail_conf()
 	fi
 }
 
+# A jail always gets an ip4.addr on the private network. It gets an ip6.addr
+# only where the host has a public IPv6, so this answers "can a service in this
+# jail bind IPv6" for every generated config.
+jail_has_ip6()
+{
+	has_public_ip6
+}
+
 jail_conf_ip6()
 {
 	local _addr; _addr="ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");"
 
-	get_public_ip6
-	if [ -z "${PUBLIC_IP6:-}" ]; then _addr="#$_addr"; fi
+	if ! jail_has_ip6; then _addr="#$_addr"; fi
 
 	echo "$_addr"
 }
@@ -436,7 +446,6 @@ add_jail_conf_d()
 	local _path="$ZFS_JAIL_MNT/$1"
 	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
 
-	# base redirects no ports, so the host has no pf rules to run for it
 	local _pf_exec=""
 	if [ "$1" != "base" ]; then
 		_pf_exec="
@@ -494,19 +503,34 @@ add_automount()
 
 assure_ip6_addr_is_declared()
 {
-	if ! grep -qs "^$1" /etc/jail.conf; then
+	local _jail="$1" _conf="${2:-/etc/jail.conf}"
+
+	if ! grep -qs "^$_jail" "$_conf"; then
 		# config for this jail hasn't been created yet
 		return
 	fi
 
-	if awk "/^$1/,/}/" /etc/jail.conf | grep -q ip6; then
+	local _section; _section=$(awk "/^$_jail/,/}/" "$_conf")
+
+	if echo "$_section" | grep -q '^[[:space:]]*ip6\.addr'; then
 		echo "ip6.addr is already declared"
 		return
 	fi
 
-	tell_status "adding ip6.addr to $1 section in /etc/jail.conf"
+	# a commented entry is waiting on the host to have one.
+	if echo "$_section" | grep -q '^[[:space:]]*#ip6\.addr'; then
+		if ! jail_has_ip6; then return; fi
+
+		tell_status "enabling ip6.addr in $_jail section in $_conf"
+		sed_inplace \
+			-e "/^$_jail/,/}/ s/^\\([[:space:]]*\\)#ip6\\.addr/\\1ip6.addr/" \
+			"$_conf"
+		return
+	fi
+
+	tell_status "adding ip6.addr to $_jail section in $_conf"
 	sed_inplace \
-		-e "/^$1/,/ip4/ s/ip4.*;/&\\
-		$(jail_conf_ip6 "$1")/" \
-		/etc/jail.conf
+		-e "/^$_jail/,/ip4/ s/ip4.*;/&\\
+		$(jail_conf_ip6 "$_jail")/" \
+		"$_conf"
 }

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -116,7 +116,7 @@ configure_mta_pf_rdr()
 	fi
 
 	store_config "$_pf_etc/rdr.conf" "overwrite" <<EO_PF_RDR
-rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip "$_jail")
+rdr inet  proto tcp from any to <ext_ip4> port { $_ports } -> $(get_jail_ip4 "$_jail")
 $_rdr6
 EO_PF_RDR
 
@@ -135,7 +135,7 @@ configure_pf_jail_table()
 	{
 		has_public_ip4 && echo "$PUBLIC_IP4"
 		has_public_ip6 && echo "$PUBLIC_IP6"
-		get_jail_ip "$_jail"
+		get_jail_ip4 "$_jail"
 		jail_has_ip6 && get_jail_ip6 "$_jail"
 	} | store_config "$_pf_etc/$_jail.table" "update"
 }

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -381,6 +381,16 @@ warn_stale_jail_conf()
 	fi
 }
 
+jail_conf_ip6()
+{
+	local _addr; _addr="ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");"
+
+	get_public_ip6
+	if [ -z "${PUBLIC_IP6:-}" ]; then _addr="#$_addr"; fi
+
+	echo "$_addr"
+}
+
 add_jail_conf()
 {
 	local _jail_ip; _jail_ip=$(get_jail_ip4 "$1");
@@ -410,7 +420,7 @@ add_jail_conf()
 	echo "$1	{$(get_safe_jail_path "$1")
 $(jail_conf_mount "$1")
 		ip4.addr = $JAIL_NET_INTERFACE|${_jail_ip};
-		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");${JAIL_CONF_EXTRA}
+		$(jail_conf_ip6 "$1")${JAIL_CONF_EXTRA}
 	}" | tee -a /etc/jail.conf
 }
 
@@ -421,12 +431,7 @@ add_jail_conf_d()
 		fatal_err "can't determine IP for $1"
 	fi
 
-	# configure IPv6 if the system has an external/public IPv6 address
-	local _IP6=""
-	get_public_ip6
-	if [ -n "$PUBLIC_IP6" ]; then
-		_IP6="ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");"
-	fi
+	local _IP6; _IP6=$(jail_conf_ip6 "$1")
 
 	local _path="$ZFS_JAIL_MNT/$1"
 	if [ "$1" = "base" ]; then _path="$BASE_MNT"; fi
@@ -502,6 +507,6 @@ assure_ip6_addr_is_declared()
 	tell_status "adding ip6.addr to $1 section in /etc/jail.conf"
 	sed_inplace \
 		-e "/^$1/,/ip4/ s/ip4.*;/&\\
-		ip6.addr = $JAIL_NET_INTERFACE|$(get_jail_ip6 "$1");/" \
+		$(jail_conf_ip6 "$1")/" \
 		/etc/jail.conf
 }

--- a/include/jail.sh
+++ b/include/jail.sh
@@ -384,9 +384,8 @@ warn_stale_jail_conf()
 	fi
 }
 
-# A jail always gets an ip4.addr on the private network. It gets an ip6.addr
-# only where the host has a public IPv6, so this answers "can a service in this
-# jail bind IPv6" for every generated config.
+# A jail always gets an ip4.addr on lo1. It gets an ip6.addr only when the host has
+# a public IPv6. This answers "can a service in this jail bind IPv6".
 jail_has_ip6()
 {
 	has_public_ip6

--- a/include/network.sh
+++ b/include/network.sh
@@ -34,9 +34,7 @@ get_public_ip4()
 	# callers rely on the PUBLIC_NIC this exports, so look it up either way
 	get_public_facing_nic ipv4
 
-	# PUBLIC_IP4 is the public facing address, which need not be bound to a
-	# local interface. ifconfig finds it only where the two coincide, so a
-	# configured value wins.
+	# PUBLIC_IP4 is the public *facing* address
 	if [ -n "$PUBLIC_IP4" ]; then return; fi
 
 	export PUBLIC_IP4
@@ -52,6 +50,18 @@ get_public_ip6()
 
 	export PUBLIC_IP6
 	PUBLIC_IP6=$(ifconfig "$PUBLIC_NIC" inet6 | grep inet6 | grep -v fe80 | awk '{print $2}' | head -n1)
+}
+
+has_public_ip4()
+{
+	get_public_ip4
+	[ -n "${PUBLIC_IP4:-}" ]
+}
+
+has_public_ip6()
+{
+	get_public_ip6
+	[ -n "${PUBLIC_IP6:-}" ]
 }
 
 get_random_ip6net()
@@ -91,7 +101,6 @@ install_acme_sh()
 	stage_exec sh -c "[ -e /data/home/acme/deploy] || ln -s /usr/local/share/examples/acme.sh/deploy /data/home/acme/deploy"
 	stage_exec ln -s /data/home/acme /root/.acme.sh
 
-	# renew the certs automatically
 	store_exec "$STAGE_MNT/usr/local/etc/periodic/daily/acme.sh" <<EO_ACME_CRON
 #!/usr/local/bin/bash
 /usr/local/sbin/acme.sh --cron

--- a/include/nginx.sh
+++ b/include/nginx.sh
@@ -51,6 +51,22 @@ EO_NG_NSL
 
 }
 
+nginx_listen()
+{
+	local _port="${1:-80}"
+	local _opts="${2:-}"
+	if [ -n "$_opts" ]; then _opts=" $_opts"; fi
+
+	get_public_ip4
+	get_public_ip6
+
+	local _c4=""; if [ -z "${PUBLIC_IP4:-}" ]; then _c4="#"; fi
+	local _c6=""; if [ -z "${PUBLIC_IP6:-}" ]; then _c6="#"; fi
+
+	printf '\t\t%slisten       %s%s;\n\t\t%slisten  [::]:%s%s;\n' \
+		"$_c4" "$_port" "$_opts" "$_c6" "$_port" "$_opts"
+}
+
 contains() {
 	string="$1"
 	substring="$2"
@@ -71,13 +87,8 @@ configure_nginx_server_d()
 
 	# no more proxy protocol on backends, since nginx can't
 	# send proxy protocol AND route URIs at the same time
-	local _prefix='server {
-		listen       80;'
-
-	if [ -n "${PUBLIC_IP6:-}" ]; then
-		_prefix="$_prefix
-		listen  [::]:80;"
-	fi
+	local _prefix; _prefix="server {
+$(nginx_listen 80)"
 
 	local _suffix='location ~ /\.ht {
 			deny  all;

--- a/include/nginx.sh
+++ b/include/nginx.sh
@@ -57,14 +57,10 @@ nginx_listen()
 	local _opts="${2:-}"
 	if [ -n "$_opts" ]; then _opts=" $_opts"; fi
 
-	get_public_ip4
-	get_public_ip6
+	local _c6=""; if ! jail_has_ip6; then _c6="#"; fi
 
-	local _c4=""; if [ -z "${PUBLIC_IP4:-}" ]; then _c4="#"; fi
-	local _c6=""; if [ -z "${PUBLIC_IP6:-}" ]; then _c6="#"; fi
-
-	printf '\t\t%slisten       %s%s;\n\t\t%slisten  [::]:%s%s;\n' \
-		"$_c4" "$_port" "$_opts" "$_c6" "$_port" "$_opts"
+	printf '\t\tlisten       %s%s;\n\t\t%slisten  [::]:%s%s;\n' \
+		"$_port" "$_opts" "$_c6" "$_port" "$_opts"
 }
 
 contains() {
@@ -106,7 +102,7 @@ $(nginx_listen 80)"
 		_suffix=''
 	fi
 
-	store_config "$_server_conf" <<EO_NGINX_SERVER_CONF
+	store_config "$_server_conf" "update" <<EO_NGINX_SERVER_CONF
 	$_prefix
 		$_NGINX_SERVER
 		$_suffix
@@ -126,7 +122,7 @@ configure_nginx()
 
 	stage_sysrc nginx_flags='-c /data/etc/nginx/nginx.conf'
 
-	store_config "$_etcdir/nginx.conf" <<EO_NGINX_CONF
+	store_config "$_etcdir/nginx.conf" "update" <<EO_NGINX_CONF
 # load_module /usr/local/libexec/nginx/ngx_http_acme_module.so;
 load_module /usr/local/libexec/nginx/ngx_mail_module.so;
 load_module /usr/local/libexec/nginx/ngx_stream_module.so;

--- a/provision/bsd_cache.sh
+++ b/provision/bsd_cache.sh
@@ -10,10 +10,9 @@ mt6-include nginx
 
 configure_nginx_server()
 {
-	_NGINX_SERVER='
+	_NGINX_SERVER="
 	server {
-		listen       80;
-		listen  [::]:80;
+$(nginx_listen 80)
 
 		server_name  pkg;
 
@@ -27,14 +26,13 @@ configure_nginx_server()
 			proxy_cache_valid        404 5m;
 		}
 	}
-'
+"
 	export _NGINX_SERVER
 	configure_nginx_server_d bsd_cache pkg
 
-	_NGINX_SERVER='
+	_NGINX_SERVER="
 	server {
-		listen       80;
-		listen  [::]:80;
+$(nginx_listen 80)
 
 		server_name  freebsd-update;
 
@@ -49,14 +47,13 @@ configure_nginx_server()
 			proxy_cache_valid        404 5m;
 		}
 	}
-'
+"
 	export _NGINX_SERVER
 	configure_nginx_server_d bsd_cache update
 
-	_NGINX_SERVER='
+	_NGINX_SERVER="
 	server {
-		listen       80;
-		listen  [::]:80;
+$(nginx_listen 80)
 
 		server_name  vulnxml;
 
@@ -71,7 +68,7 @@ configure_nginx_server()
 			proxy_cache_valid        404 5m;
 		}
 	}
-'
+"
 	export _NGINX_SERVER
 	configure_nginx_server_d bsd_cache vulnxml
 }

--- a/provision/dcc.sh
+++ b/provision/dcc.sh
@@ -33,11 +33,10 @@ install_dcc_port_options()
 	local SET=DCCIFD
 	local UNSET="DCCGREY DCCD DCCM PORTS_MILTER"
 
-	get_public_ip6
-	if [ -z "$PUBLIC_IP6" ]; then
-		UNSET="$UNSET IPV6"
-	else
+	if jail_has_ip6; then
 		SET="$SET IPV6"
+	else
+		UNSET="$UNSET IPV6"
 	fi
 
 	stage_make_conf dcc-dccd_SET "mail_dcc-dccd_SET=$SET"
@@ -84,7 +83,7 @@ start_dcc()
 	tell_status "starting up dcc-ifd"
 	stage_sysrc dccifd_enable=YES
 	stage_exec service dccifd start
-	if [ -n "$PUBLIC_IP6" ]; then
+	if jail_has_ip6; then
 		stage_exec cdcc info
 	else
 		stage_exec cdcc IPv6=off info

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -30,9 +30,9 @@ configure_dhcpd()
 	echo "configured"
 
 	local _pf_etc; _pf_etc="$(get_jail_host_etc dhcp)/pf.conf.d"
-	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
-rdr inet  proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip4  dhcp)
-rdr inet6 proto tcp from any to <ext_ips> port { 67 68 } -> $(get_jail_ip6 dhcp)
+
+	store_config "$_pf_etc/rdr.conf" "update" <<EO_PF_RDR
+rdr inet proto udp from any to <ext_ip4> port { 67 68 } -> $(get_jail_ip dhcp)
 EO_PF_RDR
 
 	if [ ! -d "$(get_jail_data dhcp)/etc" ]; then

--- a/provision/dhcp.sh
+++ b/provision/dhcp.sh
@@ -32,7 +32,7 @@ configure_dhcpd()
 	local _pf_etc; _pf_etc="$(get_jail_host_etc dhcp)/pf.conf.d"
 
 	store_config "$_pf_etc/rdr.conf" "update" <<EO_PF_RDR
-rdr inet proto udp from any to <ext_ip4> port { 67 68 } -> $(get_jail_ip dhcp)
+rdr inet proto udp from any to <ext_ip4> port { 67 68 } -> $(get_jail_ip4 dhcp)
 EO_PF_RDR
 
 	if [ ! -d "$(get_jail_data dhcp)/etc" ]; then

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -21,12 +21,18 @@ install_unbound()
 
 get_mt6_data()
 {
-	local _spf_ips
+	# a bare "ip4:" or "ip6:" is a syntax error that voids the whole record
+	# (RFC 7208 4.6.4), so an address the host does not have is left out
+	local _spf_ips="ip4:${JAIL_NET_PREFIX}.0/${JAIL_NET_MASK} ip6:$JAIL_NET6::/112"
 
-	if [ -z "$PUBLIC_IP6" ]; then
-		_spf_ips="ip4:${JAIL_NET_PREFIX}.0/${JAIL_NET_MASK} ip4:$PUBLIC_IP4 ip6:$JAIL_NET6::/112"
-	else
-		_spf_ips="ip4:${JAIL_NET_PREFIX}.0/${JAIL_NET_MASK} ip4:$PUBLIC_IP4 ip6:$JAIL_NET6::/112 ip6:$PUBLIC_IP6"
+	if has_public_ip4; then _spf_ips="$_spf_ips ip4:$PUBLIC_IP4"; fi
+	if has_public_ip6; then _spf_ips="$_spf_ips ip6:$PUBLIC_IP6"; fi
+
+	local _has_ip6=0 _hostname_aaaa=""
+	if jail_has_ip6; then
+		_has_ip6=1
+		_hostname_aaaa="
+	   local-data: \"$TOASTER_HOSTNAME AAAA $(get_jail_ip6 vpopmail)\""
 	fi
 
 	echo "
@@ -34,8 +40,7 @@ get_mt6_data()
 	   local-zone: $TOASTER_MAIL_DOMAIN typetransparent
 	   local-data: \"stage		A $(get_jail_ip4 stage)\"
 	   local-data: \"$(get_reverse_ip stage) PTR stage\"
-	   local-data: \"$TOASTER_HOSTNAME A $(get_jail_ip4 vpopmail)\"
-	   local-data: \"$TOASTER_HOSTNAME AAAA $(get_jail_ip6 vpopmail)\"
+	   local-data: \"$TOASTER_HOSTNAME A $(get_jail_ip vpopmail)\"$_hostname_aaaa
 	   local-data: '$TOASTER_MAIL_DOMAIN TXT \"v=spf1 a mx $_spf_ips -all\"'
 	   local-data: \"freebsd-update		A $(get_jail_ip4 bsd_cache)\"
 	   local-data: \"pkg				A $(get_jail_ip4 bsd_cache)\"
@@ -49,33 +54,40 @@ get_mt6_data()
 
 	for _j in $JAIL_ORDERED_LIST; do
 		echo "
-	   local-data: \"$_j		A $(get_jail_ip4 "$_j")\"
-	   local-data: \"$(get_reverse_ip "$_j") PTR $_j\"
-	   local-data: \"$_j		AAAA $(get_jail_ip6 "$_j")\"
+	   local-data: \"$_j		A $(get_jail_ip "$_j")\"
+	   local-data: \"$(get_reverse_ip "$_j") PTR $_j\""
+
+		if [ "$_has_ip6" = 0 ]; then continue; fi
+
+		echo "	   local-data: \"$_j		AAAA $(get_jail_ip6 "$_j")\"
 	   local-data: \"$(get_reverse_ip6 "$_j") PTR $_j\""
 	done
 }
 
 install_access_conf()
 {
-	get_public_ip4
-
 	# An empty address would emit "access-control:  allow", which unbound
 	# rejects. Omit the entry instead of writing a file that will not parse.
 	local _public_acl=""
-	if [ -n "$PUBLIC_IP4" ]; then
+	if has_public_ip4; then
 		_public_acl="	   access-control: $PUBLIC_IP4 allow"
 	else
 		tell_status "no public IPv4 found, omitting its access-control entry"
 	fi
 
-	store_config "$(get_jail_data dns)/access.conf" <<EO_UNBOUND_ACCESS
+	local _public_acl6=""
+	if has_public_ip6; then
+		_public_acl6="	   access-control: $PUBLIC_IP6 allow"
+	fi
+
+	store_config "$(get_jail_data dns)/access.conf" "update" <<EO_UNBOUND_ACCESS
 
 	   access-control: 0.0.0.0/0 refuse
 	   access-control: 127.0.0.0/8 allow
 	   access-control: ${JAIL_NET_PREFIX}.0${JAIL_NET_MASK} allow
 $_public_acl
 	   access-control: $JAIL_NET6::/112 allow
+$_public_acl6
 
 EO_UNBOUND_ACCESS
 }
@@ -132,9 +144,16 @@ EO_UNBOUND
 tweak_unbound_conf()
 {
 	tell_status "configuring unbound.conf"
-	# control.conf for the munin stats plugin
+
+	local _prefer_ip6="no"
+	if ! has_public_ip4; then
+		tell_status "no public IPv4 found, preferring IPv6 for resolution"
+		_prefer_ip6="yes"
+	fi
+
 	# shellcheck disable=1004
 	sed_inplace \
+		-e "s/# prefer-ip6: no\$/prefer-ip6: $_prefer_ip6/" \
 		-e 's/# interface: 192.0.2.153$/interface: 0.0.0.0/' \
 		-e 's/# interface: 192.0.2.154$/interface: ::0/' \
 		-e '/# use-syslog/s/# //' \
@@ -144,13 +163,13 @@ tweak_unbound_conf()
 		-e '/hide-identity: /s/no/yes/' \
 		-e '/# hide-version: /s/# //' \
 		-e '/hide-version: /s/no/yes/' \
-		-e '/# access-control: ::ffff:127.*/ a\ 
+		-e '/# access-control: ::ffff:127.*/ a\
 include: "/data/access.conf" \
 ' \
-		-e '/# local-data-ptr:.*/ a\ 
+		-e '/# local-data-ptr:.*/ a\
 include: "/data/mt6-local.conf" \
 ' \
-		-e '/^remote-control:/ a\ 
+		-e '/^remote-control:/ a\
 	include: "/data/control.conf" \
 ' \
 		-e '/fwd.example.com$/ a\

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -149,11 +149,17 @@ tweak_unbound_conf()
 		_prefer_ip6="yes"
 	fi
 
+	local _if6="interface: ::0"
+	if ! jail_has_ip6; then
+		tell_status "no IPv6 for this jail, unbound will not bind it"
+		_if6="# interface: ::0"
+	fi
+
 	# shellcheck disable=1004
 	sed_inplace \
 		-e "s/# prefer-ip6: no\$/prefer-ip6: $_prefer_ip6/" \
 		-e 's/# interface: 192.0.2.153$/interface: 0.0.0.0/' \
-		-e 's/# interface: 192.0.2.154$/interface: ::0/' \
+		-e "s/# interface: 192.0.2.154\$/$_if6/" \
 		-e '/# use-syslog/s/# //' \
 		-e '/# chroot: /s/# //' \
 		-e '/chroot: /s/".*"/""/' \

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -21,8 +21,6 @@ install_unbound()
 
 get_mt6_data()
 {
-	# a bare "ip4:" or "ip6:" is a syntax error that voids the whole record
-	# (RFC 7208 4.6.4), so an address the host does not have is left out
 	local _spf_ips="ip4:${JAIL_NET_PREFIX}.0/${JAIL_NET_MASK} ip6:$JAIL_NET6::/112"
 
 	if has_public_ip4; then _spf_ips="$_spf_ips ip4:$PUBLIC_IP4"; fi
@@ -40,7 +38,7 @@ get_mt6_data()
 	   local-zone: $TOASTER_MAIL_DOMAIN typetransparent
 	   local-data: \"stage		A $(get_jail_ip4 stage)\"
 	   local-data: \"$(get_reverse_ip stage) PTR stage\"
-	   local-data: \"$TOASTER_HOSTNAME A $(get_jail_ip vpopmail)\"$_hostname_aaaa
+	   local-data: \"$TOASTER_HOSTNAME A $(get_jail_ip4 vpopmail)\"$_hostname_aaaa
 	   local-data: '$TOASTER_MAIL_DOMAIN TXT \"v=spf1 a mx $_spf_ips -all\"'
 	   local-data: \"freebsd-update		A $(get_jail_ip4 bsd_cache)\"
 	   local-data: \"pkg				A $(get_jail_ip4 bsd_cache)\"
@@ -54,7 +52,7 @@ get_mt6_data()
 
 	for _j in $JAIL_ORDERED_LIST; do
 		echo "
-	   local-data: \"$_j		A $(get_jail_ip "$_j")\"
+	   local-data: \"$_j		A $(get_jail_ip4 "$_j")\"
 	   local-data: \"$(get_reverse_ip "$_j") PTR $_j\""
 
 		if [ "$_has_ip6" = 0 ]; then continue; fi

--- a/provision/dovecot.sh
+++ b/provision/dovecot.sh
@@ -47,8 +47,7 @@ configure_dovecot_local_conf() {
 	_localconf="$(get_jail_data dovecot)/etc/local.conf"
 
 	local _listen='listen = *'
-	get_public_ip6
-	if [ -n "$PUBLIC_IP6" ]; then _listen="$_listen, ::"; fi
+	if jail_has_ip6; then _listen="$_listen, ::"; fi
 
 	if grep -q "/data/etc/ssl/" $_localconf; then
 		tell_status "Upgrading $_localconf to /data/etc/tls/"

--- a/provision/haproxy.sh
+++ b/provision/haproxy.sh
@@ -42,9 +42,8 @@ install_haproxy_libressl()
 	stage_port_install net/haproxy
 }
 
-# haproxy has no way to bind "whatever this host has", so emit one bind per
-# address family the host actually has. 'bind :::80 v4v6' fails to start on
-# hosts without IPv6.
+# emit one bind per address family.
+# 'bind :::80 v4v6' fails to start on hosts without IPv6.
 haproxy_binds()
 {
 	local _ip4="$2"
@@ -53,19 +52,13 @@ haproxy_binds()
 	local _indent
 	_indent=$(printf '%b' "$1")
 
-	get_public_ip4
-	get_public_ip6
+	printf '%sbind %s:80 alpn http/1.1\n' "$_indent" "$_ip4"
+	printf '%sbind %s:443 alpn http/1.1 ssl crt /data/etc/tls.d\n' "$_indent" "$_ip4"
 
-	# with neither address detected, IPv4 is the safer guess
-	if [ -n "$PUBLIC_IP4" ] || [ -z "$PUBLIC_IP6" ]; then
-		printf '%sbind %s:80 alpn http/1.1\n' "$_indent" "$_ip4"
-		printf '%sbind %s:443 alpn http/1.1 ssl crt /data/etc/tls.d\n' "$_indent" "$_ip4"
-	fi
+	if ! jail_has_ip6; then return; fi
 
-	if [ -n "$PUBLIC_IP6" ]; then
-		printf '%sbind [%s]:80 alpn http/1.1\n' "$_indent" "$_ip6"
-		printf '%sbind [%s]:443 alpn http/1.1 ssl crt /data/etc/tls.d\n' "$_indent" "$_ip6"
-	fi
+	printf '%sbind [%s]:80 alpn http/1.1\n' "$_indent" "$_ip6"
+	printf '%sbind [%s]:443 alpn http/1.1 ssl crt /data/etc/tls.d\n' "$_indent" "$_ip6"
 }
 
 configure_haproxy_dot_conf()
@@ -73,7 +66,7 @@ configure_haproxy_dot_conf()
 	local _data_cf
 	_data_cf="$(get_jail_data haproxy)/etc/haproxy.conf"
 
-	store_config "$_data_cf" <<EO_HAPROXY_CONF
+	store_config "$_data_cf" "update" <<EO_HAPROXY_CONF
 global
 	daemon
 	maxconn     256  # Total Max Connections. This is dependent on ulimit
@@ -305,7 +298,7 @@ EO_HAPROXY_CONF
 
 	_data_cf="$STAGE_MNT/usr/local/etc/haproxy.conf"
 
-	store_config "$_data_cf" <<EO_HAPROXY_STAGE_CONF
+	store_config "$_data_cf" "update" <<EO_HAPROXY_STAGE_CONF
 global
     daemon
     log 172.16.15.1 local0 err

--- a/provision/haraka.sh
+++ b/provision/haraka.sh
@@ -351,8 +351,7 @@ url=wss://$TOASTER_HOSTNAME/watch" > "$HARAKA_CONF/watch.ini"
 
 haraka_listen_addr()
 {
-	if [ -n "${PUBLIC_IP6:-}" ]; then
-		# IPv4 and IPv6
+	if jail_has_ip6; then
 		echo "[::0]"
 	else
 		echo "0.0.0.0"

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -184,7 +184,8 @@ constrain_sshd_to_host()
 	get_public_ip4
 	get_public_ip6
 
-	local IP_MSG="	Your public IP(s) are detected as $PUBLIC_IP4"
+	local IP_MSG="	Your public IP(s) are detected as"
+	if [ -n "$PUBLIC_IP4" ]; then IP_MSG="$IP_MSG $PUBLIC_IP4"; fi
 	if [ -n "$PUBLIC_IP6" ]; then
 		IP_MSG="$IP_MSG
 		and $PUBLIC_IP6"
@@ -204,7 +205,9 @@ constrain_sshd_to_host()
 
 	tell_status "Limiting SSHd to host IP address"
 
-	sysrc sshd_flags+=" \-o ListenAddress=$PUBLIC_IP4"
+	if [ -n "$PUBLIC_IP4" ]; then
+		sysrc sshd_flags+=" \-o ListenAddress=$PUBLIC_IP4"
+	fi
 	if [ -n "$PUBLIC_IP6" ]; then
 		sysrc sshd_flags+=" \-o ListenAddress=$PUBLIC_IP6"
 	fi
@@ -236,6 +239,17 @@ EO_SSHD_REORDER
 	chmod 755 "$_file"
 }
 
+lookup_geo_defaults()
+{
+	_cc=$(fetch -q -o - https://ipinfo.io/country || echo)
+	_state=$(fetch -q -o - https://ipinfo.io/region || echo)
+	_city=$(fetch -q -o - https://ipinfo.io/city || echo)
+
+	if [ -z "$_cc$_state$_city" ]; then
+		tell_status "no answer from ipinfo.io, locality unset"
+	fi
+}
+
 update_openssl_defaults()
 {
 	if grep -q commonName_default /etc/ssl/openssl.cnf; then
@@ -243,9 +257,7 @@ update_openssl_defaults()
 	fi
 
 	tell_status "updating openssl.cnf defaults"
-	local _cc;    _cc=$(fetch -q -4 -o - https://ipinfo.io/country)
-	local _state; _state=$(fetch -q -4 -o - https://ipinfo.io/region)
-	local _city;  _city=$(fetch -q -4 -o - https://ipinfo.io/city)
+	lookup_geo_defaults
 	sed_inplace \
 		-e '/^commonName_max.*/ a\
 commonName_default = '"$TOASTER_HOSTNAME" \
@@ -295,7 +307,14 @@ configure_tls_certs()
 		openssl req -x509 -nodes -days 2190 -newkey rsa:2048 \
 			-keyout "$KEYFILE" -out "$CRTFILE"
 	else
-		local SUBJ="/C=$_cc/ST=$_state/L=$_city/O=Mail Toaster/CN=$TOASTER_HOSTNAME"
+		lookup_geo_defaults
+
+		local SUBJ=""
+		[ -z "$_cc" ]    || SUBJ="$SUBJ/C=$_cc"
+		[ -z "$_state" ] || SUBJ="$SUBJ/ST=$_state"
+		[ -z "$_city" ]  || SUBJ="$SUBJ/L=$_city"
+		SUBJ="$SUBJ/O=Mail Toaster/CN=$TOASTER_HOSTNAME"
+
 		echo "subject: $SUBJ"
 		openssl req -x509 -nodes -days 2190 -newkey rsa:2048 \
 			-keyout "$KEYFILE" -out "$CRTFILE" -subj "$SUBJ"
@@ -340,7 +359,7 @@ check_global_listeners()
 {
 	tell_status "checking for host listeners on all IPs"
 
-	if sockstat -L -4 | grep -E '\*:[0-9]' | grep -v 123; then
+	if sockstat -L -4 -6 | grep -E '\*:[0-9]' | grep -v 123; then
 		echo "oops!, you should not having anything listening on all your IP addresses!"
 		if [ -t 0 ]; then exit 2; fi
 
@@ -376,13 +395,35 @@ configure_ipv6()
 
 add_jail_nat()
 {
-	get_public_ip4
+	configure_pf_conf
 
+	kldstat -q -m pf || kldload pf
+
+	grep -q ^pf_enable /etc/rc.conf || sysrc pf_enable=YES
+	if ! /sbin/pfctl -s Running; then
+		/etc/rc.d/pf start
+	else
+		/sbin/pfctl -f /etc/pf.conf
+	fi
+
+	pf_bruteforce_expire
+}
+
+configure_pf_conf()
+{
 	if [ -z "$PUBLIC_NIC" ]; then fatal_err "PUBLIC_NIC unset!"; fi
-	if [ -z "$PUBLIC_IP4" ]; then fatal_err "PUBLIC_IP4 unset!"; fi
+
+	local _members=""
+
+	if has_public_ip4; then _members="\$ext_ip4"; fi
+	if has_public_ip6; then _members="${_members:+$_members, }\$ext_ip6"; fi
+
+	if [ -z "$_members" ]; then
+		fatal_err "no public IPv4 or IPv6 found on $PUBLIC_NIC!"
+	fi
 
 	tell_status "setting up the PF firewall and NAT for jails"
-	store_config "/etc/pf.conf" <<EO_PF_RULES
+	store_config "/etc/pf.conf" "update" <<EO_PF_RULES
 ## Macros
 
 ext_if="$PUBLIC_NIC"
@@ -392,7 +433,7 @@ ext_ip6="$PUBLIC_IP6"
 jail_ip4="$JAIL_NET_PREFIX.0${JAIL_NET_MASK}"
 jail_ip6="$JAIL_NET6:0/112"
 
-table <ext_ip>  { \$ext_ip4, \$ext_ip6 } persist
+table <ext_ip>  { $_members } persist
 table <ext_ip4> { \$ext_ip4 } persist
 table <ext_ip6> { \$ext_ip6 } persist
 
@@ -441,23 +482,6 @@ pass in quick on \$ext_if proto tcp to port ssh \
         (max-src-conn 10, max-src-conn-rate 8/15, overload <bruteforce> flush global)
 
 EO_PF_RULES
-
-	if [ -z "$PUBLIC_IP6" ]; then
-		sed_inplace \
-			-e '/^table <ext_ip>/ s/, \$ext_ip6//' \
-			/etc/pf.conf
-	fi
-
-	kldstat -q -m pf || kldload pf
-
-	grep -q ^pf_enable /etc/rc.conf || sysrc pf_enable=YES
-	if ! /sbin/pfctl -s Running; then
-		/etc/rc.d/pf start
-	else
-		/sbin/pfctl -f /etc/pf.conf
-	fi
-
-	pf_bruteforce_expire
 }
 
 install_jailmanage()

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -425,12 +425,16 @@ configure_pf_conf()
 	if [ -z "$_nic4" ]; then _nic4="$_nic6"; fi
 	if [ -z "$_nic6" ]; then _nic6="$_nic4"; fi
 
+	local _ifs="$_nic4"
+	if [ "$_nic6" != "$_nic4" ]; then _ifs="$_ifs $_nic6"; fi
+
 	tell_status "setting up the PF firewall and NAT for jails"
 	store_config "/etc/pf.conf" "update" <<EO_PF_RULES
 ## Macros
 
 ext_if="$_nic4"
 ext_if6="$_nic6"
+ext_ifs="{ $_ifs }"
 ext_ip4="$PUBLIC_IP4"
 ext_ip6="$PUBLIC_IP6"
 
@@ -443,6 +447,7 @@ table <ext_ip6> { \$ext_ip6 } persist
 
 table <bruteforce> persist
 table <sshguard> persist
+table <ssh_exempt> { \$jail_ip4, \$jail_ip6, 127.0.0.0/8, ::1 } persist
 
 ## NAT / Network Address Translation
 
@@ -479,9 +484,9 @@ pass in inet6 proto udp from port 547 to port 546
 pass in inet6 proto ipv6-icmp icmp6-type { 134, 135, 136 }
 
 # NTP
-pass out quick on \$ext_if proto udp to any port ntp keep state
+pass out quick on \$ext_ifs proto udp to any port ntp keep state
 
-pass in quick on \$ext_if proto tcp to port ssh \
+pass in quick proto tcp from ! <ssh_exempt> to port ssh \
         flags S/SA synproxy state \
         (max-src-conn 10, max-src-conn-rate 8/15, overload <bruteforce> flush global)
 

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -413,20 +413,24 @@ configure_pf_conf()
 {
 	if [ -z "$PUBLIC_NIC" ]; then fatal_err "PUBLIC_NIC unset!"; fi
 
-	local _members=""
+	local _members="" _nic4="" _nic6=""
 
-	if has_public_ip4; then _members="\$ext_ip4"; fi
-	if has_public_ip6; then _members="${_members:+$_members, }\$ext_ip6"; fi
+	if has_public_ip4; then _members="\$ext_ip4"; _nic4="$PUBLIC_NIC"; fi
+	if has_public_ip6; then _members="${_members:+$_members, }\$ext_ip6"; _nic6="$PUBLIC_NIC"; fi
 
 	if [ -z "$_members" ]; then
 		fatal_err "no public IPv4 or IPv6 found on $PUBLIC_NIC!"
 	fi
 
+	if [ -z "$_nic4" ]; then _nic4="$_nic6"; fi
+	if [ -z "$_nic6" ]; then _nic6="$_nic4"; fi
+
 	tell_status "setting up the PF firewall and NAT for jails"
 	store_config "/etc/pf.conf" "update" <<EO_PF_RULES
 ## Macros
 
-ext_if="$PUBLIC_NIC"
+ext_if="$_nic4"
+ext_if6="$_nic6"
 ext_ip4="$PUBLIC_IP4"
 ext_ip6="$PUBLIC_IP6"
 
@@ -447,8 +451,8 @@ binat-anchor "binat/*"
 nat-anchor "nat/*"
 
 # default route to the internet for jails
-nat on \$ext_if inet  from \$jail_ip4 to any -> (\$ext_if)
-nat on \$ext_if inet6 from \$jail_ip6 to any -> <ext_ip6>
+nat on \$ext_if  inet  from \$jail_ip4 to any -> (\$ext_if)
+nat on \$ext_if6 inet6 from \$jail_ip6 to any -> <ext_ip6>
 
 ## Redirection
 

--- a/provision/nginx.sh
+++ b/provision/nginx.sh
@@ -6,6 +6,8 @@ export JAIL_START_EXTRA=""
 export JAIL_CONF_EXTRA=""
 export JAIL_FSTAB=""
 
+mt6-include nginx
+
 install_nginx()
 {
 	stage_pkg_install nginx || exit
@@ -16,14 +18,17 @@ configure_nginx()
 	local _nginx_conf="$STAGE_MNT/usr/local/etc/nginx/conf.d"
 	mkdir -p "$_nginx_conf" || exit
 
+	local _listen; _listen=$(nginx_listen 80 | sed -e 's/^[[:space:]]*/+        /')
+
 	patch -d "$STAGE_MNT/usr/local/etc/nginx" <<EO_NGINX_CONF
 --- nginx.conf-dist     2016-01-16 16:20:58.874842000 -0800
 +++ nginx.conf  2016-01-16 16:22:36.860852732 -0800
-@@ -34,7 +34,10 @@
+@@ -34,7 +34,11 @@
  
      server {
-         listen       80;
+-        listen       80;
 -        server_name  localhost;
+$_listen
 +        server_name  nginx;
 +
 +        set_real_ip_from $(get_jail_ip4 haproxy);

--- a/provision/vpopmail.sh
+++ b/provision/vpopmail.sh
@@ -68,15 +68,17 @@ install_nginx_vpopmail()
 
 	configure_nginx vpopmail
 
-	_NGINX_SERVER='
+	_NGINX_SERVER="
 	server {
 		server_name vpopmail;
 
 		root  /data/htdocs;
 		index index.html;
 
-		listen 80;
-
+$(nginx_listen 80)
+"
+	# single quoted, the $variables below are nginx's, not the shell's
+	_NGINX_SERVER="$_NGINX_SERVER"'
 		location /qmailadmin/ {
 			alias /data/htdocs/qmailadmin/;
 		}

--- a/provision/webmail.sh
+++ b/provision/webmail.sh
@@ -52,16 +52,9 @@ configure_nginx_server_port_443()
 {
 	if [ "$TOASTER_WEBMAIL_PROXY" != "nginx" ]; then return; fi
 
-	local _NGINX_SERVER='
+	local _NGINX_SERVER; _NGINX_SERVER="
 	server {
-		listen      443 ssl;'
-
-	if [ -n "$PUBLIC_IP6" ]; then
-		_NGINX_SERVER="$_NGINX_SERVER
-		listen [::]:443 ssl;"
-	fi
-
-	_NGINX_SERVER="$_NGINX_SERVER
+$(nginx_listen 443 ssl)
 
 		server_name $TOASTER_HOSTNAME;"
 
@@ -89,8 +82,6 @@ configure_nginx_server_port_443()
 
 configure_nginx_server()
 {
-	get_public_ip6
-
 	configure_nginx_server_port_80
 	configure_nginx_server_port_443
 

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -361,39 +361,55 @@ configure_pf()
 	local _pf_etc
 	_pf_etc="$(get_jail_host_etc wildduck)/pf.conf.d"
 
-	get_public_ip4
-	get_public_ip6
+	local _rdr4="" _rdr6="" _nat4="" _nat6=""
 
-	store_config "$_pf_etc/rdr.conf" <<EO_PF_RDR
-int_ip4 = "$(get_jail_ip4 wildduck)"
-int_ip6 = "$(get_jail_ip6 wildduck)"
-
-ext_ip4 = "$PUBLIC_IP4"
-ext_ip6 = "$PUBLIC_IP6"
+	if has_public_ip4; then
+		_rdr4="ext_ip4 = \"$PUBLIC_IP4\"
 
 # mail traffic to wildduck
 rdr inet  proto tcp from any to \$ext_ip4 port { 25 465 587 993 995 } -> \$int_ip4
+
+# send HTTP traffic to haproxy, or uncomment to send it to webmail
+rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip haproxy)
+#rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip webmail)"
+		_nat4="ext_ip4 = \"$PUBLIC_IP4\"
+nat on \$ext_if from \$int_ip4 to any -> \$ext_ip4"
+	fi
+
+	if jail_has_ip6; then
+		_rdr6="ext_ip6 = \"$PUBLIC_IP6\"
+
+# mail traffic to wildduck
 rdr inet6 proto tcp from any to \$ext_ip6 port { 25 465 587 993 995 } -> \$int_ip6
 
-# send HTTP traffic to haproxy
-rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip4 haproxy)
+# send HTTP traffic to haproxy, or uncomment to send it to webmail
 rdr inet6 proto tcp from any to \$ext_ip6 port { 80 443 } -> $(get_jail_ip6 haproxy)
+#rdr inet6 proto tcp from any to \$ext_ip6 port { 80 443 } -> $(get_jail_ip6 webmail)"
+		_nat6="ext_ip6 = \"$PUBLIC_IP6\"
+nat on \$ext_if from \$int_ip6 to any -> \$ext_ip6"
+	fi
 
-# or send HTTP traffic to webmail
-#rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip4 webmail)
-#rdr inet6 proto tcp from any to \$ext_ip6 port { 80 443 } -> $(get_jail_ip6 webmail)
+	local _int_ip6=""
+	if jail_has_ip6; then _int_ip6="int_ip6 = \"$(get_jail_ip6 wildduck)\""; fi
+
+	store_config "$_pf_etc/rdr.conf" "update" <<EO_PF_RDR
+int_ip4 = "$(get_jail_ip wildduck)"
+$_int_ip6
+
+$_rdr4
+
+$_rdr6
 EO_PF_RDR
 
-	store_config "$_pf_etc/nat.conf" <<EO_PF_NAT
-int_ip4 = "$(get_jail_ip4 wildduck)"
-int_ip6 = "$(get_jail_ip6 wildduck)"
+	store_config "$_pf_etc/nat.conf" "update" <<EO_PF_NAT
+int_ip4 = "$(get_jail_ip wildduck)"
+$_int_ip6
 
 ext_if = "$PUBLIC_NIC"
-ext_ip4 = "$PUBLIC_IP4"
-ext_ip6 = "$PUBLIC_IP6"
 
-nat on \$ext_if from \$int_ip4 to any -> \$ext_ip4
-nat on \$ext_if from \$int_ip6 to any -> \$ext_ip6
+$_nat4
+
+$_nat6
 EO_PF_NAT
 
 	configure_pf_jail_table wildduck
@@ -466,14 +482,17 @@ authenticated=true
 private_ip=true
 EO_RSPAMD
 
-	get_public_ip4
-
 	sed_inplace \
-		-e '/^;public_ip/ s/^;//' \
-		-e "/^public_ip/ s/N.N.N.N/$PUBLIC_IP4/" \
 		-e '/^;nodes/ s/^;//' \
 		-e '/^nodes/ s/cpus/1/' \
 		"$_cfg/smtp.ini"
+
+	if has_public_ip4; then
+		sed_inplace \
+			-e '/^;public_ip/ s/^;//' \
+			-e "/^public_ip/ s/N.N.N.N/$PUBLIC_IP4/" \
+			"$_cfg/smtp.ini"
+	fi
 
 	sed_inplace \
 		-e '/^;spamd_socket/ s/^;//' \

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -361,9 +361,10 @@ configure_pf()
 	local _pf_etc
 	_pf_etc="$(get_jail_host_etc wildduck)/pf.conf.d"
 
-	local _rdr4="" _rdr6="" _nat4="" _nat6=""
+	local _rdr4="" _rdr6="" _nat4="" _nat6="" _nic4="" _nic6=""
 
 	if has_public_ip4; then
+		_nic4="$PUBLIC_NIC"
 		_rdr4="ext_ip4 = \"$PUBLIC_IP4\"
 
 # mail traffic to wildduck
@@ -377,6 +378,7 @@ nat on \$ext_if from \$int_ip4 to any -> \$ext_ip4"
 	fi
 
 	if jail_has_ip6; then
+		_nic6="$PUBLIC_NIC"
 		_rdr6="ext_ip6 = \"$PUBLIC_IP6\"
 
 # mail traffic to wildduck
@@ -386,8 +388,11 @@ rdr inet6 proto tcp from any to \$ext_ip6 port { 25 465 587 993 995 } -> \$int_i
 rdr inet6 proto tcp from any to \$ext_ip6 port { 80 443 } -> $(get_jail_ip6 haproxy)
 #rdr inet6 proto tcp from any to \$ext_ip6 port { 80 443 } -> $(get_jail_ip6 webmail)"
 		_nat6="ext_ip6 = \"$PUBLIC_IP6\"
-nat on \$ext_if from \$int_ip6 to any -> \$ext_ip6"
+nat on \$ext_if6 from \$int_ip6 to any -> \$ext_ip6"
 	fi
+
+	if [ -z "$_nic4" ]; then _nic4="$_nic6"; fi
+	if [ -z "$_nic6" ]; then _nic6="$_nic4"; fi
 
 	local _int_ip6=""
 	if jail_has_ip6; then _int_ip6="int_ip6 = \"$(get_jail_ip6 wildduck)\""; fi
@@ -405,7 +410,8 @@ EO_PF_RDR
 int_ip4 = "$(get_jail_ip4 wildduck)"
 $_int_ip6
 
-ext_if = "$PUBLIC_NIC"
+ext_if  = "$_nic4"
+ext_if6 = "$_nic6"
 
 $_nat4
 

--- a/provision/wildduck.sh
+++ b/provision/wildduck.sh
@@ -370,8 +370,8 @@ configure_pf()
 rdr inet  proto tcp from any to \$ext_ip4 port { 25 465 587 993 995 } -> \$int_ip4
 
 # send HTTP traffic to haproxy, or uncomment to send it to webmail
-rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip haproxy)
-#rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip webmail)"
+rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip4 haproxy)
+#rdr inet  proto tcp from any to \$ext_ip4 port { 80 443 } -> $(get_jail_ip4 webmail)"
 		_nat4="ext_ip4 = \"$PUBLIC_IP4\"
 nat on \$ext_if from \$int_ip4 to any -> \$ext_ip4"
 	fi
@@ -393,7 +393,7 @@ nat on \$ext_if from \$int_ip6 to any -> \$ext_ip6"
 	if jail_has_ip6; then _int_ip6="int_ip6 = \"$(get_jail_ip6 wildduck)\""; fi
 
 	store_config "$_pf_etc/rdr.conf" "update" <<EO_PF_RDR
-int_ip4 = "$(get_jail_ip wildduck)"
+int_ip4 = "$(get_jail_ip4 wildduck)"
 $_int_ip6
 
 $_rdr4
@@ -402,7 +402,7 @@ $_rdr6
 EO_PF_RDR
 
 	store_config "$_pf_etc/nat.conf" "update" <<EO_PF_NAT
-int_ip4 = "$(get_jail_ip wildduck)"
+int_ip4 = "$(get_jail_ip4 wildduck)"
 $_int_ip6
 
 ext_if = "$PUBLIC_NIC"

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -649,4 +649,121 @@ mta_rdr_setup() {
   [ ! -f "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf" ]
 }
 
+@test "configure_mta_pf_rdr - writes no file when jail owns no ports" {
+  mta_rdr_setup
+  export TOASTER_MTA="postfix" TOASTER_MSA="postfix"
+  run configure_mta_pf_rdr haraka
+  assert_success
+  [ ! -f "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf" ]
+}
 
+# --- the address families a jail has, at the moment it is [re]built ---
+
+@test "configure_mta_pf_rdr - a jail with no IPv6 gets no inet6 redirect" {
+  mta_rdr_setup
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  export TOASTER_MTA="haraka" TOASTER_MSA="haraka"
+
+  configure_mta_pf_rdr haraka
+
+  run cat "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf"
+  assert_output --partial "rdr inet  proto tcp"
+  # redirecting to an address the jail does not have sends mail nowhere
+  refute_output --partial "rdr inet6"
+}
+
+@test "configure_pf_jail_table - holds every address the jail answers on" {
+  mta_rdr_setup
+
+  configure_pf_jail_table haraka
+
+  run cat "$(get_jail_host_etc haraka)/pf.conf.d/haraka.table"
+  assert_line "203.0.113.7"
+  assert_line "2001:db8::1"
+  assert_line "172.16.15.9"
+  assert_line "fd7a::9"
+}
+
+# pfctl -T replace rejects the file over a blank line, taking the jail's
+# redirects down with it
+@test "configure_pf_jail_table - a missing address family leaves no blank line" {
+  mta_rdr_setup
+  get_public_ip4() { export PUBLIC_IP4=""; }
+
+  configure_pf_jail_table haraka
+
+  run cat "$(get_jail_host_etc haraka)/pf.conf.d/haraka.table"
+  refute_line ""
+  refute_output --partial "203.0.113.7"
+  assert_line "172.16.15.9"
+}
+
+@test "configure_pf_jail_table - a jail with no IPv6 lists no IPv6 address" {
+  mta_rdr_setup
+  get_public_ip6() { export PUBLIC_IP6=""; }
+
+  configure_pf_jail_table haraka
+
+  run cat "$(get_jail_host_etc haraka)/pf.conf.d/haraka.table"
+  refute_line ""
+  refute_output --partial "fd7a::9"
+  assert_line "172.16.15.9"
+}
+
+# --- assure_ip6_addr_is_declared: /etc/jail.conf, the pre jail.conf.d layout ---
+
+ip6_declared_setup() {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597" JAIL_NET_INTERFACE="lo1"
+  dec_to_hex() { echo "4"; }
+  tell_status() { echo "$1"; }
+  sed_inplace() { sed -i.bak "$@"; }
+
+  JAIL_CONF="$BATS_TEST_TMPDIR/jail.conf"
+  printf 'mysql\t{\n\t\tip4.addr = lo1|172.16.15.4;\n%s\n\t}\n' "$1" > "$JAIL_CONF"
+}
+
+@test "assure_ip6_addr_is_declared - an active declaration is left alone" {
+  ip6_declared_setup "		ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  run assure_ip6_addr_is_declared mysql "$JAIL_CONF"
+  assert_output --partial "already declared"
+
+  run cat "$JAIL_CONF"
+  refute_output --partial "#ip6.addr"
+}
+
+# the guard used to match the comment as a declaration, so a host that gained
+# IPv6 kept a jail that could never bind it
+@test "assure_ip6_addr_is_declared - a commented entry is enabled once the host has IPv6" {
+  ip6_declared_setup "		#ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  assure_ip6_addr_is_declared mysql "$JAIL_CONF"
+
+  run cat "$JAIL_CONF"
+  assert_line --regexp '^[[:space:]]+ip6\.addr = lo1\|fd7a:e5cd:1fc1:c597:4;$'
+  refute_output --partial "#ip6.addr"
+}
+
+@test "assure_ip6_addr_is_declared - a commented entry stays while the host has no IPv6" {
+  ip6_declared_setup "		#ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+  get_public_ip6() { export PUBLIC_IP6=""; }
+
+  assure_ip6_addr_is_declared mysql "$JAIL_CONF"
+
+  run cat "$JAIL_CONF"
+  assert_line --regexp '^[[:space:]]+#ip6\.addr'
+  # one comment, not one per run
+  assert_equal "$(grep -c 'ip6.addr' "$JAIL_CONF")" "1"
+}
+
+@test "assure_ip6_addr_is_declared - a jail with no entry gains one" {
+  ip6_declared_setup "		devfs_ruleset = 4;"
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  assure_ip6_addr_is_declared mysql "$JAIL_CONF"
+
+  run cat "$JAIL_CONF"
+  assert_line --regexp '^[[:space:]]+ip6\.addr = lo1\|fd7a:e5cd:1fc1:c597:4;$'
+}

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -94,6 +94,23 @@ setup() {
   assert_output --partial "ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
 }
 
+@test "add_jail_conf - ip6.addr is commented out without a public IPv6" {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() {
+    if [ "$1" -eq 4 ]; then echo "4"; fi
+  }
+
+  tee() { cat -; }
+  grep() { return 1; }
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  store_config() { cat -; }
+
+  run add_jail_conf mysql
+  assert_success
+  assert_output --partial "ip4.addr = lo1|172.16.15.4;"
+  assert_output --partial "#ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+}
+
 @test "add_jail_conf_d" {
   export JAIL_NET6="fd7a:e5cd:1fc1:c597"
   dec_to_hex() { if [ "$1" -eq 4 ]; then echo "4"; fi; }
@@ -105,6 +122,36 @@ setup() {
   run add_jail_conf_d mysql
   assert_success
   assert_output --partial "ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+  refute_output --partial "#ip6.addr"
+}
+
+@test "add_jail_conf_d - ip6.addr is commented out without a public IPv6" {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() { if [ "$1" -eq 4 ]; then echo "4"; fi; }
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  store_config() { cat -; }
+
+  run add_jail_conf_d mysql
+  assert_success
+  assert_output --partial "#ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+}
+
+@test "jail_conf_ip6 - declared with a public IPv6" {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() { if [ "$1" -eq 4 ]; then echo "4"; fi; }
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  run jail_conf_ip6 mysql
+  assert_output "ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
+}
+
+@test "jail_conf_ip6 - commented out without a public IPv6" {
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597"
+  dec_to_hex() { if [ "$1" -eq 4 ]; then echo "4"; fi; }
+  get_public_ip6() { export PUBLIC_IP6=""; }
+
+  run jail_conf_ip6 mysql
+  assert_output "#ip6.addr = lo1|fd7a:e5cd:1fc1:c597:4;"
 }
 
 # --- base declares no mounts and runs no pf rules ---

--- a/test/include/nginx.bats
+++ b/test/include/nginx.bats
@@ -8,6 +8,9 @@ setup() {
 mt6-include() { :; }
 tell_status() { :; }
 
+get_public_ip4() { :; }
+get_public_ip6() { :; }
+
 # faithful copy of include/jail.sh get_jail_data
 get_jail_data() { echo "$ZFS_DATA_MNT/$1"; }
 
@@ -71,6 +74,62 @@ store_config() {
   assert_failure
 }
 
+# nginx_listen() - both families, absent one commented out
+
+@test "nginx_listen - both families present" {
+  export PUBLIC_IP4="192.0.2.1"
+  export PUBLIC_IP6="2001:db8::1"
+
+  run nginx_listen 80
+  assert_line --index 0 --regexp '^[[:space:]]+listen[[:space:]]+80;$'
+  assert_line --index 1 --regexp '^[[:space:]]+listen  \[::\]:80;$'
+}
+
+@test "nginx_listen - IPv6 absent is commented out" {
+  export PUBLIC_IP4="192.0.2.1"
+  export PUBLIC_IP6=""
+
+  run nginx_listen 80
+  assert_line --index 0 --regexp '^[[:space:]]+listen[[:space:]]+80;$'
+  assert_line --index 1 --regexp '^[[:space:]]+#listen  \[::\]:80;$'
+}
+
+@test "nginx_listen - IPv4 absent is commented out" {
+  export PUBLIC_IP4=""
+  export PUBLIC_IP6="2001:db8::1"
+
+  run nginx_listen 80
+  assert_line --index 0 --regexp '^[[:space:]]+#listen[[:space:]]+80;$'
+  assert_line --index 1 --regexp '^[[:space:]]+listen  \[::\]:80;$'
+}
+
+@test "nginx_listen - defaults to port 80" {
+  export PUBLIC_IP4="192.0.2.1"
+  export PUBLIC_IP6="2001:db8::1"
+
+  run nginx_listen
+  assert_output --partial "listen       80;"
+  assert_output --partial "listen  [::]:80;"
+}
+
+@test "nginx_listen - appends options to both families" {
+  export PUBLIC_IP4="192.0.2.1"
+  export PUBLIC_IP6=""
+
+  run nginx_listen 443 ssl
+  assert_output --partial "listen       443 ssl;"
+  assert_output --partial "#listen  [::]:443 ssl;"
+}
+
+@test "nginx_listen - both families absent are both commented out" {
+  export PUBLIC_IP4=""
+  export PUBLIC_IP6=""
+
+  run nginx_listen 80
+  assert_line --index 0 --regexp '^[[:space:]]+#listen[[:space:]]+80;$'
+  assert_line --index 1 --regexp '^[[:space:]]+#listen  \[::\]:80;$'
+}
+
 # configure_nginx_server_d - creates nginx server block config
 
 @test "configure_nginx_server_d - works when PUBLIC_IP6 is unset" {
@@ -115,6 +174,7 @@ store_config() {
 @test "configure_nginx_server_d - contains listen 80" {
   local tmpdir; tmpdir=$(mktemp -d)
   export ZFS_DATA_MNT="$tmpdir"
+  export PUBLIC_IP4="192.0.2.1"
   export PUBLIC_IP6=""
   export _NGINX_SERVER="server_name test.example.com;"
 
@@ -127,16 +187,34 @@ store_config() {
   rm -rf "$tmpdir"
 }
 
-@test "configure_nginx_server_d - adds IPv6 listen when PUBLIC_IP6 set" {
+@test "configure_nginx_server_d - comments out IPv6 listen when PUBLIC_IP6 empty" {
   local tmpdir; tmpdir=$(mktemp -d)
   export ZFS_DATA_MNT="$tmpdir"
+  export PUBLIC_IP4="192.0.2.1"
+  export PUBLIC_IP6=""
+  export _NGINX_SERVER="server_name test.example.com;"
+
+  configure_nginx_server_d myjail
+
+  run grep "\[::\]:80" "$tmpdir/myjail/etc/nginx/server.d/myjail.conf"
+  assert_success
+  assert_output --partial "#listen"
+
+  rm -rf "$tmpdir"
+}
+
+@test "configure_nginx_server_d - enables IPv6 listen when PUBLIC_IP6 set" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  export ZFS_DATA_MNT="$tmpdir"
+  export PUBLIC_IP4="192.0.2.1"
   export PUBLIC_IP6="2001:db8::1"
   export _NGINX_SERVER="server_name test.example.com;"
 
   configure_nginx_server_d myjail
 
-  run grep "\[::\]" "$tmpdir/myjail/etc/nginx/server.d/myjail.conf"
+  run grep "\[::\]:80" "$tmpdir/myjail/etc/nginx/server.d/myjail.conf"
   assert_success
+  refute_output --partial "#"
 
   rm -rf "$tmpdir"
 }

--- a/test/include/nginx.bats
+++ b/test/include/nginx.bats
@@ -3,6 +3,9 @@
 setup() {
   load '../test_helper/load'
   load '../../include/nginx.sh'
+  # the real store_config: "update" is what carries a changed template onto a
+  # rebuild, and a copy of it here would not prove that
+  load '../../include/util.sh'
 }
 
 mt6-include() { :; }
@@ -11,21 +14,11 @@ tell_status() { :; }
 get_public_ip4() { :; }
 get_public_ip6() { :; }
 
+# faithful copy of include/jail.sh jail_has_ip6
+jail_has_ip6() { get_public_ip6; [ -n "${PUBLIC_IP6:-}" ]; }
+
 # faithful copy of include/jail.sh get_jail_data
 get_jail_data() { echo "$ZFS_DATA_MNT/$1"; }
-
-# faithful copy of include/util.sh store_config: always writes <file>.mt6,
-# installs the live file only when absent (or on overwrite/append)
-store_config() {
-  local _operation=${2:-""}
-  [ -d "$(dirname "$1")" ] || mkdir -p "$(dirname "$1")"
-  cat - > "$1.mt6"
-  if [ ! -f "$1" ] || [ "$_operation" = "overwrite" ]; then
-    cp "$1.mt6" "$1"
-  elif [ "$_operation" = "append" ]; then
-    cat "$1.mt6" >> "$1"
-  fi
-}
 
 # contains() - pure string membership test
 
@@ -74,10 +67,9 @@ store_config() {
   assert_failure
 }
 
-# nginx_listen() - both families, absent one commented out
+# nginx_listen() - both families, IPv6 commented out when the jail has none
 
-@test "nginx_listen - both families present" {
-  export PUBLIC_IP4="192.0.2.1"
+@test "nginx_listen - a jail with IPv6 listens on both families" {
   export PUBLIC_IP6="2001:db8::1"
 
   run nginx_listen 80
@@ -85,8 +77,7 @@ store_config() {
   assert_line --index 1 --regexp '^[[:space:]]+listen  \[::\]:80;$'
 }
 
-@test "nginx_listen - IPv6 absent is commented out" {
-  export PUBLIC_IP4="192.0.2.1"
+@test "nginx_listen - a jail without IPv6 has that listen commented out" {
   export PUBLIC_IP6=""
 
   run nginx_listen 80
@@ -94,17 +85,21 @@ store_config() {
   assert_line --index 1 --regexp '^[[:space:]]+#listen  \[::\]:80;$'
 }
 
-@test "nginx_listen - IPv4 absent is commented out" {
-  export PUBLIC_IP4=""
-  export PUBLIC_IP6="2001:db8::1"
-
+# Every jail has a private IPv4 address whatever the host has. Commenting this
+# listen out left nginx bound to [::] only, where the haproxy backends and the
+# bsd_cache DNS records could not reach it.
+@test "nginx_listen - IPv4 listens with or without a public IPv4" {
+  export PUBLIC_IP4="" PUBLIC_IP6="2001:db8::1"
   run nginx_listen 80
-  assert_line --index 0 --regexp '^[[:space:]]+#listen[[:space:]]+80;$'
-  assert_line --index 1 --regexp '^[[:space:]]+listen  \[::\]:80;$'
+  assert_line --index 0 --regexp '^[[:space:]]+listen[[:space:]]+80;$'
+
+  export PUBLIC_IP4="" PUBLIC_IP6=""
+  run nginx_listen 80
+  assert_line --index 0 --regexp '^[[:space:]]+listen[[:space:]]+80;$'
+  assert_line --index 1 --regexp '^[[:space:]]+#listen  \[::\]:80;$'
 }
 
 @test "nginx_listen - defaults to port 80" {
-  export PUBLIC_IP4="192.0.2.1"
   export PUBLIC_IP6="2001:db8::1"
 
   run nginx_listen
@@ -113,21 +108,11 @@ store_config() {
 }
 
 @test "nginx_listen - appends options to both families" {
-  export PUBLIC_IP4="192.0.2.1"
   export PUBLIC_IP6=""
 
   run nginx_listen 443 ssl
   assert_output --partial "listen       443 ssl;"
   assert_output --partial "#listen  [::]:443 ssl;"
-}
-
-@test "nginx_listen - both families absent are both commented out" {
-  export PUBLIC_IP4=""
-  export PUBLIC_IP6=""
-
-  run nginx_listen 80
-  assert_line --index 0 --regexp '^[[:space:]]+#listen[[:space:]]+80;$'
-  assert_line --index 1 --regexp '^[[:space:]]+#listen  \[::\]:80;$'
 }
 
 # configure_nginx_server_d - creates nginx server block config
@@ -190,7 +175,6 @@ store_config() {
 @test "configure_nginx_server_d - comments out IPv6 listen when PUBLIC_IP6 empty" {
   local tmpdir; tmpdir=$(mktemp -d)
   export ZFS_DATA_MNT="$tmpdir"
-  export PUBLIC_IP4="192.0.2.1"
   export PUBLIC_IP6=""
   export _NGINX_SERVER="server_name test.example.com;"
 
@@ -206,7 +190,6 @@ store_config() {
 @test "configure_nginx_server_d - enables IPv6 listen when PUBLIC_IP6 set" {
   local tmpdir; tmpdir=$(mktemp -d)
   export ZFS_DATA_MNT="$tmpdir"
-  export PUBLIC_IP4="192.0.2.1"
   export PUBLIC_IP6="2001:db8::1"
   export _NGINX_SERVER="server_name test.example.com;"
 
@@ -270,6 +253,70 @@ store_config() {
 
   run grep "worker_processes" "$tmpdir/myjail/etc/nginx/nginx.conf.mt6"
   assert_success
+
+  rm -rf "$tmpdir"
+}
+
+# --- a rebuild follows the host it is rebuilt on ---
+
+# The listen directives are decided at build time. A toaster first built with
+# no IPv6 has them commented out, and nothing but a rebuild can enable them.
+@test "configure_nginx_server_d - a rebuild enables IPv6 once the host has it" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  export ZFS_DATA_MNT="$tmpdir"
+  export _NGINX_SERVER="server_name test.example.com;"
+  local _conf="$tmpdir/myjail/etc/nginx/server.d/myjail.conf"
+
+  export PUBLIC_IP6=""
+  configure_nginx_server_d myjail
+  run grep "\[::\]:80" "$_conf"
+  assert_output --partial "#listen"
+
+  export PUBLIC_IP6="2001:db8::1"
+  configure_nginx_server_d myjail
+  run grep "\[::\]:80" "$_conf"
+  assert_success
+  refute_output --partial "#listen"
+
+  rm -rf "$tmpdir"
+}
+
+@test "configure_nginx_server_d - a rebuild comments IPv6 out once the host loses it" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  export ZFS_DATA_MNT="$tmpdir"
+  export _NGINX_SERVER="server_name test.example.com;"
+  local _conf="$tmpdir/myjail/etc/nginx/server.d/myjail.conf"
+
+  export PUBLIC_IP6="2001:db8::1"
+  configure_nginx_server_d myjail
+
+  export PUBLIC_IP6=""
+  configure_nginx_server_d myjail
+  run grep "\[::\]:80" "$_conf"
+  assert_output --partial "#listen"
+
+  rm -rf "$tmpdir"
+}
+
+# an admin who edited the server block keeps it, IPv6 or not
+@test "configure_nginx_server_d - a rebuild leaves an edited config alone" {
+  local tmpdir; tmpdir=$(mktemp -d)
+  export ZFS_DATA_MNT="$tmpdir"
+  export _NGINX_SERVER="server_name test.example.com;"
+  local _conf="$tmpdir/myjail/etc/nginx/server.d/myjail.conf"
+
+  export PUBLIC_IP6=""
+  configure_nginx_server_d myjail
+  echo "# hand written" >> "$_conf"
+
+  export PUBLIC_IP6="2001:db8::1"
+  configure_nginx_server_d myjail
+
+  run cat "$_conf"
+  assert_output --partial "# hand written"
+  # the shadow still shows what a pristine config would have held
+  run grep "\[::\]:80" "$_conf.mt6"
+  refute_output --partial "#listen"
 
   rm -rf "$tmpdir"
 }

--- a/test/provision/dcc.bats
+++ b/test/provision/dcc.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Functional tests for provision/dcc.sh
+#
+# dcc speaks IPv6 only when the port was built with the IPV6 option and cdcc
+# was not told to turn it off, so both decisions have to follow the jail.
+
+setup_file() {
+  export DCC_FNS="$BATS_FILE_TMPDIR/dcc_fns_only.sh"
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/dcc.sh" > "$DCC_FNS"
+}
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  export MT6_TEST_ENV=1
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
+
+  # shellcheck source=/dev/null
+  . "$DCC_FNS"
+
+  # the stubs are no-ops; report the arguments so the tests can assert on them
+  stage_make_conf() { echo "make_conf: $*"; }
+  stage_exec()      { echo "exec: $*"; }
+  stage_sysrc()     { echo "sysrc: $*"; }
+}
+
+teardown() {
+  rm -rf "$STAGE_MNT"
+}
+
+host_has_ip6() {
+  if [ "$1" = "yes" ]; then
+    export PUBLIC_IP6="2001:db8::1"
+  else
+    export PUBLIC_IP6=""
+  fi
+  get_public_ip6() { :; }
+}
+
+@test "dcc - the port builds with IPV6 when the jail has an IPv6 address" {
+  host_has_ip6 yes
+
+  run install_dcc_port_options
+  assert_line --partial "mail_dcc-dccd_SET=DCCIFD IPV6"
+  refute_output --partial "_UNSET=DCCGREY DCCD DCCM PORTS_MILTER IPV6"
+}
+
+@test "dcc - the port drops IPV6 when the jail has no IPv6 address" {
+  host_has_ip6 no
+
+  run install_dcc_port_options
+  assert_line --partial "mail_dcc-dccd_UNSET=DCCGREY DCCD DCCM PORTS_MILTER IPV6"
+  assert_line --partial "mail_dcc-dccd_SET=DCCIFD"
+  refute_output --partial "_SET=DCCIFD IPV6"
+}
+
+# start_dcc used to read a PUBLIC_IP6 nothing in this script populates, so an
+# IPv6 only host reached cdcc with IPv6 switched off
+@test "dcc - cdcc keeps IPv6 on when the jail has an IPv6 address" {
+  host_has_ip6 yes
+
+  run start_dcc
+  assert_line "exec: cdcc info"
+}
+
+@test "dcc - cdcc turns IPv6 off when the jail has none" {
+  host_has_ip6 no
+
+  run start_dcc
+  assert_line "exec: cdcc IPv6=off info"
+}
+
+@test "dcc - start_dcc does not depend on its caller for PUBLIC_IP6" {
+  # the real has_public_ip6, which jail_has_ip6 defers to
+  # shellcheck source=/dev/null
+  . "$BATS_TEST_DIRNAME/../../include/network.sh"
+
+  # stub what it shells out to. These must come after the source above, or
+  # network.sh replaces get_public_facing_nic with the real one, which reads the
+  # host routing table and fails wherever netstat has no "default" line.
+  get_public_facing_nic() { export PUBLIC_NIC="em0"; }
+  ifconfig() { echo "	inet6 2001:db8::1 prefixlen 64"; }
+
+  unset PUBLIC_IP6
+  run start_dcc
+  assert_line "exec: cdcc info"
+}

--- a/test/provision/dhcp.bats
+++ b/test/provision/dhcp.bats
@@ -53,5 +53,5 @@ setup() {
   configure_dhcpd > /dev/null
 
   run cat "$RDR_CONF"
-  assert_output --partial "port { 67 68 } -> $(get_jail_ip dhcp)"
+  assert_output --partial "port { 67 68 } -> $(get_jail_ip4 dhcp)"
 }

--- a/test/provision/dhcp.bats
+++ b/test/provision/dhcp.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# Functional tests for provision/dhcp.sh
+
+setup_file() {
+  export DHCP_FNS="$BATS_FILE_TMPDIR/dhcp_fns_only.sh"
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/dhcp.sh" > "$DHCP_FNS"
+}
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  export MT6_TEST_ENV=1
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export JAIL_DEVFS_RULESET_BPF="5"
+  export MT6_ETC="$BATS_TEST_TMPDIR/etc"
+  export ZFS_DATA_MNT="$BATS_TEST_TMPDIR/data"
+
+  RDR_CONF="$MT6_ETC/dhcp/pf.conf.d/rdr.conf"
+
+  # shellcheck source=/dev/null
+  . "$DHCP_FNS"
+}
+
+# /etc/pf.conf declares <ext_ip>, <ext_ip4> and <ext_ip6>. A rule naming any
+# other table fails to load, taking the whole anchor with it.
+@test "dhcp - rdr.conf names a table pf.conf declares" {
+  configure_dhcpd > /dev/null
+
+  run cat "$RDR_CONF"
+  refute_output --partial "<ext_ips>"
+  assert_output --partial "<ext_ip4>"
+}
+
+@test "dhcp - rdr.conf redirects udp, the protocol DHCP speaks" {
+  configure_dhcpd > /dev/null
+
+  run cat "$RDR_CONF"
+  assert_output --partial "proto udp"
+  refute_output --partial "proto tcp"
+}
+
+# ports 67 and 68 are DHCPv4; DHCPv6 is a different service on 546 and 547
+@test "dhcp - rdr.conf has no IPv6 rule" {
+  configure_dhcpd > /dev/null
+
+  run cat "$RDR_CONF"
+  refute_output --partial "inet6"
+}
+
+@test "dhcp - rdr.conf sends the DHCP ports to the dhcp jail" {
+  configure_dhcpd > /dev/null
+
+  run cat "$RDR_CONF"
+  assert_output --partial "port { 67 68 } -> $(get_jail_ip dhcp)"
+}

--- a/test/provision/dns.bats
+++ b/test/provision/dns.bats
@@ -27,6 +27,7 @@ setup_file() {
   # Minimal unbound.conf.sample with all patterns tweak_unbound_conf targets.
   cat > "$STAGE_MNT/usr/local/etc/unbound/unbound.conf.sample" <<'EOF'
 server:
+	# prefer-ip6: no
 	# interface: 192.0.2.153
 	# interface: 192.0.2.154
 	# use-syslog: no
@@ -129,6 +130,29 @@ load_dns_fns() {
   export PUBLIC_IP6=""
   run get_mt6_data
   refute_output --partial "ip6:2001:db8"
+}
+
+@test "dns - get_mt6_data publishes AAAA records when the jails have IPv6" {
+  export PUBLIC_IP6="2001:db8::1"
+  run get_mt6_data
+  assert_output --partial "AAAA"
+  assert_output --partial "1.0.0.0.fd7a.ip6.arpa"
+}
+
+# an AAAA for an address no jail is listening on is a connection every client
+# tries first and waits out
+@test "dns - get_mt6_data publishes no AAAA records when the jails have none" {
+  export PUBLIC_IP6=""
+  run get_mt6_data
+  refute_output --partial "AAAA"
+  refute_output --partial "ip6.arpa"
+}
+
+@test "dns - get_mt6_data still publishes A records without IPv6" {
+  export PUBLIC_IP6=""
+  run get_mt6_data
+  assert_output --partial "local-data: \"dns		A "
+  assert_output --partial "in-addr.arpa PTR dns"
 }
 
 # --- tweak_unbound_conf outcomes (verified on the post-setup unbound.conf) ---
@@ -278,4 +302,51 @@ setup_access_conf() {
 
   run cat "$ACCESS_CONF"
   assert_output --partial "access-control: 198.51.100.4 allow"
+}
+
+@test "dns - access.conf includes the public IPv6 when one is known" {
+  rm -f "$ZFS_DATA_MNT/dns/access.conf"
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+  install_access_conf
+  run cat "$ZFS_DATA_MNT/dns/access.conf"
+  assert_output --partial "access-control: 2001:db8::1 allow"
+}
+
+# --- outgoing address family follows the host ---
+
+# tweak_unbound_conf rewrites the sample; give each case an untouched copy
+unbound_conf_from_sample() {
+  export UNBOUND_DIR="$STAGE_MNT/usr/local/etc/unbound"
+  cp "$UNBOUND_DIR/unbound.conf.sample" "$UNBOUND_DIR/unbound.conf"
+}
+
+@test "dns - a dual stack host leaves unbound preferring IPv4" {
+  unbound_conf_from_sample
+  get_public_ip4() { export PUBLIC_IP4="203.0.113.7"; }
+  tweak_unbound_conf
+
+  run grep '^[[:space:]]*prefer-ip6:' "$UNBOUND_DIR/unbound.conf"
+  assert_output --partial "prefer-ip6: no"
+}
+
+# an IPv6 only host has no NAT rule for the jail network, so every outgoing
+# IPv4 query waits out its timeout before unbound tries the IPv6 address
+@test "dns - an IPv6 only host prefers IPv6 for resolution" {
+  unbound_conf_from_sample
+  get_public_ip4() { export PUBLIC_IP4=""; }
+  tweak_unbound_conf
+
+  run grep '^[[:space:]]*prefer-ip6:' "$UNBOUND_DIR/unbound.conf"
+  assert_output --partial "prefer-ip6: yes"
+}
+
+# do-ip4 governs answering as well as asking, and every jail queries dns at its
+# private IPv4, so it must stay enabled on a host with no public IPv4
+@test "dns - an IPv6 only host still answers over IPv4" {
+  unbound_conf_from_sample
+  get_public_ip4() { export PUBLIC_IP4=""; }
+  tweak_unbound_conf
+
+  run grep -c '^[[:space:]]*do-ip4: no' "$UNBOUND_DIR/unbound.conf"
+  assert_output "0"
 }

--- a/test/provision/dns.bats
+++ b/test/provision/dns.bats
@@ -133,6 +133,7 @@ load_dns_fns() {
 }
 
 @test "dns - get_mt6_data publishes AAAA records when the jails have IPv6" {
+  load_dns_fns
   export PUBLIC_IP6="2001:db8::1"
   run get_mt6_data
   assert_output --partial "AAAA"
@@ -142,6 +143,7 @@ load_dns_fns() {
 # an AAAA for an address no jail is listening on is a connection every client
 # tries first and waits out
 @test "dns - get_mt6_data publishes no AAAA records when the jails have none" {
+  load_dns_fns
   export PUBLIC_IP6=""
   run get_mt6_data
   refute_output --partial "AAAA"
@@ -149,6 +151,7 @@ load_dns_fns() {
 }
 
 @test "dns - get_mt6_data still publishes A records without IPv6" {
+  load_dns_fns
   export PUBLIC_IP6=""
   run get_mt6_data
   assert_output --partial "local-data: \"dns		A "
@@ -305,10 +308,12 @@ setup_access_conf() {
 }
 
 @test "dns - access.conf includes the public IPv6 when one is known" {
-  rm -f "$ZFS_DATA_MNT/dns/access.conf"
+  setup_access_conf
   get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
   install_access_conf
-  run cat "$ZFS_DATA_MNT/dns/access.conf"
+
+  run cat "$ACCESS_CONF"
   assert_output --partial "access-control: 2001:db8::1 allow"
 }
 
@@ -316,8 +321,10 @@ setup_access_conf() {
 
 # tweak_unbound_conf rewrites the sample; give each case an untouched copy
 unbound_conf_from_sample() {
-  export UNBOUND_DIR="$STAGE_MNT/usr/local/etc/unbound"
-  cp "$UNBOUND_DIR/unbound.conf.sample" "$UNBOUND_DIR/unbound.conf"
+  load_dns_fns
+  export UNBOUND_DIR="$BATS_TEST_TMPDIR/unbound"
+  mkdir -p "$UNBOUND_DIR"
+  cp "$STAGE_MNT/usr/local/etc/unbound/unbound.conf.sample" "$UNBOUND_DIR/unbound.conf"
 }
 
 @test "dns - a dual stack host leaves unbound preferring IPv4" {

--- a/test/provision/dns.bats
+++ b/test/provision/dns.bats
@@ -357,3 +357,36 @@ unbound_conf_from_sample() {
   run grep -c '^[[:space:]]*do-ip4: no' "$UNBOUND_DIR/unbound.conf"
   assert_output "0"
 }
+
+@test "dns - a jail with IPv6 binds the wildcard" {
+  unbound_conf_from_sample
+  get_public_ip4() { export PUBLIC_IP4="203.0.113.7"; }
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+  tweak_unbound_conf
+
+  run grep 'interface: ::0' "$UNBOUND_DIR/unbound.conf"
+  assert_output --regexp '^[[:space:]]*interface: ::0'
+}
+
+@test "dns - a jail without IPv6 leaves that interface commented" {
+  unbound_conf_from_sample
+  get_public_ip4() { export PUBLIC_IP4="203.0.113.7"; }
+  get_public_ip6() { export PUBLIC_IP6=""; }
+  tweak_unbound_conf
+
+  run grep 'interface: ::0' "$UNBOUND_DIR/unbound.conf"
+  assert_output --regexp '^[[:space:]]*#'
+}
+
+@test "dns - the IPv4 interface binds whatever the jail has" {
+  local _case
+  for _case in "2001:db8::1" ""; do
+    unbound_conf_from_sample
+    get_public_ip4() { export PUBLIC_IP4="203.0.113.7"; }
+    eval "get_public_ip6() { export PUBLIC_IP6=\"$_case\"; }"
+    tweak_unbound_conf
+
+    run grep '^[[:space:]]*interface: 0.0.0.0' "$UNBOUND_DIR/unbound.conf"
+    assert_success
+  done
+}

--- a/test/provision/haproxy.bats
+++ b/test/provision/haproxy.bats
@@ -87,7 +87,8 @@ assert_haproxy_accepts() {
 # --- frontend binds ---
 #
 # 'bind :::80 v4v6' refuses to start on a host without IPv6, so each address
-# family gets its own bind and only the families the host has are emitted.
+# family gets its own bind and IPv6 is emitted only where the host has one.
+# IPv4 always binds: the jails reach haproxy at its private IPv4 address.
 
 @test "haproxy.conf - dual stack binds both families" {
   run grep '^	bind ' "$(conf both)"
@@ -104,11 +105,11 @@ assert_haproxy_accepts() {
   refute_line --partial '[::]'
 }
 
-@test "haproxy.conf - IPv6 only host binds no IPv4" {
+@test "haproxy.conf - IPv6 only host still binds IPv4" {
   run grep '^	bind ' "$(conf ip6only)"
   assert_line '	bind [::]:80 alpn http/1.1'
   assert_line '	bind [::]:443 alpn http/1.1 ssl crt /data/etc/tls.d'
-  refute_line --partial '0.0.0.0'
+  assert_line '	bind 0.0.0.0:80 alpn http/1.1'
 }
 
 @test "haproxy.conf - with no public address detected, falls back to IPv4" {
@@ -137,10 +138,12 @@ assert_haproxy_accepts() {
   refute_line --partial '['
 }
 
-@test "haproxy stage conf - IPv6 only host binds no IPv4" {
+# the jail's private IPv4 is there whatever the host has, and the DNS records
+# and haproxy backends for the other jails all name it
+@test "haproxy stage conf - IPv6 only host still binds the private IPv4" {
   run grep '^    bind ' "$(stage_conf ip6only)"
   assert_line '    bind [fd7a:e5cd:1fc1:c597:dead:beef:cafe:00fe]:80 alpn http/1.1'
-  refute_line --partial '172.16.15'
+  assert_line '    bind 172.16.15.1:80 alpn http/1.1'
 }
 
 # --- haproxy accepts the generated configs ---

--- a/test/provision/haproxy.bats
+++ b/test/provision/haproxy.bats
@@ -143,7 +143,7 @@ assert_haproxy_accepts() {
 @test "haproxy stage conf - IPv6 only host still binds the private IPv4" {
   run grep '^    bind ' "$(stage_conf ip6only)"
   assert_line '    bind [fd7a:e5cd:1fc1:c597:dead:beef:cafe:00fe]:80 alpn http/1.1'
-  assert_line '    bind 172.16.15.1:80 alpn http/1.1'
+  assert_line '    bind 172.16.15.254:80 alpn http/1.1'
 }
 
 # --- haproxy accepts the generated configs ---

--- a/test/provision/haraka.bats
+++ b/test/provision/haraka.bats
@@ -70,7 +70,25 @@ setup() {
   assert_output "[::0]"
 }
 
-@test "configure_haraka_smtp_ini binds every port to that address" {
+# haraka.sh populates no address itself, so reading PUBLIC_IP6 straight left an
+# IPv6 only host listening on 0.0.0.0 and taking no mail at all
+@test "haraka_listen_addr does not depend on its caller for PUBLIC_IP6" {
+  # the real has_public_ip6, which jail_has_ip6 defers to
+  # shellcheck source=/dev/null
+  . "$BATS_TEST_DIRNAME/../../include/network.sh"
+
+  # stub what it shells out to. These must come after the source above, or
+  # network.sh replaces get_public_facing_nic with the real one, which reads the
+  # host routing table and fails wherever netstat has no "default" line.
+  get_public_facing_nic() { export PUBLIC_NIC="em0"; }
+  ifconfig() { echo "	inet6 2001:db8::1 prefixlen 64"; }
+
+  unset PUBLIC_IP6
+  run haraka_listen_addr
+  assert_output "[::0]"
+}
+
+@test "configure_haraka_smtp_ini binds IPv4 when no public IPv6" {
   printf ';listen=[::0]:25\n' > "$HARAKA_CONF/smtp.ini"
   unset PUBLIC_IP6
   configure_haraka_smtp_ini

--- a/test/provision/host.bats
+++ b/test/provision/host.bats
@@ -40,6 +40,32 @@ host_has() {
   get_public_ip6() { :; }
 }
 
+# each get_public_ip* resolves its own family's default route into PUBLIC_NIC,
+# so the last one called used to decide ext_if for both
+@test "configure_pf_conf - each family NATs on its own interface" {
+  export PUBLIC_IP4="203.0.113.7" PUBLIC_IP6="2001:db8::1"
+  get_public_ip4() { export PUBLIC_NIC="em0"; }
+  get_public_ip6() { export PUBLIC_NIC="gif0"; }
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'ext_if="em0"'
+  assert_line 'ext_if6="gif0"'
+}
+
+@test "configure_pf_conf - a single family host NATs both rules on its one interface" {
+  export PUBLIC_IP4="" PUBLIC_IP6="2001:db8::1"
+  get_public_ip4() { export PUBLIC_NIC="gif0"; }
+  get_public_ip6() { export PUBLIC_NIC="gif0"; }
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'ext_if="gif0"'
+  assert_line 'ext_if6="gif0"'
+}
+
 @test "configure_pf_conf - a dual stack host NATs and tables both families" {
   host_has "203.0.113.7" "2001:db8::1"
 
@@ -49,8 +75,8 @@ host_has() {
   assert_line 'table <ext_ip>  { $ext_ip4, $ext_ip6 } persist'
   assert_line 'table <ext_ip4> { $ext_ip4 } persist'
   assert_line 'table <ext_ip6> { $ext_ip6 } persist'
-  assert_line 'nat on $ext_if inet  from $jail_ip4 to any -> ($ext_if)'
-  assert_line 'nat on $ext_if inet6 from $jail_ip6 to any -> <ext_ip6>'
+  assert_line 'nat on $ext_if  inet  from $jail_ip4 to any -> ($ext_if)'
+  assert_line 'nat on $ext_if6 inet6 from $jail_ip6 to any -> <ext_ip6>'
 }
 
 # an empty macro inside { } expands to an empty table, which pf accepts. A
@@ -85,8 +111,8 @@ host_has() {
     run cat "$PF_CONF"
     assert_line 'table <ext_ip4> { $ext_ip4 } persist'
     assert_line 'table <ext_ip6> { $ext_ip6 } persist'
-    assert_line 'nat on $ext_if inet  from $jail_ip4 to any -> ($ext_if)'
-    assert_line 'nat on $ext_if inet6 from $jail_ip6 to any -> <ext_ip6>'
+    assert_line 'nat on $ext_if  inet  from $jail_ip4 to any -> ($ext_if)'
+    assert_line 'nat on $ext_if6 inet6 from $jail_ip6 to any -> <ext_ip6>'
   done
 }
 

--- a/test/provision/host.bats
+++ b/test/provision/host.bats
@@ -54,6 +54,41 @@ host_has() {
   assert_line 'ext_if6="gif0"'
 }
 
+# scoping the rule to an interface let ssh over a v6 tunnel escape the limit.
+# It matches every interface now, so the jail network is excluded by source.
+@test "configure_pf_conf - ssh is rate limited on every interface" {
+  export PUBLIC_IP4="203.0.113.7" PUBLIC_IP6="2001:db8::1"
+  get_public_ip4() { export PUBLIC_NIC="em0"; }
+  get_public_ip6() { export PUBLIC_NIC="gif0"; }
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line --partial 'pass in quick proto tcp from ! <ssh_exempt> to port ssh'
+  refute_line --partial 'on $ext_if proto tcp to port ssh'
+  refute_line --partial 'on $ext_ifs proto tcp to port ssh'
+}
+
+@test "configure_pf_conf - jail and loopback sources are exempt from the ssh limit" {
+  host_has "203.0.113.7" "2001:db8::1"
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'table <ssh_exempt> { $jail_ip4, $jail_ip6, 127.0.0.0/8, ::1 } persist'
+}
+
+@test "configure_pf_conf - one interface is not listed twice" {
+  export PUBLIC_IP4="203.0.113.7" PUBLIC_IP6="2001:db8::1"
+  get_public_ip4() { export PUBLIC_NIC="em0"; }
+  get_public_ip6() { export PUBLIC_NIC="em0"; }
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'ext_ifs="{ em0 }"'
+}
+
 @test "configure_pf_conf - a single family host NATs both rules on its one interface" {
   export PUBLIC_IP4="" PUBLIC_IP6="2001:db8::1"
   get_public_ip4() { export PUBLIC_NIC="gif0"; }

--- a/test/provision/host.bats
+++ b/test/provision/host.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Functional tests for provision/host.sh
+#
+# configure_pf_conf writes /etc/pf.conf, so setup extracts the function
+# definitions and each test calls it with store_config caught in $BATS_TEST_TMPDIR.
+
+setup_file() {
+  export HOST_FNS="$BATS_FILE_TMPDIR/host_fns_only.sh"
+  sed '/^update_host$/,$d' \
+    "$BATS_TEST_DIRNAME/../../provision/host.sh" > "$HOST_FNS"
+}
+
+setup() {
+  load '../test_helper/bats-support/load'
+  load '../test_helper/bats-assert/load'
+
+  export MT6_TEST_ENV=1
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export PUBLIC_NIC="vtnet0"
+  export JAIL_NET_PREFIX="172.16.15"
+  export JAIL_NET_MASK="/19"
+  export JAIL_NET6="fd7a:e5cd:1fc1:c597:dead:beef:cafe"
+
+  PF_CONF="$BATS_TEST_TMPDIR/pf.conf"
+
+  # shellcheck source=/dev/null
+  . "$HOST_FNS"
+
+  # configure_pf_conf names /etc/pf.conf; catch it before it reaches the host
+  store_config() { cat - > "$PF_CONF"; }
+  # the stub reports and returns; a real one exits, so stop here either way
+  fatal_err()    { echo "FATAL: $*"; exit 1; }
+}
+
+# get_public_ip4/6 return early when the address is already set, as the real
+# ones do for a PUBLIC_IP4 configured in mail-toaster.conf
+host_has() {
+  export PUBLIC_IP4="$1" PUBLIC_IP6="$2"
+  get_public_ip4() { :; }
+  get_public_ip6() { :; }
+}
+
+@test "configure_pf_conf - a dual stack host NATs and tables both families" {
+  host_has "203.0.113.7" "2001:db8::1"
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'table <ext_ip>  { $ext_ip4, $ext_ip6 } persist'
+  assert_line 'table <ext_ip4> { $ext_ip4 } persist'
+  assert_line 'table <ext_ip6> { $ext_ip6 } persist'
+  assert_line 'nat on $ext_if inet  from $jail_ip4 to any -> ($ext_if)'
+  assert_line 'nat on $ext_if inet6 from $jail_ip6 to any -> <ext_ip6>'
+}
+
+# an empty macro inside { } expands to an empty table, which pf accepts. A
+# dangling comma in the <ext_ip> list does not parse, so only that list varies.
+@test "configure_pf_conf - an IPv4 only host omits IPv6 from the ext_ip list" {
+  host_has "203.0.113.7" ""
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'table <ext_ip>  { $ext_ip4 } persist'
+  refute_line --regexp '^table <ext_ip> .*,'
+}
+
+@test "configure_pf_conf - an IPv6 only host omits IPv4 from the ext_ip list" {
+  host_has "" "2001:db8::1"
+
+  configure_pf_conf > /dev/null
+
+  run cat "$PF_CONF"
+  assert_line 'table <ext_ip>  { $ext_ip6 } persist'
+  refute_line --regexp '^table <ext_ip> .*,'
+}
+
+@test "configure_pf_conf - the per-family tables and NAT rules never vary" {
+  local _case
+  for _case in "203.0.113.7 2001:db8::1" "203.0.113.7 " " 2001:db8::1"; do
+    # shellcheck disable=SC2086
+    host_has $_case
+    configure_pf_conf > /dev/null
+
+    run cat "$PF_CONF"
+    assert_line 'table <ext_ip4> { $ext_ip4 } persist'
+    assert_line 'table <ext_ip6> { $ext_ip6 } persist'
+    assert_line 'nat on $ext_if inet  from $jail_ip4 to any -> ($ext_if)'
+    assert_line 'nat on $ext_if inet6 from $jail_ip6 to any -> <ext_ip6>'
+  done
+}
+
+@test "configure_pf_conf - a host with neither family is an error, not a broken pf.conf" {
+  host_has "" ""
+
+  run configure_pf_conf
+  assert_failure
+  assert_output --partial "no public IPv4 or IPv6"
+}
+
+@test "configure_pf_conf - without a public NIC it stops before writing" {
+  export PUBLIC_NIC=""
+  host_has "203.0.113.7" "2001:db8::1"
+
+  run configure_pf_conf
+  assert_failure
+  assert_output --partial "PUBLIC_NIC unset"
+}
+
+# ipinfo.io publishes no AAAA, so on an IPv6 only host every one of these
+# lookups fails. Under set -e an unguarded assignment took the host build with it.
+@test "lookup_geo_defaults - a failed lookup is not fatal" {
+  fetch() { return 1; }
+
+  lookup_geo_defaults
+
+  assert_equal "$_cc$_state$_city" ""
+}
+
+@test "lookup_geo_defaults - the values reach the caller" {
+  fetch() { echo "US"; }
+
+  lookup_geo_defaults
+  assert_equal "$_cc" "US"
+}
+
+# openssl req rejects "/C=", so a subject built from a failed lookup produced no
+# certificate at all
+@test "configure_tls_certs - an unanswered lookup still yields a valid subject" {
+  fetch() { return 1; }
+  openssl() { echo "openssl $*"; }
+  mkdir -p "$BATS_TEST_TMPDIR/ssl/private" "$BATS_TEST_TMPDIR/ssl/certs"
+
+  run configure_tls_certs < /dev/null
+  assert_output --partial "subject: /O=Mail Toaster/CN=$TOASTER_HOSTNAME"
+  refute_output --partial "/C=/"
+  refute_output --partial "/ST=/"
+}
+
+@test "configure_tls_certs - an answered lookup names the locality" {
+  fetch() { echo "US"; }
+  openssl() { echo "openssl $*"; }
+  mkdir -p "$BATS_TEST_TMPDIR/ssl/private" "$BATS_TEST_TMPDIR/ssl/certs"
+
+  run configure_tls_certs < /dev/null
+  assert_output --partial "subject: /C=US/ST=US/L=US/O=Mail Toaster/CN=$TOASTER_HOSTNAME"
+}
+
+# a wildcard listener on the host swallows the jails' traffic whichever family
+# it is bound to, and on an IPv6 only host it is the IPv6 one that matters
+@test "check_global_listeners - both address families are inspected" {
+  local _flags="$BATS_TEST_TMPDIR/sockstat.flags"
+  sockstat() { echo "$*" > "$_flags"; }
+
+  check_global_listeners > /dev/null
+
+  run cat "$_flags"
+  assert_output --partial "-4"
+  assert_output --partial "-6"
+}

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -144,6 +144,9 @@ stage_resolv_conf()        { :; }
 port_is_listening()        { return 0; }
 get_random_ip6net()        { echo "fd7a:e5cd:1fc1:dead:beef:cafe:1"; }
 get_public_ip()            { :; }
+has_public_ip4()           { get_public_ip4; [ -n "${PUBLIC_IP4:-}" ]; }
+has_public_ip6()           { get_public_ip6; [ -n "${PUBLIC_IP6:-}" ]; }
+jail_has_ip6()             { has_public_ip6; }
 get_public_ip4()           { :; }
 get_public_ip6()           { :; }
 get_public_facing_nic()    { :; }

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -124,6 +124,8 @@ safe_jailname()            { echo "$1" | tr '.-' '__'; }
 add_jail_conf()            { :; }
 add_jail_conf_d()          { :; }
 assure_ip6_addr_is_declared() { :; }
+configure_pf_jail_table()  { :; }
+configure_mta_pf_rdr()     { :; }
 install_fstab()            { :; }
 fstab_add_mount()          { :; }
 

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -205,6 +205,7 @@ configure_nginx_server_d() { :; }
 start_nginx()              { :; }
 test_nginx()               { :; }
 contains()                 { [ "${1#*"$2"}" != "$1" ]; }
+nginx_listen()             { printf '\t\tlisten       %s%s;\n\t\tlisten  [::]:%s%s;\n' "${1:-80}" "${2:+ $2}" "${1:-80}" "${2:+ $2}"; }
 
 # MTA include stubs
 configure_mta()            { :; }

--- a/test/provision/wildduck.bats
+++ b/test/provision/wildduck.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# Functional tests for provision/wildduck.sh
+
+setup_file() {
+  export WD_FNS="$BATS_FILE_TMPDIR/wildduck_fns_only.sh"
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/wildduck.sh" > "$WD_FNS"
+}
+
+setup() {
+  load '../test_helper/load'
+
+  export MT6_TEST_ENV=1
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export MT6_ETC="$BATS_TEST_TMPDIR/etc"
+  export PUBLIC_NIC="em0"
+
+  RDR_CONF="$MT6_ETC/wildduck/pf.conf.d/rdr.conf"
+  NAT_CONF="$MT6_ETC/wildduck/pf.conf.d/nat.conf"
+
+  # shellcheck source=/dev/null
+  . "$WD_FNS"
+}
+
+# each get_public_ip* resolves its own family's default route into PUBLIC_NIC
+two_nic_host() {
+  export PUBLIC_IP4="$1" PUBLIC_IP6="$2"
+  get_public_ip4() { export PUBLIC_NIC="em0"; }
+  get_public_ip6() { export PUBLIC_NIC="gif0"; }
+}
+
+@test "wildduck - each family NATs on its own interface" {
+  two_nic_host "203.0.113.7" "2001:db8::1"
+
+  configure_pf > /dev/null
+
+  run cat "$NAT_CONF"
+  assert_line 'ext_if  = "em0"'
+  assert_line 'ext_if6 = "gif0"'
+  assert_line 'nat on $ext_if from $int_ip4 to any -> $ext_ip4'
+  assert_line 'nat on $ext_if6 from $int_ip6 to any -> $ext_ip6'
+}
+
+@test "wildduck - a one NIC host uses it for both families" {
+  export PUBLIC_IP4="203.0.113.7" PUBLIC_IP6="2001:db8::1"
+  get_public_ip4() { export PUBLIC_NIC="em0"; }
+  get_public_ip6() { export PUBLIC_NIC="em0"; }
+
+  configure_pf > /dev/null
+
+  run cat "$NAT_CONF"
+  assert_line 'ext_if  = "em0"'
+  assert_line 'ext_if6 = "em0"'
+}
+
+@test "wildduck - an IPv4 only host emits no IPv6 rules" {
+  two_nic_host "203.0.113.7" ""
+
+  configure_pf > /dev/null
+
+  run cat "$NAT_CONF"
+  assert_line 'ext_if  = "em0"'
+  assert_line 'ext_if6 = "em0"'
+  refute_output --partial 'int_ip6'
+  refute_output --partial '$ext_ip6'
+
+  run cat "$RDR_CONF"
+  refute_output --partial 'inet6'
+}
+
+@test "wildduck - an IPv6 only host emits no IPv4 NAT" {
+  two_nic_host "" "2001:db8::1"
+
+  configure_pf > /dev/null
+
+  run cat "$NAT_CONF"
+  assert_line 'ext_if  = "gif0"'
+  assert_line 'ext_if6 = "gif0"'
+  assert_line 'nat on $ext_if6 from $int_ip6 to any -> $ext_ip6'
+  refute_output --partial 'to any -> $ext_ip4'
+
+  run cat "$RDR_CONF"
+  assert_output --partial 'inet6'
+  refute_output --partial 'rdr inet '
+}
+
+@test "wildduck - mail and http redirects reach the right jails" {
+  two_nic_host "203.0.113.7" "2001:db8::1"
+
+  configure_pf > /dev/null
+
+  run cat "$RDR_CONF"
+  assert_output --partial "int_ip4 = \"$(get_jail_ip4 wildduck)\""
+  assert_output --partial "int_ip6 = \"$(get_jail_ip6 wildduck)\""
+  assert_output --partial 'port { 25 465 587 993 995 } -> $int_ip4'
+  assert_output --partial "port { 80 443 } -> $(get_jail_ip4 haproxy)"
+}


### PR DESCRIPTION
- refactor(net): build clean on IPv4-only, v6-only, and dual-stack
- nginx: add nginx_listen(), emitting IPv4 and IPv6 listen directives
- jail.conf: include ipv6 entry but commented (was omitted)
- jail: rename get_jail_ip to get_jail_ip4
- host: pf.conf gains ext_if6, each family NATs on its own default route NIC
- host: ntp rule covers every public NIC, not just the IPv4 one
- host: ssh rate limit applies on every interface, jail and loopback sources exempt

NOTE: an IPv6-only build is aspirational / forward looking, it currently fails because github.com returns only an IPv4 address.