### PR TITLE
perf(test): make the test suite much faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,13 @@ jobs:
     - name: checkout
       uses: actions/checkout@v6
     - name: Setup Bats
-      run: git submodule update --init --recursive
+      run: |
+        git submodule update --init --recursive
+        sudo apt-get install -y parallel
     - name: bats test
       run: |
-        ./test/bats/bin/bats test/*.bats test/include/*.bats test/provision/*.bats test/contrib/*.bats
+        ./test/bats/bin/bats --jobs "$(nproc)" --no-parallelize-within-files \
+          test/*.bats test/include/*.bats test/provision/*.bats test/contrib/*.bats
 
   freebsd:
     runs-on: ubuntu-latest

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-08
 
+- perf(test): source the assertion libraries once, scripts once per file
 - linux jails: rc.d/linux mounts /compat/linux inside the jail
 - dma: create /var/spool/dma when the port has not
 - mt: jail control files move to /etc/mail-toaster/<jail>

--- a/test/contrib/pfrule.bats
+++ b/test/contrib/pfrule.bats
@@ -2,8 +2,7 @@
 # contrib/pfrule.sh resolves its rule directory across the layouts MT6 has used
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   PFRULE="$BATS_TEST_DIRNAME/../../contrib/pfrule.sh"
   # pfrule.sh readlink -f's its own path, so the fixture has to be the resolved

--- a/test/include.bats
+++ b/test/include.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load './test_helper/bats-support/load'
-  load './test_helper/bats-assert/load'
+  load './test_helper/load'
 }
 
 @test "./include/djb.sh" {

--- a/test/include/config.bats
+++ b/test/include/config.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   load '../../include/util.sh'   # config.sh calls _file_mode from here
   load '../../include/config.sh'
 }

--- a/test/include/jail.bats
+++ b/test/include/jail.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   # Mock variables
   export JAIL_NET_PREFIX="172.16.15"
@@ -17,52 +16,42 @@ setup() {
   load '../../include/network.sh'
 }
 
-@test "safe_jailname - replaces dots" {
+# a jail name reaches jail.conf, where only alpha-numerics and _ are legal
+@test "safe_jailname - replaces the characters jail.conf rejects" {
   run safe_jailname "my.jail"
   assert_output "my_jail"
-}
 
-@test "safe_jailname - replaces dashes" {
   run safe_jailname "my-jail"
   assert_output "my_jail"
 }
 
-@test "get_jail_ip - syslog" {
+# a jail's address is its position in JAIL_ORDERED_LIST
+@test "get_jail_ip - each jail lands on its own octet" {
   run get_jail_ip syslog
   assert_output "172.16.15.1"
-}
 
-@test "get_jail_ip - dns" {
   run get_jail_ip dns
   assert_output "172.16.15.3"
-}
 
-@test "get_jail_ip - mysql" {
   run get_jail_ip mysql
   assert_output "172.16.15.4"
 }
 
-@test "jail_is_running - yes" {
-  jls() {
-    echo "myjail"
-  }
+@test "jail_is_running - follows jls" {
+  jls() { echo "myjail"; }
   run jail_is_running myjail
   assert_success
-}
 
-@test "jail_is_running - no" {
   jls() { return 1; }
   run jail_is_running myjail
   assert_failure
 }
 
-@test "jail_conf_header - dns" {
+@test "jail_conf_header - each jail gets its own path" {
   run jail_conf_header dns
   assert_output --partial "path = \"/jails/dns\";"
   assert_output --partial "interface = lo1;"
-}
 
-@test "jail_conf_header - base" {
   run jail_conf_header base
   assert_output --partial "path = \"/jails/base-13.2-RELEASE\";"
 }
@@ -204,19 +193,6 @@ devfs_setup() {
   assert_output "service devfs restart"
 }
 
-@test "assure_devfs_bpf_ruleset - is a no-op when already present" {
-  export DEVFS_RULES="$BATS_TEST_TMPDIR/devfs.rules"
-  printf '%s\n' "[devfsrules_jail_bpf=7]" "add path 'bpf*' unhide" > "$DEVFS_RULES"
-  local _before; _before=$(cat "$DEVFS_RULES")
-  tell_status() { :; }
-  service() { echo "restarted" > "$BATS_TEST_TMPDIR/svc"; }
-
-  run assure_devfs_bpf_ruleset
-  assert_success
-  [ "$(cat "$DEVFS_RULES")" = "$_before" ]
-  [ ! -f "$BATS_TEST_TMPDIR/svc" ]
-}
-
 @test "assure_devfs_bpf_ruleset - the jails needing bpf ask for that ruleset" {
   run grep -h "^export JAIL_DEVFS_RULESET" provision/haraka.sh provision/dhcp.sh
   assert_success
@@ -245,15 +221,6 @@ devfs_rules_setup() {
   assert_output "service devfs restart"
 }
 
-@test "assure_devfs_bpf_ruleset - still unhides bpf" {
-  devfs_rules_setup
-  assure_devfs_bpf_ruleset > /dev/null
-
-  run cat "$DEVFS_RULES"
-  assert_output --partial "[devfsrules_jail_bpf=7]"
-  assert_output --partial "add path 'bpf*' unhide"
-}
-
 @test "assure_devfs_ruleset - the two rulesets do not collide" {
   devfs_rules_setup
   assure_devfs_bpf_ruleset > /dev/null
@@ -275,14 +242,19 @@ devfs_rules_setup() {
   assert_output "1"
 }
 
+# restarting devfs for a ruleset that is already there would bounce every jail
 @test "assure_devfs_ruleset - is a no-op when the ruleset is present" {
   devfs_rules_setup
+  assure_devfs_bpf_ruleset > /dev/null
   assure_devfs_linux_ruleset > /dev/null
   local _before; _before=$(cat "$DEVFS_RULES")
   rm -f "$BATS_TEST_TMPDIR/svc"
 
+  run assure_devfs_bpf_ruleset
+  assert_success
   run assure_devfs_linux_ruleset
   assert_success
+
   [ "$(cat "$DEVFS_RULES")" = "$_before" ]
   [ ! -f "$BATS_TEST_TMPDIR/svc" ]
 }
@@ -615,19 +587,17 @@ mta_rdr_setup() {
   assert_output --partial "port { 25 }"
 }
 
-@test "configure_mta_pf_rdr - removes stale rdr.conf when jail owns no ports" {
+@test "configure_mta_pf_rdr - a jail owning no ports gets no rdr.conf" {
   mta_rdr_setup
   export TOASTER_MTA="postfix" TOASTER_MSA="postfix"
-  mkdir -p "$(get_jail_host_etc haraka)/pf.conf.d"
-  echo "stale rule" > "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf"
+
   run configure_mta_pf_rdr haraka
   assert_success
   [ ! -f "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf" ]
-}
 
-@test "configure_mta_pf_rdr - writes no file when jail owns no ports" {
-  mta_rdr_setup
-  export TOASTER_MTA="postfix" TOASTER_MSA="postfix"
+  # a rule left from when it did own them would still redirect mail here
+  mkdir -p "$(get_jail_host_etc haraka)/pf.conf.d"
+  echo "stale rule" > "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf"
   run configure_mta_pf_rdr haraka
   assert_success
   [ ! -f "$(get_jail_host_etc haraka)/pf.conf.d/rdr.conf" ]

--- a/test/include/linux.bats
+++ b/test/include/linux.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   export STAGE_MNT; STAGE_MNT=$(mktemp -d)
   mkdir -p "$STAGE_MNT/compat/linux/etc/apt"
   load '../../include/linux.sh'

--- a/test/include/mta.bats
+++ b/test/include/mta.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export BASE; BASE=$(mktemp -d)
   mkdir -p "$BASE/etc/mail" "$BASE/usr/libexec" "$BASE/usr/local/libexec"

--- a/test/include/mua.bats
+++ b/test/include/mua.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   load ../../include/mua.sh
 }
 

--- a/test/include/mysql.bats
+++ b/test/include/mysql.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   # Mock some variables that are normally set by mail-toaster.sh
   export ZFS_JAIL_MNT="/jails"

--- a/test/include/network.bats
+++ b/test/include/network.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   export MT6_TEST_ENV=1
   load ../../include/util.sh
   load ../../include/network.sh

--- a/test/include/nginx.bats
+++ b/test/include/nginx.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   load '../../include/nginx.sh'
 }
 

--- a/test/include/shell.bats
+++ b/test/include/shell.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   # Mock variables
   export TOASTER_EDITOR="vim"

--- a/test/include/user.bats
+++ b/test/include/user.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   export ZFS_JAIL_MNT; ZFS_JAIL_MNT=$(mktemp -d)
   export STAGE_MNT; STAGE_MNT=$(mktemp -d)
   load '../../include/user.sh'

--- a/test/include/util.bats
+++ b/test/include/util.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
   load '../../include/util.sh'
 }
 

--- a/test/include/vpopmail.bats
+++ b/test/include/vpopmail.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   # Mock variables
   export TOASTER_MYSQL="1"

--- a/test/include/zfs.bats
+++ b/test/include/zfs.bats
@@ -1,7 +1,6 @@
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   # Mock variables
   export ZFS_JAIL_VOL="zroot/jails"

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -283,7 +283,7 @@ setup_fstab_tree() {
   assert_output --partial "$ZFS_JAIL_MNT/myjail/data"
 
   # the jail mounts its own devfs, the host declares none
-  run grep "devfs" "$BATS_TEST_TMPDIR/myjail/etc/fstab"
+  run grep "devfs" "$(get_jail_host_etc myjail)/fstab"
   assert_failure
 }
 

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -1,8 +1,7 @@
 # https://bats-core.readthedocs.io/en/stable/writing-tests.html
 
 setup() {
-  load 'test_helper/bats-support/load'
-  load 'test_helper/bats-assert/load'
+  load 'test_helper/load'
   export MT6_TEST_ENV=1
   load ../mail-toaster.sh
   # Manually load includes that mt6_init would have loaded
@@ -81,41 +80,36 @@ setup() {
   assert_output --partial "Success! A new 'test' jail is provisioned"
 }
 
-@test "get_random_pass 20" {
+@test "get_random_pass - honors the requested length and character set" {
   run get_random_pass 20
-  #echo "# $output" >&3
   assert_success
   assert_equal ${#output} 20
-}
 
-@test "get_random_pass (defaults)" {
   run get_random_pass
-  #echo "# $output" >&3
   assert_success
   assert_equal ${#output} 14
-}
 
-@test "get_random_pass 14 strong" {
   run get_random_pass 14 strong
-  #echo "# $output" >&3
   assert_success
-  #assert_equal ${#output} 14
-}
 
-@test "get_random_pass 14 safe" {
   run get_random_pass 14 safe
-  #echo "# $output" >&3
   assert_success
-  #assert_equal ${#output} 14
 }
 
-@test "get_jail_ip mysql" {
+# a jail's address is its position in JAIL_ORDERED_LIST
+@test "get_jail_ip - each jail lands on its own octet" {
+  run get_jail_ip syslog
+  assert_success
+  assert_output "172.16.15.1"
+
+  run get_jail_ip dns
+  assert_success
+  assert_output "172.16.15.3"
+
   run get_jail_ip mysql
   assert_success
   assert_output "172.16.15.4"
-}
 
-@test "get_jail_ip haraka" {
   run get_jail_ip haraka
   assert_success
   assert_output "172.16.15.9"
@@ -212,18 +206,6 @@ setup() {
   rm -rf "$STAGE_MNT"
 }
 
-@test "get_jail_ip dns" {
-  run get_jail_ip dns
-  assert_success
-  assert_output "172.16.15.3"
-}
-
-@test "get_jail_ip syslog" {
-  run get_jail_ip syslog
-  assert_success
-  assert_output "172.16.15.1"
-}
-
 @test "check_last_hour - returns failure when no timestamp exists" {
   local tmp; tmp=$(mktemp -d)
   TMPDIR="$tmp" run check_last_hour
@@ -278,151 +260,77 @@ setup() {
   assert_failure
 }
 
-@test "install_fstab creates fstab with data nullfs mount" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  export ZFS_DATA_MNT="$tmpdir"
-  export ZFS_JAIL_MNT="$tmpdir/jails"
-  export STAGE_MNT="$tmpdir/jails/stage"
-  export JAIL_FSTAB=""
-  export TOASTER_USE_TMPFS=0
-  export MT6_ETC="$tmpdir/etc"
+setup_fstab_tree() {
+  export ZFS_DATA_MNT="$BATS_TEST_TMPDIR"
+  export ZFS_JAIL_MNT="$BATS_TEST_TMPDIR/jails"
+  export STAGE_MNT="$BATS_TEST_TMPDIR/jails/stage"
+  export MT6_ETC="$BATS_TEST_TMPDIR/etc"
+  export JAIL_FSTAB="${1:-}"
+  export TOASTER_USE_TMPFS="${2:-0}"
   mkdir -p "$(get_jail_host_etc myjail)" "$(get_jail_host_etc stage)"
 
   tell_status() { :; }
+}
+
+@test "install_fstab creates the data nullfs mount and no host devfs mount" {
+  setup_fstab_tree
 
   run install_fstab myjail
   assert_success
 
   run grep "nullfs" "$(get_jail_host_etc myjail)/fstab"
   assert_success
-  assert_output --partial "$tmpdir/jails/myjail/data"
+  assert_output --partial "$ZFS_JAIL_MNT/myjail/data"
 
-  rm -rf "$tmpdir"
-}
-
-@test "install_fstab creates no host devfs mount" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  export ZFS_DATA_MNT="$tmpdir"
-  export ZFS_JAIL_MNT="$tmpdir/jails"
-  export STAGE_MNT="$tmpdir/jails/stage"
-  export JAIL_FSTAB=""
-  export TOASTER_USE_TMPFS=0
-  export MT6_ETC="$tmpdir/etc"
-  mkdir -p "$(get_jail_host_etc myjail)" "$(get_jail_host_etc stage)"
-
-  tell_status() { :; }
-
-  run install_fstab myjail
-  assert_success
-
-  run grep "devfs" "$tmpdir/myjail/etc/fstab"
+  # the jail mounts its own devfs, the host declares none
+  run grep "devfs" "$BATS_TEST_TMPDIR/myjail/etc/fstab"
   assert_failure
-
-  rm -rf "$tmpdir"
 }
 
-setup_tmpfs_fstab() {
-  export ZFS_DATA_MNT="$1"
-  export ZFS_JAIL_MNT="$1/jails"
-  export STAGE_MNT="$1/jails/stage"
-  export JAIL_FSTAB=""
-  export TOASTER_USE_TMPFS=1
-  export MT6_ETC="$1/etc"
-  mkdir -p "$(get_jail_host_etc myjail)" "$(get_jail_host_etc stage)"
-
-  tell_status() { :; }
-}
-
-@test "install_fstab mounts the runtime /tmp noexec" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  setup_tmpfs_fstab "$tmpdir"
+@test "install_fstab appends JAIL_FSTAB when set" {
+  setup_fstab_tree "/extra/src /extra/dest nullfs rw 0 0"
 
   install_fstab myjail
 
-  run grep "$tmpdir/jails/myjail/tmp" "$(get_jail_host_etc myjail)/fstab"
+  run grep "/extra/src" "$(get_jail_host_etc myjail)/fstab"
   assert_success
-  assert_output --partial "rw,mode=01777,noexec,nosuid"
-
-  rm -rf "$tmpdir"
-}
-
-@test "install_fstab mounts the stage /tmp exec, so ports can build there" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  setup_tmpfs_fstab "$tmpdir"
-
-  install_fstab myjail
-
-  run grep "$tmpdir/jails/stage/tmp" "$(get_jail_host_etc myjail)/fstab.stage"
-  assert_success
-  refute_output --partial "noexec"
-  assert_output --partial "rw,mode=01777,nosuid"
-
-  rm -rf "$tmpdir"
-}
-
-@test "install_fstab keeps the stage /var/run noexec" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  setup_tmpfs_fstab "$tmpdir"
-
-  install_fstab myjail
-
-  run grep "$tmpdir/jails/stage/var/run" "$(get_jail_host_etc myjail)/fstab.stage"
-  assert_success
-  assert_output --partial "rw,mode=01755,noexec,nosuid"
-
-  rm -rf "$tmpdir"
-}
-
-@test "install_fstab copies the exec /tmp into the stage shutdown fstab" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  setup_tmpfs_fstab "$tmpdir"
-
-  install_fstab myjail
-
-  run grep "$tmpdir/jails/stage/tmp" "$(get_jail_host_etc stage)/fstab"
-  assert_success
-  refute_output --partial "noexec"
-
-  rm -rf "$tmpdir"
 }
 
 # a jail relative source sits in column 0, where the old rewrite missed it
 @test "install_fstab - the stage fstab rewrites a source as well as a target" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  export ZFS_DATA_MNT="$tmpdir" ZFS_JAIL_MNT="$tmpdir/jails"
-  export STAGE_MNT="$tmpdir/jails/stage" TOASTER_USE_TMPFS=0
-  export MT6_ETC="$tmpdir/etc"
+  setup_fstab_tree
   export JAIL_FSTAB="$ZFS_JAIL_MNT/myjail/dev $ZFS_JAIL_MNT/myjail/compat/linux/dev nullfs rw 0 0"
-  mkdir -p "$(get_jail_host_etc myjail)" "$(get_jail_host_etc stage)"
-  tell_status() { :; }
 
   install_fstab myjail
 
   run grep "compat/linux/dev" "$(get_jail_host_etc myjail)/fstab.stage"
   assert_output --partial "$STAGE_MNT/dev $STAGE_MNT/compat/linux/dev"
   refute_output --partial "$ZFS_JAIL_MNT/myjail"
-
-  rm -rf "$tmpdir"
 }
 
-@test "install_fstab appends JAIL_FSTAB when set" {
-  local tmpdir; tmpdir=$(mktemp -d)
-  export ZFS_DATA_MNT="$tmpdir"
-  export ZFS_JAIL_MNT="$tmpdir/jails"
-  export STAGE_MNT="$tmpdir/jails/stage"
-  export JAIL_FSTAB="/extra/src /extra/dest nullfs rw 0 0"
-  export TOASTER_USE_TMPFS=0
-  export MT6_ETC="$tmpdir/etc"
-  mkdir -p "$(get_jail_host_etc myjail)" "$(get_jail_host_etc stage)"
-
-  tell_status() { :; }
+# ports build in /tmp, so the stage jail gets an exec /tmp the running jail does not
+@test "install_fstab - tmpfs mounts differ between the stage and the jail" {
+  setup_fstab_tree "" 1
 
   install_fstab myjail
 
-  run grep "/extra/src" "$(get_jail_host_etc myjail)/fstab"
+  run grep "$ZFS_JAIL_MNT/myjail/tmp" "$(get_jail_host_etc myjail)/fstab"
   assert_success
+  assert_output --partial "rw,mode=01777,noexec,nosuid"
 
-  rm -rf "$tmpdir"
+  run grep "$STAGE_MNT/tmp" "$(get_jail_host_etc myjail)/fstab.stage"
+  assert_success
+  refute_output --partial "noexec"
+  assert_output --partial "rw,mode=01777,nosuid"
+
+  run grep "$STAGE_MNT/var/run" "$(get_jail_host_etc myjail)/fstab.stage"
+  assert_success
+  assert_output --partial "rw,mode=01755,noexec,nosuid"
+
+  # the shutdown fstab has to name the same exec /tmp, or unmounting misses it
+  run grep "$STAGE_MNT/tmp" "$(get_jail_host_etc stage)/fstab"
+  assert_success
+  refute_output --partial "noexec"
 }
 
 @test "stage_fbsd_pkgbase derives base_release_<minor> and invokes pkg" {
@@ -492,39 +400,20 @@ unmounted_paths() {
   stage_unmount | awk '/^umount /{ print $2 }'
 }
 
-@test "stage_unmount unmounts nested mounts before their parents" {
+@test "stage_unmount unmounts every stage mount, deepest first, once each" {
   fake_mount
   run unmounted_paths
   assert_success
+
+  # a parent unmounted first would leave the nested mount stranded
   assert_line --index 0 "$STAGE_MNT/usr/ports/distfiles"
   assert_line --index 1 "$STAGE_MNT/usr/ports"
-}
-
-@test "stage_unmount unmounts each mountpoint once" {
-  fake_mount
-  run unmounted_paths
-  assert_success
-  assert_equal "${#lines[@]}" 4
-}
-
-@test "stage_unmount unmounts the stage devfs" {
-  fake_mount
-  run unmounted_paths
-  assert_success
   assert_line "$STAGE_MNT/dev"
-}
+  assert_equal "${#lines[@]}" 4
 
-@test "stage_unmount leaves the stage root mounted" {
-  fake_mount
-  run unmounted_paths
-  assert_success
+  # the stage root itself stays, the jail is still there to promote
   refute_line "$STAGE_MNT"
-}
 
-@test "stage_unmount ignores mounts outside the stage" {
-  fake_mount
-  run unmounted_paths
-  assert_success
   # 'stage' as a substring elsewhere in the mount line is not a stage mount
   refute_line "${STAGE_MNT}-other/data"
   refute_line "$ZFS_JAIL_MNT/dovecot/stagefiles"
@@ -591,6 +480,7 @@ host_etc_setup() {
 @test "adopt_jail_host_etc - copies the rules, leaves the original in place" {
   host_etc_setup
   echo "shadow"    > "$OLD/pf.conf.d/rdr.conf.mt6"
+  chmod 600 "$OLD/pf.conf.d/rdr.conf.mt6"
   echo "10.0.0.0/8"> "$OLD/pf.conf.d/blocklist.table"
   echo "tshadow"   > "$OLD/pf.conf.d/blocklist.table.mt6"
   echo "stray"     > "$OLD/pf.conf.d/notes.txt"
@@ -608,20 +498,12 @@ host_etc_setup() {
   [ ! -e "$_new/notes.txt" ]
 
   [ -f "$OLD/pf.conf.d/rdr.conf" ]
-}
 
-@test "adopt_jail_host_etc - keeps a .mt6 shadow at 0600" {
-  host_etc_setup
-  echo "secret" > "$OLD/pf.conf.d/rdr.conf.mt6"
-  chmod 600 "$OLD/pf.conf.d/rdr.conf.mt6"
-
-  adopt_jail_host_etc dovecot
-
-  local _pfd="$(get_jail_host_etc dovecot)/pf.conf.d"
-  run find "$_pfd" -name "rdr.conf.mt6" -perm 600
-  assert_output "$_pfd/rdr.conf.mt6"
-  run find "$_pfd" -name "rdr.conf" -perm 644
-  assert_output "$_pfd/rdr.conf"
+  # a .mt6 shadow can hold a credential, so it keeps its tighter mode
+  run find "$_new" -name "rdr.conf.mt6" -perm 600
+  assert_output "$_new/rdr.conf.mt6"
+  run find "$_new" -name "rdr.conf" -perm 644
+  assert_output "$_new/rdr.conf"
 }
 
 @test "adopt_jail_host_etc - a symlink is never adopted" {

--- a/test/provision.bats
+++ b/test/provision.bats
@@ -3,8 +3,7 @@
 # Verifies required elements without executing FreeBSD-specific code.
 
 setup() {
-  load './test_helper/bats-support/load'
-  load './test_helper/bats-assert/load'
+  load './test_helper/load'
 }
 
 # ---------------------------------------------------------------------------
@@ -32,103 +31,54 @@ _no_start_required() {
 # Bulk structural checks
 # ---------------------------------------------------------------------------
 
-@test "standard provision scripts export JAIL_START_EXTRA" {
-  local failed=0
-  for script in provision/*.sh; do
-    _is_special "$script" && continue
-    if ! grep -q "^export JAIL_START_EXTRA" "$script"; then
-      echo "MISSING JAIL_START_EXTRA: $script" >&3
-      failed=$((failed + 1))
-    fi
+# One grep -L over every script beats one grep per script: these run over 70
+# files and the process spawns, not the matching, are what cost.
+_scripts_lacking() {
+  local _pattern="$1" _exempt="${2:-_is_special}" _script _failed=0
+
+  for _script in $(grep -L "$_pattern" provision/*.sh); do
+    "$_exempt" "$_script" && continue
+    echo "MISSING ${_pattern}: $_script" >&3
+    _failed=$((_failed + 1))
   done
-  [ "$failed" -eq 0 ]
+
+  [ "$_failed" -eq 0 ]
 }
 
-@test "standard provision scripts export JAIL_CONF_EXTRA" {
-  local failed=0
-  for script in provision/*.sh; do
-    _is_special "$script" && continue
-    if ! grep -q "^export JAIL_CONF_EXTRA" "$script"; then
-      echo "MISSING JAIL_CONF_EXTRA: $script" >&3
-      failed=$((failed + 1))
-    fi
-  done
-  [ "$failed" -eq 0 ]
+_none_exempt() { return 1; }
+
+@test "standard provision scripts export the jail variables" {
+  _scripts_lacking "^export JAIL_START_EXTRA"
+  _scripts_lacking "^export JAIL_CONF_EXTRA"
+  _scripts_lacking "^export JAIL_FSTAB"
 }
 
-@test "standard provision scripts export JAIL_FSTAB" {
-  local failed=0
-  for script in provision/*.sh; do
-    _is_special "$script" && continue
-    if ! grep -q "^export JAIL_FSTAB" "$script"; then
-      echo "MISSING JAIL_FSTAB: $script" >&3
-      failed=$((failed + 1))
-    fi
-  done
-  [ "$failed" -eq 0 ]
-}
-
-@test "all provision scripts define an install_ function" {
-  local failed=0
-  for script in provision/*.sh; do
-    if ! grep -q "^install_" "$script"; then
-      echo "MISSING install_*: $script" >&3
-      failed=$((failed + 1))
-    fi
-  done
-  [ "$failed" -eq 0 ]
-}
-
-@test "service provision scripts define a start_ function" {
-  local failed=0
-  for script in provision/*.sh; do
-    _no_start_required "$script" && continue
-    if ! grep -q "^start_" "$script"; then
-      echo "MISSING start_*: $script" >&3
-      failed=$((failed + 1))
-    fi
-  done
-  [ "$failed" -eq 0 ]
+@test "provision scripts define the functions their lifecycle needs" {
+  _scripts_lacking "^install_" _none_exempt
+  _scripts_lacking "^start_" _no_start_required
 }
 
 @test "all provision scripts source mail-toaster.sh" {
-  local failed=0
-  for script in provision/*.sh; do
-    if ! grep -q "mail-toaster.sh" "$script"; then
-      echo "MISSING mail-toaster.sh source: $script" >&3
-      failed=$((failed + 1))
-    fi
-  done
-  [ "$failed" -eq 0 ]
+  _scripts_lacking "mail-toaster.sh" _none_exempt
 }
 
 # ---------------------------------------------------------------------------
 # Jail capability assertions: scripts needing special jail permissions
 # ---------------------------------------------------------------------------
 
-@test "dovecot exports allow.sysvipc in JAIL_START_EXTRA" {
-  run grep "^export JAIL_START_EXTRA" provision/dovecot.sh
-  assert_output --partial "allow.sysvipc=1"
-}
-
-@test "gitlab exports allow.sysvipc in JAIL_START_EXTRA" {
-  run grep "^export JAIL_START_EXTRA" provision/gitlab.sh
-  assert_output --partial "allow.sysvipc=1"
-}
-
-@test "mongodb exports allow.sysvipc in JAIL_START_EXTRA" {
-  run grep "^export JAIL_START_EXTRA" provision/mongodb.sh
-  assert_output --partial "allow.sysvipc=1"
-}
-
-@test "mongodb exports allow.mlock in JAIL_START_EXTRA" {
-  run grep "^export JAIL_START_EXTRA" provision/mongodb.sh
-  assert_output --partial "allow.mlock=1"
-}
-
-@test "elasticsearch exports enforce_statfs in JAIL_START_EXTRA" {
-  run grep "^export JAIL_START_EXTRA" provision/elasticsearch.sh
-  assert_output --partial "enforce_statfs=1"
+# <jail> <permission the jail cannot run without>
+@test "jails needing a permission ask for it in JAIL_START_EXTRA" {
+  while read -r _jail _permission; do
+    [ -n "$_jail" ] || continue
+    run grep "^export JAIL_START_EXTRA" "provision/$_jail.sh"
+    assert_output --partial "$_permission"
+  done <<'EO_PERMS'
+dovecot       allow.sysvipc=1
+gitlab        allow.sysvipc=1
+mongodb       allow.sysvipc=1
+mongodb       allow.mlock=1
+elasticsearch enforce_statfs=1
+EO_PERMS
 }
 
 @test "linux jails let rc.d/linux mount /compat/linux" {
@@ -166,14 +116,17 @@ _no_start_required() {
 # JAIL_FSTAB mount assertions
 # ---------------------------------------------------------------------------
 
-@test "dovecot mounts vpopmail home in JAIL_FSTAB" {
-  run grep "JAIL_FSTAB=.*vpopmail" provision/dovecot.sh
-  assert_output --partial "vpopmail"
-}
-
-@test "spamassassin mounts geoip in JAIL_FSTAB" {
-  run grep "JAIL_FSTAB=.*geoip" provision/spamassassin.sh
-  assert_output --partial "geoip"
+# <jail> <dataset it mounts from another jail>
+@test "jails mount the data they share in JAIL_FSTAB" {
+  while read -r _jail _dataset; do
+    [ -n "$_jail" ] || continue
+    run grep "JAIL_FSTAB=.*$_dataset" "provision/$_jail.sh"
+    assert_output --partial "$_dataset"
+  done <<'EO_FSTAB'
+dovecot      vpopmail
+spamassassin geoip
+dcc          dcc
+EO_FSTAB
 }
 
 @test "spamassassin builds RELAY_COUNTRY unconditionally" {
@@ -197,170 +150,101 @@ _config_declared_settings() {
   } | sort -u
 }
 
+# "<file> <setting>" for every $SETTING or ${SETTING} read outside config.sh,
+# which declares the settings rather than consuming them. One pass over the
+# tree, because a grep per declared setting is 50 passes.
+_setting_reference_pairs() {
+  grep -roE '[$][{]?[A-Z_][A-Z_0-9]*' \
+      provision/*.sh deprecated/*.sh include/*.sh mail-toaster.sh \
+    | grep -v '^include/config\.sh:' \
+    | sed -e 's/:[$]{\{0,1\}/ /' \
+    | sort -u
+}
+
 @test "config.sh declares no setting that only one jail reads" {
-  local failed=0 _setting _readers _count
-  for _setting in $(_config_declared_settings); do
-    # config.sh declares the setting, it does not consume it
-    _readers=$(grep -rlE "[\$][{]?${_setting}([^A-Z_0-9]|$)" \
-                 provision/*.sh deprecated/*.sh include/*.sh mail-toaster.sh \
-               | grep -v '^include/config\.sh$') || true
-    _count=$(printf '%s' "$_readers" | grep -c . || true)
-    [ "$_count" -eq 1 ] || continue
+  local _offenders
+  _offenders=$(
+    {
+      _config_declared_settings | sed -e 's/^/DECLARED /'
+      _setting_reference_pairs
+    } | awk '
+      $1 == "DECLARED" { declared[$2] = 1; next }
+      { readers[$2] = readers[$2] " " $1; count[$2]++ }
+      END {
+        for (s in declared) {
+          if (count[s] != 1) continue
+          r = substr(readers[s], 2)
+          # base.sh, host.sh and bhyve-ubuntu.sh configure the host rather than
+          # a jail, so a setting only they read is still toaster-wide
+          if (r == "provision/base.sh" || r == "provision/host.sh") continue
+          if (r == "provision/bhyve-ubuntu.sh") continue
+          if (r !~ /^(provision|deprecated)\//) continue
+          printf "JAIL-PRIVATE (%s), belongs in its provision script: %s\n", r, s
+        }
+      }')
 
-    # base.sh, host.sh and bhyve-ubuntu.sh configure the host rather than a
-    # jail, so a setting only they read is still toaster-wide. They still count
-    # as readers above, or a setting they share with one jail looks jail-private.
-    case "$_readers" in
-      provision/base.sh|provision/host.sh|provision/bhyve-ubuntu.sh) continue ;;
-      provision/*|deprecated/*) ;;
-      *) continue ;;
-    esac
-
-    echo "JAIL-PRIVATE ($_readers), belongs in its provision script: $_setting" >&3
-    failed=$((failed + 1))
-  done
-  [ "$failed" -eq 0 ]
+  if [ -n "$_offenders" ]; then
+    echo "$_offenders" >&3
+    return 1
+  fi
 }
 
-
-@test "dcc mounts dcc db in JAIL_FSTAB" {
-  run grep "JAIL_FSTAB=.*dcc" provision/dcc.sh
-  assert_output --partial "dcc"
-}
 
 # ---------------------------------------------------------------------------
-# Port assertions: verify test_ functions check the right port
+# What each jail listens on, installs and enables
 # ---------------------------------------------------------------------------
 
-@test "redis tests port 6379" {
-  run grep "stage_listening" provision/redis.sh
-  assert_output --partial "6379"
+# <jail> <port its test_ function waits for>
+@test "test_ functions check the service port" {
+  while read -r _jail _port; do
+    [ -n "$_jail" ] || continue
+    run grep "stage_listening" "provision/$_jail.sh"
+    assert_output --partial "$_port"
+  done <<'EO_PORTS'
+redis         6379
+memcached     11211
+influxdb      8086
+nginx         80
+haproxy       443
+mysql         3306
+dovecot       993
+elasticsearch 9200
+minecraft     25565
+EO_PORTS
 }
 
-@test "memcached tests port 11211" {
-  run grep "stage_listening" provision/memcached.sh
-  assert_output --partial "11211"
+# <jail> <install call> <package or port it installs>
+@test "install_ functions install the service" {
+  while read -r _jail _installer _package; do
+    [ -n "$_jail" ] || continue
+    run grep "$_installer" "provision/$_jail.sh"
+    assert_output --partial "$_package"
+  done <<'EO_PACKAGES'
+redis        stage_pkg_install  redis
+memcached    stage_pkg_install  memcached
+mysql        stage_pkg_install  mysql
+nginx        stage_pkg_install  nginx
+influxdb     stage_pkg_install  influxdb
+grafana      stage_pkg_install  grafana
+telegraf     stage_pkg_install  telegraf
+rspamd       stage_pkg_install  rspamd
+dovecot      stage_pkg_install  dovecot
+spamassassin stage_port_install spamassassin
+EO_PACKAGES
 }
 
-@test "influxdb tests port 8086" {
-  run grep "stage_listening" provision/influxdb.sh
-  assert_output --partial "8086"
-}
-
-@test "nginx provision tests port 80" {
-  run grep "stage_listening" provision/nginx.sh
-  assert_output --partial "80"
-}
-
-@test "haproxy tests port 443" {
-  run grep "stage_listening" provision/haproxy.sh
-  assert_output --partial "443"
-}
-
-@test "mysql tests port 3306" {
-  run grep "stage_listening" provision/mysql.sh
-  assert_output --partial "3306"
-}
-
-@test "dovecot tests port 993 (IMAPS)" {
-  run grep "stage_listening" provision/dovecot.sh
-  assert_output --partial "993"
-}
-
-@test "elasticsearch tests port 9200" {
-  run grep "stage_listening" provision/elasticsearch.sh
-  assert_output --partial "9200"
-}
-
-@test "minecraft tests port 25565" {
-  run grep "stage_listening" provision/minecraft.sh
-  assert_output --partial "25565"
-}
-
-# ---------------------------------------------------------------------------
-# Package / installation assertions
-# ---------------------------------------------------------------------------
-
-@test "redis installs redis package" {
-  run grep "stage_pkg_install" provision/redis.sh
-  assert_output --partial "redis"
-}
-
-@test "memcached installs memcached package" {
-  run grep "stage_pkg_install" provision/memcached.sh
-  assert_output --partial "memcached"
-}
-
-@test "mysql installs mysql or mariadb server" {
-  run grep "stage_pkg_install" provision/mysql.sh
-  assert_output --partial "mysql"
-}
-
-@test "nginx provision installs nginx package" {
-  run grep "stage_pkg_install" provision/nginx.sh
-  assert_output --partial "nginx"
-}
-
-@test "influxdb installs influxdb" {
-  run grep "stage_pkg_install" provision/influxdb.sh
-  assert_output --partial "influxdb"
-}
-
-@test "grafana installs grafana" {
-  run grep "stage_pkg_install" provision/grafana.sh
-  assert_output --partial "grafana"
-}
-
-@test "telegraf installs telegraf" {
-  run grep "stage_pkg_install" provision/telegraf.sh
-  assert_output --partial "telegraf"
-}
-
-@test "rspamd installs rspamd" {
-  run grep "stage_pkg_install" provision/rspamd.sh
-  assert_output --partial "rspamd"
-}
-
-@test "spamassassin installs via port mail/spamassassin" {
-  run grep "stage_port_install" provision/spamassassin.sh
-  assert_output --partial "spamassassin"
-}
-
-@test "dovecot installs dovecot package" {
-  run grep "stage_pkg_install" provision/dovecot.sh
-  assert_output --partial "dovecot"
-}
-
-# ---------------------------------------------------------------------------
-# Service enable assertions
-# ---------------------------------------------------------------------------
-
-@test "redis start enables redis service" {
-  run grep "stage_sysrc" provision/redis.sh
-  assert_output --partial "redis_enable=YES"
-}
-
-@test "memcached start enables memcached service" {
-  run grep "stage_sysrc" provision/memcached.sh
-  assert_output --partial "memcached_enable=YES"
-}
-
-@test "nginx start enables nginx service" {
-  run grep "stage_sysrc" provision/nginx.sh
-  assert_output --partial "nginx_enable=YES"
-}
-
-@test "mysql start enables mysql or mariadb service" {
-  run grep "stage_sysrc" provision/mysql.sh
-  assert_output --partial "enable=YES"
-}
-
-@test "rspamd start enables rspamd service" {
-  run grep "stage_sysrc" provision/rspamd.sh
-  assert_output --partial "rspamd_enable=YES"
-}
-
-@test "dovecot start enables dovecot service" {
-  run grep "stage_sysrc" provision/dovecot.sh
-  assert_output --partial "dovecot_enable=YES"
+# <jail> <the rc variable its start_ function sets>
+@test "start_ functions enable the service at boot" {
+  while read -r _jail _enable; do
+    [ -n "$_jail" ] || continue
+    run grep "stage_sysrc" "provision/$_jail.sh"
+    assert_output --partial "$_enable"
+  done <<'EO_ENABLE'
+redis     redis_enable=YES
+memcached memcached_enable=YES
+nginx     nginx_enable=YES
+mysql     enable=YES
+rspamd    rspamd_enable=YES
+dovecot   dovecot_enable=YES
+EO_ENABLE
 }

--- a/test/provision/clamav.bats
+++ b/test/provision/clamav.bats
@@ -1,23 +1,25 @@
 #!/usr/bin/env bats
 # Functional tests for provision/clamav.sh
+#
+# setup_file sources clamav.sh once, executing install and configure against
+# $BATS_FILE_TMPDIR. Tests read what that run produced; only the tests that
+# call a function with its own stubs pay to source the definitions.
 
-setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
+setup_file() {
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
 
-  # Disable optional sub-installers that require network/interactive access
+  # the optional sub-installers want network and an interactive terminal
   export CLAMAV_UNOFFICIAL=0
   export CLAMAV_FANGFRISCH=0
 
-  # Pre-create filesystem layout expected by install_clamav and configure_*
-  mkdir -p "$STAGE_MNT/data/etc"
-  mkdir -p "$STAGE_MNT/usr/local/etc/rc.d"
+  export CLAMAV_FNS="$BATS_FILE_TMPDIR/clamav_fns_only.sh"
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/clamav.sh" > "$CLAMAV_FNS"
 
-  # clamd.conf template (representative commented options)
+  mkdir -p "$STAGE_MNT/data/etc" "$STAGE_MNT/usr/local/etc/rc.d"
+
   cat > "$STAGE_MNT/usr/local/etc/clamd.conf" <<'EOF'
 #TCPSocket 3310
 #LogFacility LOG_LOCAL6
@@ -40,7 +42,6 @@ DatabaseDirectory /var/db/clamav
 #ScanArchive yes
 EOF
 
-  # freshclam.conf template
   cat > "$STAGE_MNT/usr/local/etc/freshclam.conf" <<'EOF'
 DatabaseDirectory /var/db/clamav
 UpdateLogFile /var/log/clamav/freshclam.log
@@ -50,7 +51,7 @@ UpdateLogFile /var/log/clamav/freshclam.log
 #DatabaseMirror XY
 EOF
 
-  # rc.d stubs with paths that configure_* will rewrite
+  # rc.d stubs with the paths configure_* rewrites
   echo "conf=/usr/local/etc/clamd.conf; db=/var/db/clamav" \
     > "$STAGE_MNT/usr/local/etc/rc.d/clamav_clamd"
   echo "conf=/usr/local/etc/freshclam.conf; db=/var/db/clamav" \
@@ -60,49 +61,47 @@ EOF
   . "$BATS_TEST_DIRNAME/../../provision/clamav.sh"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
+setup() {
+  load '../test_helper/load'
+  CLAMD_CONF="$STAGE_MNT/data/etc/clamd.conf"
+  FRESHCLAM_CONF="$STAGE_MNT/data/etc/freshclam.conf"
 }
 
-# --- JAIL variable exports ---
+load_clamav_fns() {
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=/dev/null
+  . "$CLAMAV_FNS"
+}
 
-@test "clamav - JAIL_START_EXTRA is empty" {
+# a setting is enabled when it appears uncommented, with the wanted value
+assert_conf_enabled() {
+  local _conf="$1"; shift
+  local _setting
+  for _setting in "$@"; do
+    run grep "^$_setting" "$_conf"
+    assert_success
+  done
+}
+
+@test "clamav - declares no jail extras" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "clamav - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "clamav - JAIL_FSTAB is empty" {
   assert_equal "$JAIL_FSTAB" ""
 }
 
-# --- Function existence ---
-
-@test "clamav - defines install_clamav" {
-  run type install_clamav
-  assert_success
+@test "clamav - defines the jail lifecycle functions" {
+  load_clamav_fns
+  local _fn
+  for _fn in install_clamav configure_clamav start_clamav test_clamav; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
-@test "clamav - defines configure_clamav" {
-  run type configure_clamav
-  assert_success
-}
-
-@test "clamav - defines start_clamav" {
-  run type start_clamav
-  assert_success
-}
-
-@test "clamav - defines test_clamav" {
-  run type test_clamav
-  assert_success
-}
-
-# --- install_clamav behaviour ---
+# --- install_clamav ---
 
 @test "clamav - install uses clamav package" {
+  load_clamav_fns
   stage_pkg_install() { echo "PKG:$*"; }
   run install_clamav
   assert_output --partial "PKG:clamav"
@@ -114,131 +113,67 @@ teardown() {
   [ -d "$STAGE_MNT/data/log" ]
 }
 
-# --- configure_clamd outcomes ---
+# --- configure_clamd ---
 
-@test "clamav - configure_clamd enables TCPSocket" {
-  run grep "^TCPSocket" "$STAGE_MNT/data/etc/clamd.conf"
-  assert_success
+@test "clamav - configure_clamd enables the scanner options" {
+  assert_conf_enabled "$CLAMD_CONF" TCPSocket LogFacility "LogSyslog yes" \
+    DetectPUA "OLE2BlockMacros yes" "ArchiveBlockEncrypted yes"
 }
 
-@test "clamav - configure_clamd enables LogFacility" {
-  run grep "^LogFacility" "$STAGE_MNT/data/etc/clamd.conf"
-  assert_success
-}
-
-@test "clamav - configure_clamd enables syslog" {
-  run grep "^LogSyslog yes" "$STAGE_MNT/data/etc/clamd.conf"
-  assert_success
-}
-
-@test "clamav - configure_clamd redirects LogFile to /data/log" {
-  run grep "^LogFile" "$STAGE_MNT/data/etc/clamd.conf"
+@test "clamav - configure_clamd points the log and database at /data" {
+  run grep "^LogFile" "$CLAMD_CONF"
   assert_output --partial "/data/log"
-}
-
-@test "clamav - configure_clamd sets DatabaseDirectory to /data/db" {
-  run grep "^DatabaseDirectory" "$STAGE_MNT/data/etc/clamd.conf"
+  run grep "^DatabaseDirectory" "$CLAMD_CONF"
   assert_output --partial "/data/db"
 }
 
-@test "clamav - configure_clamd enables DetectPUA" {
-  run grep "^DetectPUA" "$STAGE_MNT/data/etc/clamd.conf"
-  assert_success
-}
+# --- configure_freshclam ---
 
-@test "clamav - configure_clamd enables OLE2BlockMacros" {
-  run grep "^OLE2BlockMacros yes" "$STAGE_MNT/data/etc/clamd.conf"
-  assert_success
-}
-
-@test "clamav - configure_clamd enables ArchiveBlockEncrypted" {
-  run grep "^ArchiveBlockEncrypted yes" "$STAGE_MNT/data/etc/clamd.conf"
-  assert_success
-}
-
-@test "clamav - configure_clamd rewrites rc.d conf path" {
-  run grep "data/etc" "$STAGE_MNT/usr/local/etc/rc.d/clamav_clamd"
-  assert_success
-  run grep "usr/local/etc" "$STAGE_MNT/usr/local/etc/rc.d/clamav_clamd"
-  assert_failure
-}
-
-@test "clamav - configure_clamd rewrites rc.d db path" {
-  run grep "data/db" "$STAGE_MNT/usr/local/etc/rc.d/clamav_clamd"
-  assert_success
-  run grep "var/db/clamav" "$STAGE_MNT/usr/local/etc/rc.d/clamav_clamd"
-  assert_failure
-}
-
-# --- configure_freshclam outcomes ---
-
-@test "clamav - configure_freshclam sets DatabaseDirectory to /data/db" {
-  run grep "^DatabaseDirectory" "$STAGE_MNT/data/etc/freshclam.conf"
-  assert_output --partial "/data/db"
-}
-
-@test "clamav - configure_freshclam redirects UpdateLogFile to /data/log" {
-  run grep "^UpdateLogFile" "$STAGE_MNT/data/etc/freshclam.conf"
-  assert_output --partial "/data/log"
-}
-
-@test "clamav - configure_freshclam enables LogSyslog" {
-  run grep "^LogSyslog" "$STAGE_MNT/data/etc/freshclam.conf"
-  assert_success
-}
-
-@test "clamav - configure_freshclam enables DatabaseMirror with us region" {
-  run grep "^DatabaseMirror" "$STAGE_MNT/data/etc/freshclam.conf"
+@test "clamav - configure_freshclam enables syslog and a us mirror" {
+  assert_conf_enabled "$FRESHCLAM_CONF" LogSyslog
+  run grep "^DatabaseMirror" "$FRESHCLAM_CONF"
   assert_output --partial "us"
 }
 
-@test "clamav - configure_freshclam rewrites rc.d conf path" {
-  run grep "data/etc" "$STAGE_MNT/usr/local/etc/rc.d/clamav_freshclam"
-  assert_success
-  run grep "usr/local/etc" "$STAGE_MNT/usr/local/etc/rc.d/clamav_freshclam"
-  assert_failure
+@test "clamav - configure_freshclam points the log and database at /data" {
+  run grep "^DatabaseDirectory" "$FRESHCLAM_CONF"
+  assert_output --partial "/data/db"
+  run grep "^UpdateLogFile" "$FRESHCLAM_CONF"
+  assert_output --partial "/data/log"
 }
 
-@test "clamav - configure_freshclam rewrites rc.d db path" {
-  run grep "data/db" "$STAGE_MNT/usr/local/etc/rc.d/clamav_freshclam"
-  assert_success
-  run grep "var/db/clamav" "$STAGE_MNT/usr/local/etc/rc.d/clamav_freshclam"
-  assert_failure
+# --- rc.d scripts read the configs and database under /data ---
+
+@test "clamav - configure rewrites the rc.d conf and db paths" {
+  local _rc
+  for _rc in clamav_clamd clamav_freshclam; do
+    run grep "data/etc" "$STAGE_MNT/usr/local/etc/rc.d/$_rc"
+    assert_success
+    run grep "usr/local/etc" "$STAGE_MNT/usr/local/etc/rc.d/$_rc"
+    assert_failure
+
+    run grep "data/db" "$STAGE_MNT/usr/local/etc/rc.d/$_rc"
+    assert_success
+    run grep "var/db/clamav" "$STAGE_MNT/usr/local/etc/rc.d/$_rc"
+    assert_failure
+  done
 }
 
-# --- start_clamav behaviour ---
+# --- start / test behaviour ---
 
-@test "clamav - start enables clamav_clamd service" {
+@test "clamav - start enables and starts both services" {
+  load_clamav_fns
   stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
+  stage_exec()  { echo "EXEC:$*"; }
   run start_clamav
   assert_output --partial "SYSRC:clamav_clamd_enable=YES"
-}
-
-@test "clamav - start enables clamav_freshclam service" {
-  stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
-  run start_clamav
   assert_output --partial "SYSRC:clamav_freshclam_enable=YES"
-}
-
-@test "clamav - start calls service clamav_clamd start" {
-  stage_sysrc() { :; }
-  stage_exec()  { echo "EXEC:$*"; }
-  run start_clamav
   assert_output --partial "EXEC:service clamav_clamd start"
-}
-
-@test "clamav - start calls service clamav_freshclam start" {
-  stage_sysrc() { :; }
-  stage_exec()  { echo "EXEC:$*"; }
-  run start_clamav
   assert_output --partial "EXEC:service clamav_freshclam start"
 }
 
-# --- test_clamav behaviour ---
-
 @test "clamav - test checks port 3310" {
+  load_clamav_fns
   stage_listening() { echo "PORT:$*"; }
   run test_clamav
   assert_success

--- a/test/provision/dns.bats
+++ b/test/provision/dns.bats
@@ -1,41 +1,31 @@
 #!/usr/bin/env bats
 # Functional tests for provision/dns.sh
 #
-# Performance design:
-# - setup_file() runs ONCE: sources the full dns.sh (executing configure_unbound)
-#   and saves the resulting file tree + stripped function definitions to
-#   BATS_FILE_TMPDIR.
-# - setup() runs per-test (fast): copies the cached templates and sources only
-#   the function definitions (no execution block, no expensive subshells).
+# setup_file sources dns.sh once, executing configure_unbound against
+# $BATS_FILE_TMPDIR. Tests read what that run produced; only the tests that
+# call a function pay to source the definitions.
 #
-# Root cause of slowness: bats installs DEBUG traps that make every subshell
-# spawn expensive. configure_unbound calls get_mt6_data which spawns many
-# subshells via $(get_jail_ip ...) for each jail. Running it 43 times would
-# take ~25s; running it once takes ~1s.
+# bats traps DEBUG, which makes every subshell spawn expensive. get_mt6_data
+# spawns one per jail via $(get_jail_ip ...), so running configure_unbound per
+# test cost more than the rest of the file put together.
 
 setup_file() {
-  local _stage="$BATS_FILE_TMPDIR/stage"
-  local _data="$BATS_FILE_TMPDIR/data"
-  local _fns="$BATS_FILE_TMPDIR/dns_fns_only.sh"
-
-  # Strip the execution block (everything from base_snapshot_exists onward)
-  # so setup() can source function definitions without re-running configure_unbound.
-  awk '/^base_snapshot_exists/{exit} {print}' \
-    "$BATS_TEST_DIRNAME/../../provision/dns.sh" > "$_fns"
-
-  # Build the file templates by running configure_unbound exactly once.
   export MT6_TEST_ENV=1
-  export STAGE_MNT="$_stage"
-  export ZFS_DATA_MNT="$_data"
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
+  export ZFS_DATA_MNT="$BATS_FILE_TMPDIR/data"
   # Single-entry list: only jails referenced by name in dns.sh matter.
   export JAIL_ORDERED_LIST="dns"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export DNS_FNS="$BATS_FILE_TMPDIR/dns_fns_only.sh"
 
-  mkdir -p "$_stage/usr/local/etc/unbound" "$_stage/usr/local/sbin" \
-           "$_stage/etc" "$_data/dns"
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/dns.sh" > "$DNS_FNS"
+
+  mkdir -p "$STAGE_MNT/usr/local/etc/unbound" "$STAGE_MNT/usr/local/sbin" \
+           "$STAGE_MNT/etc" "$ZFS_DATA_MNT/dns"
 
   # Minimal unbound.conf.sample with all patterns tweak_unbound_conf targets.
-  cat > "$_stage/usr/local/etc/unbound/unbound.conf.sample" <<'EOF'
+  cat > "$STAGE_MNT/usr/local/etc/unbound/unbound.conf.sample" <<'EOF'
 server:
 	# interface: 192.0.2.153
 	# interface: 192.0.2.154
@@ -54,100 +44,53 @@ remote-control:
 EOF
 
   printf '#!/bin/sh\nDESTDIR=/usr/local/etc/unbound\n' \
-    > "$_stage/usr/local/sbin/unbound-control-setup"
+    > "$STAGE_MNT/usr/local/sbin/unbound-control-setup"
 
   get_reverse_ip()  { echo "1.15.16.172.in-addr.arpa"; }
   get_reverse_ip6() { echo "1.0.0.0.fd7a.ip6.arpa"; }
 
-  # Source full dns.sh once: runs configure_unbound to produce the templates.
   # shellcheck source=/dev/null
   . "$BATS_TEST_DIRNAME/../../provision/dns.sh"
 }
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
-  export MT6_TEST_ENV=1
-  export JAIL_ORDERED_LIST="dns"
-  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
-
-  # Fresh per-test directories, restored from the cached templates (fast cp).
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
-  export ZFS_DATA_MNT; ZFS_DATA_MNT=$(mktemp -d)
-  cp -r "$BATS_FILE_TMPDIR/stage/." "$STAGE_MNT/"
-  cp -r "$BATS_FILE_TMPDIR/data/." "$ZFS_DATA_MNT/"
-
-  # Stub reverse-IP helpers (not provided by stubs/mail-toaster.sh).
-  get_reverse_ip()  { echo "1.15.16.172.in-addr.arpa"; }
-  get_reverse_ip6() { echo "1.0.0.0.fd7a.ip6.arpa"; }
-
-  # Source function definitions only (no execution block = no configure_unbound).
-  # shellcheck source=/dev/null
-  . "$BATS_FILE_TMPDIR/dns_fns_only.sh"
+  load '../test_helper/load'
+  UNBOUND_CONF="$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT" "$ZFS_DATA_MNT"
+load_dns_fns() {
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # stubs/mail-toaster.sh does not provide these
+  get_reverse_ip()  { echo "1.15.16.172.in-addr.arpa"; }
+  get_reverse_ip6() { echo "1.0.0.0.fd7a.ip6.arpa"; }
+  # shellcheck source=/dev/null
+  . "$DNS_FNS"
 }
 
 # --- JAIL variable exports ---
 
-@test "dns - JAIL_START_EXTRA is empty" {
+@test "dns - declares the jail extras unbound needs" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "dns - JAIL_CONF_EXTRA contains allow.raw_sockets" {
+  assert_equal "$JAIL_FSTAB" ""
   echo "$JAIL_CONF_EXTRA" | grep -q 'allow.raw_sockets'
-}
-
-@test "dns - JAIL_CONF_EXTRA contains exec.poststart" {
   echo "$JAIL_CONF_EXTRA" | grep -q 'exec.poststart'
-}
-
-@test "dns - JAIL_CONF_EXTRA contains exec.prestop" {
   echo "$JAIL_CONF_EXTRA" | grep -q 'exec.prestop'
 }
 
-@test "dns - JAIL_FSTAB is empty" {
-  assert_equal "$JAIL_FSTAB" ""
-}
-
-# --- Function existence ---
-
-@test "dns - defines install_unbound" {
-  run type install_unbound
-  assert_success
-}
-
-@test "dns - defines configure_unbound" {
-  run type configure_unbound
-  assert_success
-}
-
-@test "dns - defines start_unbound" {
-  run type start_unbound
-  assert_success
-}
-
-@test "dns - defines test_unbound" {
-  run type test_unbound
-  assert_success
-}
-
-@test "dns - defines get_mt6_data" {
-  run type get_mt6_data
-  assert_success
-}
-
-@test "dns - defines switch_host_resolver" {
-  run type switch_host_resolver
-  assert_success
+@test "dns - defines the jail lifecycle functions" {
+  load_dns_fns
+  local _fn
+  for _fn in install_unbound configure_unbound start_unbound test_unbound \
+             get_mt6_data switch_host_resolver; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
 # --- install_unbound behaviour ---
 
 @test "dns - install uses unbound package" {
+  load_dns_fns
   stage_pkg_install() { echo "PKG:$*"; }
   run install_unbound
   assert_success
@@ -156,226 +99,112 @@ teardown() {
 
 # --- get_mt6_data behaviour ---
 
-@test "dns - get_mt6_data includes local-zone for mail domain" {
+@test "dns - get_mt6_data serves the toaster's own records" {
+  load_dns_fns
   run get_mt6_data
   assert_output --partial "local-zone: $TOASTER_MAIL_DOMAIN"
-}
-
-@test "dns - get_mt6_data includes stage A record" {
-  run get_mt6_data
   assert_output --partial '"stage'
   assert_output --partial 'A '
-}
-
-@test "dns - get_mt6_data includes SPF TXT record" {
-  run get_mt6_data
   assert_output --partial 'v=spf1'
   assert_output --partial 'ip4:'
 }
 
-@test "dns - get_mt6_data adds MX record when hostname differs from mail domain" {
-  # Default stub values: TOASTER_HOSTNAME=mail.example.com, TOASTER_MAIL_DOMAIN=example.com
+# a hostname inside the mail domain is already covered by the domain's MX
+@test "dns - get_mt6_data adds an MX only when the hostname differs" {
+  load_dns_fns
   run get_mt6_data
   assert_output --partial "MX 0"
-}
 
-@test "dns - get_mt6_data omits MX record when hostname equals mail domain" {
-  local _saved="$TOASTER_HOSTNAME"
   export TOASTER_HOSTNAME="$TOASTER_MAIL_DOMAIN"
   run get_mt6_data
-  export TOASTER_HOSTNAME="$_saved"
   refute_output --partial "MX 0"
 }
 
-@test "dns - get_mt6_data includes PUBLIC_IP6 in SPF when set" {
-  local _saved="$PUBLIC_IP6"
+@test "dns - get_mt6_data publishes ip6 in SPF only when PUBLIC_IP6 is set" {
+  load_dns_fns
   export PUBLIC_IP6="2001:db8::1"
   run get_mt6_data
-  export PUBLIC_IP6="$_saved"
   assert_output --partial "ip6:2001:db8::1"
-}
 
-@test "dns - get_mt6_data omits PUBLIC_IP6 from SPF when unset" {
-  local _saved="$PUBLIC_IP6"
   export PUBLIC_IP6=""
   run get_mt6_data
-  export PUBLIC_IP6="$_saved"
   refute_output --partial "ip6:2001:db8"
 }
 
 # --- tweak_unbound_conf outcomes (verified on the post-setup unbound.conf) ---
 
-@test "dns - configure sets interface to 0.0.0.0" {
-  run grep "interface: 0.0.0.0" "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
+@test "dns - configure listens on both address families" {
+  run grep "interface: 0.0.0.0" "$UNBOUND_CONF"
+  assert_success
+  run grep "interface: ::0" "$UNBOUND_CONF"
   assert_success
 }
 
-@test "dns - configure sets interface to ::0" {
-  run grep "interface: ::0" "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
-  assert_success
-}
-
-@test "dns - configure enables use-syslog" {
-  run grep "use-syslog:" "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
+@test "dns - configure enables syslog, unsets chroot and hides the server" {
+  run grep "use-syslog:" "$UNBOUND_CONF"
   assert_success
   refute_output --partial "# use-syslog"
-}
 
-@test "dns - configure sets chroot to empty string" {
-  run grep 'chroot:' "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
+  run grep 'chroot:' "$UNBOUND_CONF"
   assert_output --partial 'chroot: ""'
-}
 
-@test "dns - configure hides identity" {
-  run grep "hide-identity:" "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
+  run grep "hide-identity:" "$UNBOUND_CONF"
   assert_output --partial "yes"
-}
-
-@test "dns - configure hides version" {
-  run grep "hide-version:" "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
+  run grep "hide-version:" "$UNBOUND_CONF"
   assert_output --partial "yes"
 }
 
 @test "dns - configure adds forward.conf include" {
-  run grep 'include: "/data/forward.conf"' "$STAGE_MNT/usr/local/etc/unbound/unbound.conf"
+  run grep 'include: "/data/forward.conf"' "$UNBOUND_CONF"
   assert_success
 }
 
 # --- enable_control outcomes (post-setup file/directory checks) ---
 
-@test "dns - enable_control creates control directory" {
+@test "dns - enable_control writes the control config under /data" {
   [ -d "$ZFS_DATA_MNT/dns/control" ]
-}
-
-@test "dns - enable_control creates control.conf" {
   [ -f "$ZFS_DATA_MNT/dns/control.conf" ]
-}
 
-@test "dns - enable_control sets control-enable: yes" {
   run grep "control-enable: yes" "$ZFS_DATA_MNT/dns/control.conf"
   assert_success
-}
-
-@test "dns - enable_control sets control-interface to 0.0.0.0" {
   run grep "control-interface: 0.0.0.0" "$ZFS_DATA_MNT/dns/control.conf"
   assert_success
-}
-
-@test "dns - enable_control rewrites DESTDIR to /data/control in setup script" {
   run grep "^DESTDIR=/data/control" "$STAGE_MNT/usr/local/sbin/unbound-control-setup"
   assert_success
 }
 
 # --- start_unbound behaviour ---
 
-@test "dns - start enables unbound via sysrc" {
+@test "dns - start enables unbound and starts it" {
+  load_dns_fns
   stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
-  run start_unbound
-  assert_success
-  assert_output --partial "SYSRC:unbound_enable=YES"
-}
-
-@test "dns - start calls service unbound start" {
-  stage_sysrc() { :; }
   stage_exec()  { echo "EXEC:$*"; }
   run start_unbound
   assert_success
+  assert_output --partial "SYSRC:unbound_enable=YES"
   assert_output --partial "EXEC:service unbound start"
 }
 
 # --- test_unbound behaviour ---
 
-@test "dns - test checks unbound is running" {
+@test "dns - test checks unbound is running and resolves through it" {
+  load_dns_fns
   stage_test_running() { echo "RUNNING:$*"; }
-  stage_exec() { :; }
+  stage_exec()         { echo "EXEC:$*"; }
   run test_unbound
   assert_success
   assert_output --partial "RUNNING:unbound"
-}
-
-@test "dns - test calls host dns lookup via stage_exec" {
-  stage_test_running() { :; }
-  stage_exec() { echo "EXEC:$*"; }
-  run test_unbound
-  assert_success
   assert_output --partial "EXEC:host dns"
 }
 
 @test "dns - test writes nameserver to resolv.conf" {
+  load_dns_fns
+  # it writes into the tree, so work on a copy the other tests do not read
+  export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
+  mkdir -p "$STAGE_MNT/etc"
   stage_test_running() { :; }
-  stage_exec() { :; }
+  stage_exec()         { :; }
   test_unbound
   run grep "^nameserver" "$STAGE_MNT/etc/resolv.conf"
   assert_success
-}
-
-@test "dns - test sets resolv.conf to production dns IP on completion" {
-  stage_test_running() { :; }
-  stage_exec() { :; }
-  test_unbound
-  run cat "$STAGE_MNT/etc/resolv.conf"
-  assert_output --partial "$(get_jail_ip dns)"
-}
-
-# --- switch_host_resolver behaviour ---
-
-@test "dns - switch_host_resolver creates poststart script" {
-  store_exec() { echo "EXEC:$1"; cat - > /dev/null; }
-  run switch_host_resolver
-  assert_output --partial "EXEC:$(get_jail_host_etc dns)/rc.d/poststart.sh"
-}
-
-@test "dns - switch_host_resolver creates prestop script" {
-  store_exec() { echo "EXEC:$1"; cat - > /dev/null; }
-  run switch_host_resolver
-  assert_output --partial "EXEC:$(get_jail_host_etc dns)/rc.d/prestop.sh"
-}
-
-# --- install_access_conf behaviour ---
-
-@test "dns - access.conf includes the public IPv4 when one is known" {
-  rm -f "$ZFS_DATA_MNT/dns/access.conf"
-  get_public_ip4() { export PUBLIC_IP4="203.0.113.7"; }
-  install_access_conf
-  run cat "$ZFS_DATA_MNT/dns/access.conf"
-  assert_output --partial "access-control: 203.0.113.7 allow"
-}
-
-# An empty PUBLIC_IP4 used to emit "access-control:  allow", which unbound
-# rejects, taking DNS down for every jail.
-@test "dns - access.conf omits the entry when no public IPv4 is found" {
-  rm -f "$ZFS_DATA_MNT/dns/access.conf"
-  get_public_ip4() { export PUBLIC_IP4=""; }
-  install_access_conf
-  run grep -c "access-control:[[:space:]]*allow" "$ZFS_DATA_MNT/dns/access.conf"
-  assert_output "0"
-}
-
-@test "dns - access.conf always keeps the jail network entries" {
-  rm -f "$ZFS_DATA_MNT/dns/access.conf"
-  get_public_ip4() { export PUBLIC_IP4=""; }
-  install_access_conf
-  run cat "$ZFS_DATA_MNT/dns/access.conf"
-  assert_output --partial "access-control: 0.0.0.0/0 refuse"
-  assert_output --partial "access-control: 127.0.0.0/8 allow"
-}
-
-@test "dns - install_access_conf does not depend on its caller for PUBLIC_IP4" {
-  rm -f "$ZFS_DATA_MNT/dns/access.conf"
-
-  # the real get_public_ip4, so this exercises install_access_conf calling it
-  # shellcheck source=/dev/null
-  . "$BATS_TEST_DIRNAME/../../include/network.sh"
-
-  # stub what it shells out to. These must come after the source above, or
-  # network.sh replaces get_public_facing_nic with the real one, which reads the
-  # host routing table and fails wherever netstat has no "default" line.
-  get_public_facing_nic() { export PUBLIC_NIC="em0"; }
-  ifconfig() { echo "	inet 198.51.100.4 netmask 0xffffff00"; }
-
-  unset PUBLIC_IP4
-  install_access_conf
-  run cat "$ZFS_DATA_MNT/dns/access.conf"
-  assert_output --partial "access-control: 198.51.100.4 allow"
 }

--- a/test/provision/dns.bats
+++ b/test/provision/dns.bats
@@ -197,14 +197,85 @@ load_dns_fns() {
   assert_output --partial "EXEC:host dns"
 }
 
-@test "dns - test writes nameserver to resolv.conf" {
+@test "dns - test leaves resolv.conf on the dns jail, not the stage IP it probed with" {
   load_dns_fns
   # it writes into the tree, so work on a copy the other tests do not read
   export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
   mkdir -p "$STAGE_MNT/etc"
   stage_test_running() { :; }
   stage_exec()         { :; }
+
   test_unbound
-  run grep "^nameserver" "$STAGE_MNT/etc/resolv.conf"
-  assert_success
+
+  run cat "$STAGE_MNT/etc/resolv.conf"
+  assert_output --partial "nameserver $(get_jail_ip dns)"
+  refute_output --partial "$(get_jail_ip stage)"
+}
+
+# --- switch_host_resolver behaviour ---
+
+@test "dns - switch_host_resolver writes the poststart and prestop hooks" {
+  load_dns_fns
+  store_exec() { echo "EXEC:$1"; cat - > /dev/null; }
+
+  run switch_host_resolver
+  assert_output --partial "EXEC:$(get_jail_host_etc dns)/rc.d/poststart.sh"
+  assert_output --partial "EXEC:$(get_jail_host_etc dns)/rc.d/prestop.sh"
+}
+
+# --- install_access_conf behaviour ---
+
+setup_access_conf() {
+  load_dns_fns
+  export ZFS_DATA_MNT="$BATS_TEST_TMPDIR/data"
+  mkdir -p "$ZFS_DATA_MNT/dns"
+  ACCESS_CONF="$ZFS_DATA_MNT/dns/access.conf"
+}
+
+@test "dns - access.conf includes the public IPv4 when one is known" {
+  setup_access_conf
+  get_public_ip4() { export PUBLIC_IP4="203.0.113.7"; }
+
+  install_access_conf
+
+  run cat "$ACCESS_CONF"
+  assert_output --partial "access-control: 203.0.113.7 allow"
+}
+
+@test "dns - access.conf omits the entry rather than emit the empty one unbound rejects" {
+  setup_access_conf
+  get_public_ip4() { export PUBLIC_IP4=""; }
+
+  install_access_conf
+
+  run grep -c "access-control:[[:space:]]*allow" "$ACCESS_CONF"
+  assert_output "0"
+}
+
+@test "dns - access.conf keeps the jail network entries whatever the public IP" {
+  setup_access_conf
+  get_public_ip4() { export PUBLIC_IP4=""; }
+
+  install_access_conf
+
+  run cat "$ACCESS_CONF"
+  assert_output --partial "access-control: 0.0.0.0/0 refuse"
+  assert_output --partial "access-control: 127.0.0.0/8 allow"
+  assert_output --partial "access-control: ${JAIL_NET_PREFIX}.0${JAIL_NET_MASK} allow"
+}
+
+@test "dns - install_access_conf finds its own PUBLIC_IP4" {
+  setup_access_conf
+
+  # shellcheck source=/dev/null
+  . "$BATS_TEST_DIRNAME/../../include/network.sh"
+
+  get_public_facing_nic() { export PUBLIC_NIC="em0"; }
+  ifconfig() { echo "	inet 198.51.100.4 netmask 0xffffff00"; }
+
+  unset PUBLIC_IP4
+  install_access_conf
+
+  run cat "$ACCESS_CONF"
+  assert_output --partial "access-control: 198.51.100.4 allow"
 }

--- a/test/provision/haproxy.bats
+++ b/test/provision/haproxy.bats
@@ -49,16 +49,9 @@ conf()       { echo "$BATS_FILE_TMPDIR/$1/data/haproxy/etc/haproxy.conf"; }
 stage_conf() { echo "$BATS_FILE_TMPDIR/$1/stage/usr/local/etc/haproxy.conf"; }
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
-  export MT6_TEST_ENV=1
-  export ZFS_DATA_MNT="$BATS_FILE_TMPDIR/both/data"
-  export HAPROXY_CONF="$ZFS_DATA_MNT/haproxy/etc/haproxy.conf"
-  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
-
-  # shellcheck source=/dev/null
-  . "$BATS_FILE_TMPDIR/haproxy_fns_only.sh"
+  HAPROXY_CONF="$(conf both)"
 }
 
 # haproxy -c on a copy with the cert path and DH params pointed at fixtures
@@ -85,15 +78,9 @@ assert_haproxy_accepts() {
 
 # --- JAIL variable exports ---
 
-@test "haproxy - JAIL_START_EXTRA is empty" {
+@test "haproxy - declares no jail extras" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "haproxy - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "haproxy - JAIL_FSTAB is empty" {
   assert_equal "$JAIL_FSTAB" ""
 }
 
@@ -158,85 +145,31 @@ assert_haproxy_accepts() {
 
 # --- haproxy accepts the generated configs ---
 
-@test "haproxy.conf - haproxy validates dual stack config" {
-  assert_haproxy_accepts "$(conf both)"
-}
-
-@test "haproxy.conf - haproxy validates IPv4 only config" {
-  assert_haproxy_accepts "$(conf ip4only)"
-}
-
-@test "haproxy.conf - haproxy validates IPv6 only config" {
-  assert_haproxy_accepts "$(conf ip6only)"
-}
-
-@test "haproxy stage conf - haproxy validates dual stack config" {
-  assert_haproxy_accepts "$(stage_conf both)"
-}
-
-@test "haproxy stage conf - haproxy validates IPv4 only config" {
-  assert_haproxy_accepts "$(stage_conf ip4only)"
-}
-
-@test "haproxy stage conf - haproxy validates IPv6 only config" {
-  assert_haproxy_accepts "$(stage_conf ip6only)"
+@test "haproxy - validates every generated config" {
+  local _case
+  for _case in both ip4only ip6only; do
+    assert_haproxy_accepts "$(conf "$_case")"
+    assert_haproxy_accepts "$(stage_conf "$_case")"
+  done
 }
 
 # --- haproxy.conf security headers ---
 
-@test "haproxy.conf - X-Frame-Options header is present" {
-  run grep -q 'X-Frame-Options' "$HAPROXY_CONF"
-  assert_success
-}
-
-@test "haproxy.conf - X-Frame-Options set to sameorigin" {
-  run grep 'X-Frame-Options' "$HAPROXY_CONF"
-  assert_output --partial 'sameorigin'
-}
-
-@test "haproxy.conf - X-XSS-Protection header is present" {
-  run grep -q 'X-XSS-Protection' "$HAPROXY_CONF"
-  assert_success
-}
-
-@test "haproxy.conf - X-XSS-Protection set to block mode" {
-  run grep 'X-XSS-Protection' "$HAPROXY_CONF"
-  assert_output --partial '1; mode=block'
-}
-
-@test "haproxy.conf - X-Content-Type-Options header is present" {
-  run grep -q 'X-Content-Type-Options' "$HAPROXY_CONF"
-  assert_success
-}
-
-@test "haproxy.conf - X-Content-Type-Options set to nosniff" {
-  run grep 'X-Content-Type-Options' "$HAPROXY_CONF"
-  assert_output --partial 'nosniff'
-}
-
-@test "haproxy.conf - Referrer-Policy header is present" {
-  run grep -q 'Referrer-Policy' "$HAPROXY_CONF"
-  assert_success
-}
-
-@test "haproxy.conf - Referrer-Policy set to strict-origin-when-cross-origin" {
-  run grep 'Referrer-Policy' "$HAPROXY_CONF"
-  assert_output --partial 'strict-origin-when-cross-origin'
-}
-
-@test "haproxy.conf - Content-Security-Policy header is present" {
-  run grep -q 'Content-Security-Policy' "$HAPROXY_CONF"
-  assert_success
-}
-
-@test "haproxy.conf - CSP restricts default-src to self" {
-  run grep 'Content-Security-Policy' "$HAPROXY_CONF"
-  assert_output --partial "default-src 'self'"
-}
-
-@test "haproxy.conf - CSP restricts frame-ancestors to self" {
-  run grep 'Content-Security-Policy' "$HAPROXY_CONF"
-  assert_output --partial "frame-ancestors 'self'"
+# <header> <value it must carry>
+@test "haproxy.conf - sets the security headers" {
+  while read -r _header _value; do
+    [ -n "$_header" ] || continue
+    run grep "$_header" "$HAPROXY_CONF"
+    assert_success
+    assert_output --partial "$_value"
+  done <<'EO_HEADERS'
+X-Frame-Options         sameorigin
+X-XSS-Protection        1; mode=block
+X-Content-Type-Options  nosniff
+Referrer-Policy         strict-origin-when-cross-origin
+Content-Security-Policy default-src 'self'
+Content-Security-Policy frame-ancestors 'self'
+EO_HEADERS
 }
 
 @test "haproxy.conf - security headers use http-response set-header" {
@@ -248,34 +181,25 @@ assert_haproxy_accepts() {
 
 # --- /auth-check endpoint ---
 
-@test "haproxy.conf - auth-check returns 204 for authenticated users" {
+@test "haproxy.conf - auth-check answers the fetch probe without a challenge" {
   run grep -q 'http-request return status 204 if auth_check { http_auth(adminusers) }' "$HAPROXY_CONF"
   assert_success
-}
-
-@test "haproxy.conf - auth-check returns 204 for local clients" {
   run grep -q 'http-request return status 204 if auth_check is_local' "$HAPROXY_CONF"
   assert_success
-}
-
-@test "haproxy.conf - auth-check returns bare 401 (no WWW-Authenticate) for fetch probe" {
+  # a bare 401, no WWW-Authenticate, or the browser pops its own dialog
   run grep -q 'http-request return status 401 if auth_check' "$HAPROXY_CONF"
   assert_success
 }
 
-@test "haproxy.conf - auth-login returns cookie-setting page for authenticated users" {
+@test "haproxy.conf - auth-login sets the admin cookie, else challenges" {
   run grep 'http-request return.*200.*auth_login.*http_auth' "$HAPROXY_CONF"
   assert_success
   assert_output --partial 'is_admin=1'
-}
 
-@test "haproxy.conf - auth-login returns cookie-setting page for local clients" {
   run grep 'http-request return.*200.*auth_login is_local' "$HAPROXY_CONF"
   assert_success
   assert_output --partial 'is_admin=1'
-}
 
-@test "haproxy.conf - auth-login sends WWW-Authenticate challenge for unauthenticated users" {
   run grep -q 'http-request auth realm "Restricted" if auth_login' "$HAPROXY_CONF"
   assert_success
 }

--- a/test/provision/haproxy.bats
+++ b/test/provision/haproxy.bats
@@ -127,13 +127,13 @@ assert_haproxy_accepts() {
 
 @test "haproxy stage conf - dual stack binds both families" {
   run grep '^    bind ' "$(stage_conf both)"
-  assert_line '    bind 172.16.15.1:80 alpn http/1.1'
+  assert_line '    bind 172.16.15.254:80 alpn http/1.1'
   assert_line '    bind [fd7a:e5cd:1fc1:c597:dead:beef:cafe:00fe]:80 alpn http/1.1'
 }
 
 @test "haproxy stage conf - IPv4 only host binds no IPv6" {
   run grep '^    bind ' "$(stage_conf ip4only)"
-  assert_line '    bind 172.16.15.1:80 alpn http/1.1'
+  assert_line '    bind 172.16.15.254:80 alpn http/1.1'
   refute_line --partial '['
 }
 

--- a/test/provision/haraka.bats
+++ b/test/provision/haraka.bats
@@ -1,12 +1,20 @@
 #!/usr/bin/env bats
 # Functional tests for provision/haraka.sh
+#
+# Every test edits the config tree, so each gets its own $BATS_TEST_TMPDIR.
+# setup_file strips the execution block once; setup only sources the result.
+
+setup_file() {
+  export HARAKA_FNS="$BATS_FILE_TMPDIR/haraka_fns_only.sh"
+  sed '/^preinstall_checks$/,$d' \
+    "$BATS_TEST_DIRNAME/../../provision/haraka.sh" > "$HARAKA_FNS"
+}
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d /tmp/mt6hkXXXXXX)
+  export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
 
   export ZFS_DATA_MNT="$STAGE_MNT/data"
@@ -20,36 +28,20 @@ setup() {
   mkdir -p "$HARAKA_CONF"
   printf '# syslog\n' > "$HARAKA_CONF/plugins"
 
-  # source the function definitions only; the execution block at the bottom
-  # provisions a jail
-  sed '/^preinstall_checks$/,$d' "$BATS_TEST_DIRNAME/../../provision/haraka.sh" \
-    > "$STAGE_MNT/haraka-functions.sh"
   # shellcheck source=/dev/null
-  . "$STAGE_MNT/haraka-functions.sh"
+  . "$HARAKA_FNS"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
-}
-
-@test "configure_haraka_syslog logs to the data volume" {
+@test "configure_haraka_syslog keeps the maillog on the data volume" {
   configure_haraka_syslog
 
   run cat "$STAGE_MNT/etc/syslog.conf"
   assert_success
   assert_output --partial "/data/log/maillog"
   refute_output --partial "/var/log/maillog"
-}
-
-@test "configure_haraka_syslog creates the log dir and maillog" {
-  configure_haraka_syslog
 
   [ -d "$ZFS_DATA_MNT/haraka/log" ]
   [ -f "$ZFS_DATA_MNT/haraka/log/maillog" ]
-}
-
-@test "configure_haraka_syslog points log-reader at the data volume" {
-  configure_haraka_syslog
 
   run cat "$HARAKA_CONF/log.reader.ini"
   assert_success
@@ -68,33 +60,27 @@ teardown() {
 
 # --- listen address follows IPv6 availability ---
 
-@test "haraka_listen_addr returns 0.0.0.0 when no public IPv6" {
+@test "haraka_listen_addr follows IPv6 availability" {
   unset PUBLIC_IP6
   run haraka_listen_addr
   assert_output "0.0.0.0"
-}
 
-@test "haraka_listen_addr returns [::0] when public IPv6 present" {
   export PUBLIC_IP6="2001:db8::1"
   run haraka_listen_addr
   assert_output "[::0]"
 }
 
-@test "configure_haraka_smtp_ini binds IPv4 when no public IPv6" {
+@test "configure_haraka_smtp_ini binds every port to that address" {
   printf ';listen=[::0]:25\n' > "$HARAKA_CONF/smtp.ini"
   unset PUBLIC_IP6
   configure_haraka_smtp_ini
-
   run cat "$HARAKA_CONF/smtp.ini"
   assert_output --partial "listen=0.0.0.0:25,0.0.0.0:465,0.0.0.0:587"
   refute_output --partial "[::0]"
-}
 
-@test "configure_haraka_smtp_ini binds IPv6 when public IPv6 present" {
   printf ';listen=[::0]:25\n' > "$HARAKA_CONF/smtp.ini"
   export PUBLIC_IP6="2001:db8::1"
   configure_haraka_smtp_ini
-
   run cat "$HARAKA_CONF/smtp.ini"
   assert_output --partial "listen=[::0]:25,[::0]:465,[::0]:587"
 }
@@ -113,17 +99,15 @@ teardown() {
 @test "haraka_enable_plugin appends when Haraka ships no entry" {
   printf '# status\n# syslog\n' > "$HARAKA_CONF/plugins"
   haraka_enable_plugin watch > /dev/null
-
-  run cat "$HARAKA_CONF/plugins"
-  assert_line "watch"
-}
-
-@test "haraka_enable_plugin appends p0f when Haraka ships no entry" {
-  printf '# karma\n# geoip\n' > "$HARAKA_CONF/plugins"
   haraka_enable_plugin p0f > /dev/null
 
   run cat "$HARAKA_CONF/plugins"
+  assert_line "watch"
   assert_line "p0f"
+
+  # the plugins it was not asked about stay as Haraka shipped them
+  assert_line "# status"
+  assert_line "# syslog"
 }
 
 @test "haraka_enable_plugin does not double-add an enabled plugin" {
@@ -132,15 +116,6 @@ teardown() {
 
   run grep -c '^watch$' "$HARAKA_CONF/plugins"
   assert_output "1"
-}
-
-@test "haraka_enable_plugin leaves other commented plugins alone" {
-  printf '# status\n# syslog\n' > "$HARAKA_CONF/plugins"
-  haraka_enable_plugin watch > /dev/null
-
-  run cat "$HARAKA_CONF/plugins"
-  assert_line "# status"
-  assert_line "# syslog"
 }
 
 @test "configure_haraka_watch enables the plugin and writes watch.ini" {
@@ -153,14 +128,7 @@ teardown() {
 
   run cat "$HARAKA_CONF/watch.ini"
   assert_output --partial "url=wss://mail.example.com/watch"
-}
-
-@test "configure_haraka_watch - the wss url names a host" {
-  printf '# status\n# syslog\n' > "$HARAKA_CONF/plugins"
-  export TOASTER_HOSTNAME="mail.example.com"
-  configure_haraka_watch > /dev/null
-
-  run cat "$HARAKA_CONF/watch.ini"
+  # an empty hostname would leave wss:/// and the browser nowhere to connect
   refute_output --partial "wss:///"
   assert_line --regexp '^url=wss://[a-z0-9.-]+/watch$'
 }

--- a/test/provision/memcached.bats
+++ b/test/provision/memcached.bats
@@ -1,59 +1,45 @@
 #!/usr/bin/env bats
 # Functional tests for provision/memcached.sh
-# Uses stub mail-toaster.sh via PATH injection so the provision script can be
-# sourced without FreeBSD infrastructure.
+#
+# setup_file sources memcached.sh once against $BATS_FILE_TMPDIR, through the
+# stub mail-toaster.sh on PATH. Only the tests that call a function with their
+# own stubs pay to source the definitions.
 
-setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
+setup_file() {
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
-
-  # Inject stub directory first in PATH so '. mail-toaster.sh' finds the stub
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export MEMCACHED_FNS="$BATS_FILE_TMPDIR/memcached_fns_only.sh"
 
-  # Source the provision script; the execution block runs against stub functions
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/memcached.sh" > "$MEMCACHED_FNS"
+
+  mkdir -p "$STAGE_MNT"
+
   # shellcheck source=/dev/null
   . "$BATS_TEST_DIRNAME/../../provision/memcached.sh"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
+setup() {
+  load '../test_helper/load'
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=/dev/null
+  . "$MEMCACHED_FNS"
 }
 
-# --- JAIL variable exports ---
-
-@test "memcached - JAIL_START_EXTRA is empty (no special capabilities needed)" {
+@test "memcached - declares no jail extras" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "memcached - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "memcached - JAIL_FSTAB is empty (no extra mounts needed)" {
   assert_equal "$JAIL_FSTAB" ""
 }
 
-# --- Function existence ---
-
-@test "memcached - defines install_memcached" {
-  run type install_memcached
-  assert_success
+@test "memcached - defines the jail lifecycle functions" {
+  local _fn
+  for _fn in install_memcached start_memcached test_memcached; do
+    run type "$_fn"
+    assert_success
+  done
 }
-
-@test "memcached - defines start_memcached" {
-  run type start_memcached
-  assert_success
-}
-
-@test "memcached - defines test_memcached" {
-  run type test_memcached
-  assert_success
-}
-
-# --- install_memcached behaviour ---
 
 @test "memcached - install installs memcached package" {
   stage_pkg_install() { echo "PKG:$*"; }
@@ -62,25 +48,14 @@ teardown() {
   assert_output --partial "PKG:memcached"
 }
 
-# --- start_memcached behaviour ---
-
-@test "memcached - start enables service via sysrc" {
+@test "memcached - start enables the service and starts it" {
   stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
-  run start_memcached
-  assert_success
-  assert_output --partial "SYSRC:memcached_enable=YES"
-}
-
-@test "memcached - start calls service memcached start" {
-  stage_sysrc() { :; }
   stage_exec()  { echo "EXEC:$*"; }
   run start_memcached
   assert_success
+  assert_output --partial "SYSRC:memcached_enable=YES"
   assert_output --partial "EXEC:service memcached start"
 }
-
-# --- test_memcached behaviour ---
 
 @test "memcached - test checks port 11211" {
   stage_listening() { echo "PORT:$*"; }

--- a/test/provision/mysql.bats
+++ b/test/provision/mysql.bats
@@ -60,8 +60,7 @@ EOF
 }
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export MT6_TEST_ENV=1
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
@@ -82,73 +81,21 @@ teardown() {
 
 # --- JAIL variable exports ---
 
-@test "mysql - JAIL_START_EXTRA is empty" {
+@test "mysql - declares no jail extras" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "mysql - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "mysql - JAIL_FSTAB is empty" {
   assert_equal "$JAIL_FSTAB" ""
 }
 
-# --- Function existence ---
-
-@test "mysql - defines install_db_server" {
-  run type install_db_server
-  assert_success
-}
-
-@test "mysql - defines install_mysql" {
-  run type install_mysql
-  assert_success
-}
-
-@test "mysql - defines install_mariadb" {
-  run type install_mariadb
-  assert_success
-}
-
-@test "mysql - defines configure_mysql" {
-  run type configure_mysql
-  assert_success
-}
-
-@test "mysql - defines start_mysql" {
-  run type start_mysql
-  assert_success
-}
-
-@test "mysql - defines test_mysql" {
-  run type test_mysql
-  assert_success
-}
-
-@test "mysql - defines write_pass_to_conf" {
-  run type write_pass_to_conf
-  assert_success
-}
-
-@test "mysql - defines configure_mysql_keys" {
-  run type configure_mysql_keys
-  assert_success
-}
-
-@test "mysql - defines configure_mysql_root_password" {
-  run type configure_mysql_root_password
-  assert_success
-}
-
-@test "mysql - defines migrate_mysql_dbs" {
-  run type migrate_mysql_dbs
-  assert_success
-}
-
-@test "mysql - defines check_mysql_native_passwords" {
-  run type check_mysql_native_passwords
-  assert_success
+@test "mysql - defines the functions the provisioner calls" {
+  local _fn
+  for _fn in install_db_server install_mysql install_mariadb configure_mysql \
+             start_mysql test_mysql write_pass_to_conf configure_mysql_keys \
+             configure_mysql_root_password migrate_mysql_dbs \
+             check_mysql_native_passwords; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
 # --- configure_mysql outcomes (verified against the post-setup_file my.cnf) ---
@@ -200,17 +147,11 @@ EOF
   [ -f "$STAGE_MNT/usr/local/etc/newsyslog.conf.d/mysql.conf" ]
 }
 
-@test "mysql - configure enables mysql service via sysrc" {
+@test "mysql - configure enables the service and points it at /data/db" {
   stage_sysrc() { echo "SYSRC:$*"; }
   run configure_mysql
   assert_success
   assert_output --partial "SYSRC:mysql_enable=YES"
-}
-
-@test "mysql - configure sets mysql_dbdir via sysrc" {
-  stage_sysrc() { echo "SYSRC:$*"; }
-  run configure_mysql
-  assert_success
   assert_output --partial "SYSRC:mysql_dbdir=/data/db"
 }
 

--- a/test/provision/postfix.bats
+++ b/test/provision/postfix.bats
@@ -1,12 +1,17 @@
 #!/usr/bin/env bats
 # Functional tests for provision/postfix.sh
 
+setup_file() {
+  export POSTFIX_FNS="$BATS_FILE_TMPDIR/postfix_fns_only.sh"
+  sed '/^base_snapshot_exists/,$d' \
+    "$BATS_TEST_DIRNAME/../../provision/postfix.sh" > "$POSTFIX_FNS"
+}
+
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d /tmp/mt6pfXXXXXX)
+  export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
 
   export ZFS_DATA_MNT="$STAGE_MNT/data"
@@ -37,19 +42,11 @@ smtp      inet  n       -       n       -       -       smtpd
 pickup    unix  n       -       n       60      1       pickup
 EOF
 
-  # source the function definitions only; the execution block at the bottom
-  # provisions a jail
-  sed '/^base_snapshot_exists/,$d' "$BATS_TEST_DIRNAME/../../provision/postfix.sh" \
-    > "$STAGE_MNT/postfix-functions.sh"
   # shellcheck source=/dev/null
-  . "$STAGE_MNT/postfix-functions.sh"
+  . "$POSTFIX_FNS"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
-}
-
-@test "enable_postfix_submission uncomments the submission service block" {
+@test "enable_postfix_submission uncomments the submission and smtps blocks" {
   enable_postfix_submission "$MASTER_CF"
 
   run cat "$MASTER_CF"
@@ -57,18 +54,11 @@ teardown() {
   assert_line "submission inet n       -       n       -       -       smtpd"
   assert_line "  -o syslog_name=postfix/submission"
   assert_line "  -o smtpd_tls_security_level=encrypt"
-}
-
-@test "enable_postfix_submission uncomments the smtps service block" {
-  enable_postfix_submission "$MASTER_CF"
-
-  run cat "$MASTER_CF"
-  assert_success
   assert_line "smtps     inet  n       -       n       -       -       smtpd"
   assert_line "  -o smtpd_tls_wrappermode=yes"
 }
 
-@test "enable_postfix_submission leaves unrelated commented services alone" {
+@test "enable_postfix_submission leaves the rest of master.cf alone" {
   enable_postfix_submission "$MASTER_CF"
 
   run cat "$MASTER_CF"
@@ -76,13 +66,7 @@ teardown() {
   assert_line "#smtp      inet  n       -       n       -       1       postscreen"
   assert_line "smtp      inet  n       -       n       -       -       smtpd"
   assert_line "pickup    unix  n       -       n       60      1       pickup"
-}
-
-@test "enable_postfix_submission leaves non-option text commented" {
-  enable_postfix_submission "$MASTER_CF"
-
-  run cat "$MASTER_CF"
-  assert_success
+  # prose in the comment block is not an -o option to uncomment
   assert_line "#     Instead of specifying complex smtpd_<xxx>_restrictions here,"
 }
 

--- a/test/provision/redis.bats
+++ b/test/provision/redis.bats
@@ -1,19 +1,23 @@
 #!/usr/bin/env bats
 # Functional tests for provision/redis.sh
-# redis.sh uses `set -e`; configure_redis uses `sed -i.bak` (GNU-compatible).
-# We pre-create a stub redis.conf so configure_redis succeeds.
+#
+# setup_file sources redis.sh once, executing install and configure against
+# $BATS_FILE_TMPDIR. Tests read what that run produced; only the tests that
+# call a function with its own stubs pay to source the definitions.
 
-setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
+setup_file() {
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export REDIS_CONF="$STAGE_MNT/usr/local/etc/redis.conf"
+  export REDIS_FNS="$BATS_FILE_TMPDIR/redis_fns_only.sh"
 
-  # Pre-create directories and stub redis.conf so configure_redis can run
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/redis.sh" > "$REDIS_FNS"
+
+  # configure_redis edits redis.conf in place, so it has to exist first
   mkdir -p "$STAGE_MNT/usr/local/etc"
-  cat > "$STAGE_MNT/usr/local/etc/redis.conf" <<'EOF'
+  cat > "$REDIS_CONF" <<'EOF'
 stop-writes-on-bgsave-error yes
 dir /var/db/redis/
 # syslog-enabled no
@@ -26,114 +30,80 @@ EOF
   . "$BATS_TEST_DIRNAME/../../provision/redis.sh"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
+setup() {
+  load '../test_helper/load'
 }
 
-# --- JAIL variable exports ---
+load_redis_fns() {
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=/dev/null
+  . "$REDIS_FNS"
+}
 
-@test "redis - JAIL_START_EXTRA is empty (no special capabilities)" {
+@test "redis - declares no jail extras" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "redis - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "redis - JAIL_FSTAB is empty" {
   assert_equal "$JAIL_FSTAB" ""
 }
 
-# --- Function existence ---
-
-@test "redis - defines install_redis" {
-  run type install_redis
-  assert_success
-}
-
-@test "redis - defines configure_redis" {
-  run type configure_redis
-  assert_success
-}
-
-@test "redis - defines start_redis" {
-  run type start_redis
-  assert_success
-}
-
-@test "redis - defines test_redis" {
-  run type test_redis
-  assert_success
+@test "redis - defines the jail lifecycle functions" {
+  load_redis_fns
+  local _fn
+  for _fn in install_redis configure_redis start_redis test_redis; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
 # --- configure_redis outcomes ---
 
-@test "redis - configure disables stop-writes-on-bgsave-error" {
-  run grep "stop-writes-on-bgsave-error" "$STAGE_MNT/usr/local/etc/redis.conf"
+@test "redis - configure rewrites redis.conf for the jail" {
+  run grep "stop-writes-on-bgsave-error" "$REDIS_CONF"
   assert_output --partial "no"
   refute_output --partial "yes"
-}
 
-@test "redis - configure sets data dir to /data/db/" {
-  run grep "^dir" "$STAGE_MNT/usr/local/etc/redis.conf"
+  run grep "^dir" "$REDIS_CONF"
   assert_output --partial "/data/db/"
-}
 
-@test "redis - configure enables syslog" {
-  run grep "syslog-enabled" "$STAGE_MNT/usr/local/etc/redis.conf"
+  run grep "syslog-enabled" "$REDIS_CONF"
   assert_output --partial "yes"
-}
 
-@test "redis - configure disables protected-mode" {
-  run grep "^protected-mode" "$STAGE_MNT/usr/local/etc/redis.conf"
+  # the jail's own address is the only one it answers on
+  run grep "^protected-mode" "$REDIS_CONF"
   assert_output --partial "no"
-}
-
-@test "redis - configure comments out bind directive" {
-  run grep "^#bind" "$STAGE_MNT/usr/local/etc/redis.conf"
+  run grep "^#bind" "$REDIS_CONF"
   assert_success
 }
 
-@test "redis - configure creates newsyslog rotation config" {
-  [ -f "$STAGE_MNT/usr/local/etc/newsyslog.conf.d/redis.conf" ]
-}
-
-@test "redis - configure creates data subdirectories" {
+@test "redis - configure creates the data directories and log rotation" {
   [ -d "$STAGE_MNT/data/db" ]
   [ -d "$STAGE_MNT/data/log" ]
   [ -d "$STAGE_MNT/data/etc" ]
+  [ -f "$STAGE_MNT/usr/local/etc/newsyslog.conf.d/redis.conf" ]
 }
 
-# --- install_redis behaviour ---
+# --- install / start / test behaviour ---
 
 @test "redis - install uses redis package" {
+  load_redis_fns
   stage_pkg_install() { echo "PKG:$*"; }
   run install_redis
   assert_success
   assert_output --partial "PKG:redis"
 }
 
-# --- start_redis behaviour ---
-
-@test "redis - start enables redis service" {
+@test "redis - start enables the service and starts it" {
+  load_redis_fns
   stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
-  run start_redis
-  assert_success
-  assert_output --partial "SYSRC:redis_enable=YES"
-}
-
-@test "redis - start calls service redis start" {
-  stage_sysrc() { :; }
   stage_exec()  { echo "EXEC:$*"; }
   run start_redis
   assert_success
+  assert_output --partial "SYSRC:redis_enable=YES"
   assert_output --partial "EXEC:service redis start"
 }
 
-# --- test_redis behaviour ---
-
 @test "redis - test checks port 6379" {
+  load_redis_fns
   stage_listening() { echo "PORT:$*"; }
   run test_redis
   assert_success

--- a/test/provision/roundcube.bats
+++ b/test/provision/roundcube.bats
@@ -1,12 +1,17 @@
 #!/usr/bin/env bats
 # Functional tests for provision/roundcube.sh
 
+setup_file() {
+  export ROUNDCUBE_FNS="$BATS_FILE_TMPDIR/roundcube_fns_only.sh"
+  sed '/^tell_settings ROUNDCUBE$/,$d' \
+    "$BATS_TEST_DIRNAME/../../provision/roundcube.sh" > "$ROUNDCUBE_FNS"
+}
+
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d /tmp/mt6rcXXXXXX)
+  export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
 
   export ZFS_DATA_MNT="$STAGE_MNT/data"
@@ -17,16 +22,8 @@ setup() {
   NGINX_CONF="$ZFS_DATA_MNT/roundcube/etc/nginx/server.d/roundcube.conf"
   mkdir -p "$(dirname "$NGINX_CONF")"
 
-  # source the function definitions only; the execution block at the bottom
-  # provisions a jail
-  sed '/^tell_settings ROUNDCUBE$/,$d' "$BATS_TEST_DIRNAME/../../provision/roundcube.sh" \
-    > "$STAGE_MNT/roundcube-functions.sh"
   # shellcheck source=/dev/null
-  . "$STAGE_MNT/roundcube-functions.sh"
-}
-
-teardown() {
-  rm -rf "$STAGE_MNT"
+  . "$ROUNDCUBE_FNS"
 }
 
 @test "migrate_roundcube_nginx_conf retires a pre-1.7 server block" {

--- a/test/provision/rspamd.bats
+++ b/test/provision/rspamd.bats
@@ -1,142 +1,98 @@
 #!/usr/bin/env bats
 # Functional tests for provision/rspamd.sh
+#
+# setup_file sources rspamd.sh once, executing install/configure/start/test
+# against $BATS_FILE_TMPDIR. Tests read what that run produced; only the tests
+# that call a function with its own stubs pay to source the definitions.
 
-setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
+setup_file() {
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
+  export RSPAMD_ETC="$STAGE_MNT/usr/local/etc/rspamd"
+  export RSPAMD_FNS="$BATS_FILE_TMPDIR/rspamd_fns_only.sh"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
 
-  # Pre-create the rspamd config tree that configure_rspamd expects
-  mkdir -p "$STAGE_MNT/usr/local/etc/rspamd"
-  mkdir -p "$STAGE_MNT/etc"
+  local _script="$BATS_TEST_DIRNAME/../../provision/rspamd.sh"
+
+  # everything from tell_settings on is the execution block
+  awk '/^tell_settings/{exit} {print}' "$_script" > "$RSPAMD_FNS"
+
+  mkdir -p "$RSPAMD_ETC" "$STAGE_MNT/etc"
 
   # shellcheck source=/dev/null
-  . "$BATS_TEST_DIRNAME/../../provision/rspamd.sh"
+  . "$_script"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
+setup() {
+  load '../test_helper/load'
 }
 
-# --- JAIL variable exports ---
+load_rspamd_fns() {
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=/dev/null
+  . "$RSPAMD_FNS"
+}
 
-@test "rspamd - JAIL_START_EXTRA is empty" {
+@test "rspamd - declares no jail extras, RSPAMD_ETC lives under STAGE_MNT" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "rspamd - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "rspamd - JAIL_FSTAB is empty" {
   assert_equal "$JAIL_FSTAB" ""
-}
-
-# --- RSPAMD_ETC points into STAGE_MNT ---
-
-@test "rspamd - RSPAMD_ETC is under STAGE_MNT" {
   assert_equal "$RSPAMD_ETC" "$STAGE_MNT/usr/local/etc/rspamd"
 }
 
-# --- Function existence ---
-
-@test "rspamd - defines install_rspamd" {
-  run type install_rspamd
-  assert_success
+@test "rspamd - defines the jail lifecycle functions" {
+  load_rspamd_fns
+  local _fn
+  for _fn in install_rspamd configure_rspamd start_rspamd test_rspamd; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
-@test "rspamd - defines configure_rspamd" {
-  run type configure_rspamd
-  assert_success
-}
-
-@test "rspamd - defines start_rspamd" {
-  run type start_rspamd
-  assert_success
-}
-
-@test "rspamd - defines test_rspamd" {
-  run type test_rspamd
-  assert_success
-}
-
-# --- configure_rspamd filesystem outcomes ---
-
-@test "rspamd - configure creates local.d directory" {
+@test "rspamd - configure creates the config directories" {
   [ -d "$RSPAMD_ETC/local.d" ]
-}
-
-@test "rspamd - configure creates override.d directory" {
   [ -d "$RSPAMD_ETC/override.d" ]
 }
 
-@test "rspamd - configure_enable writes enabled=true for mxcheck" {
-  run cat "$RSPAMD_ETC/local.d/mxcheck.conf"
-  assert_output --partial "enabled = true;"
+@test "rspamd - configure_enable writes enabled=true for each module" {
+  local _mod
+  for _mod in mxcheck url_reputation url_tags; do
+    run cat "$RSPAMD_ETC/local.d/$_mod.conf"
+    assert_output --partial "enabled = true;"
+  done
 }
 
-@test "rspamd - configure_enable writes enabled=true for url_reputation" {
-  run cat "$RSPAMD_ETC/local.d/url_reputation.conf"
-  assert_output --partial "enabled = true;"
-}
-
-@test "rspamd - configure_enable writes enabled=true for url_tags" {
-  run cat "$RSPAMD_ETC/local.d/url_tags.conf"
-  assert_output --partial "enabled = true;"
-}
-
-# --- configure_logging ---
-
-@test "rspamd - configure_logging writes syslog config when RSPAMD_SYSLOG=1" {
-  _captured=""
-  store_config() { _captured=$(cat -); }
+@test "rspamd - configure_logging accepts RSPAMD_SYSLOG=1" {
+  load_rspamd_fns
+  store_config() { cat - > /dev/null; }
   RSPAMD_SYSLOG=1 run configure_logging
   assert_success
 }
 
-# --- install_rspamd behaviour ---
-
-@test "rspamd - install uses rspamd package" {
+@test "rspamd - install uses the rspamd package" {
+  load_rspamd_fns
   stage_pkg_install() { echo "PKG:$*"; }
   run install_rspamd
   assert_success
   assert_output --partial "PKG:rspamd"
 }
 
-# --- start_rspamd behaviour ---
-
-@test "rspamd - start enables rspamd service" {
+@test "rspamd - start enables the service and starts it" {
+  load_rspamd_fns
   stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
-  run start_rspamd
-  assert_success
-  assert_output --partial "SYSRC:rspamd_enable=YES"
-}
-
-@test "rspamd - start calls service rspamd start" {
-  stage_sysrc() { :; }
   stage_exec()  { echo "EXEC:$*"; }
   run start_rspamd
   assert_success
+  assert_output --partial "SYSRC:rspamd_enable=YES"
   assert_output --partial "EXEC:service rspamd start"
 }
 
-# --- test_rspamd behaviour ---
-
-@test "rspamd - test runs configtest" {
+@test "rspamd - test runs configtest and checks port 11334" {
+  load_rspamd_fns
   stage_exec()      { echo "EXEC:$*"; }
-  stage_listening() { :; }
-  run test_rspamd
-  assert_output --partial "EXEC:/usr/local/bin/rspamadm configtest"
-}
-
-@test "rspamd - test checks port 11334" {
-  stage_exec()      { :; }
   stage_listening() { echo "PORT:$*"; }
   run test_rspamd
   assert_success
+  assert_output --partial "EXEC:/usr/local/bin/rspamadm configtest"
   assert_output --partial "PORT:11334"
 }

--- a/test/provision/spamassassin.bats
+++ b/test/provision/spamassassin.bats
@@ -1,111 +1,86 @@
 #!/usr/bin/env bats
 # Functional tests for provision/spamassassin.sh
+#
+# setup_file sources spamassassin.sh once, executing install and configure
+# against $BATS_FILE_TMPDIR. Tests read what that run produced; only the tests
+# that call a function with its own stubs pay to source the definitions.
 
-setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
+setup_file() {
   export MT6_TEST_ENV=1
-  # Use a dot-free path: configure_spamassassin uses `cut -f1-2 -d.` to derive
-  # the target filename from *.sample files; dots in parent dirs break that.
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d /tmp/mt6saXXXXXX)
+  # configure_spamassassin derives target filenames from *.sample with
+  # `cut -f1-2 -d.`, so no parent directory may contain a dot
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
 
-  # Redirect ZFS data/jail mounts to temp tree so no real paths are touched
   export ZFS_DATA_MNT="$STAGE_MNT/data"
   export ZFS_JAIL_MNT="$STAGE_MNT/jails"
   export ZFS_DATA_VOL="zroot${ZFS_DATA_MNT}"
   export ZFS_JAIL_VOL="zroot${ZFS_JAIL_MNT}"
 
-  # Skip MySQL sub-install (requires live DB connection)
+  # the MySQL sub-install wants a live DB
   export TOASTER_MYSQL=0
 
-  # Pre-create directories that provision steps expect to exist before running
-  mkdir -p "$STAGE_MNT/etc/razor"
-  mkdir -p "$STAGE_MNT/usr/local/etc/mail"
-  mkdir -p "$STAGE_MNT/usr/local/etc/newsyslog.conf.d"
-  mkdir -p "$STAGE_MNT/data/spamassassin"
+  export SA_SCRIPT="$BATS_TEST_DIRNAME/../../provision/spamassassin.sh"
+  export SA_FNS="$BATS_FILE_TMPDIR/spamassassin_fns_only.sh"
+  awk '/^base_snapshot_exists/{exit} {print}' "$SA_SCRIPT" > "$SA_FNS"
 
-  # razor-agent.conf must exist or install_spamassassin_razor aborts
+  mkdir -p "$STAGE_MNT/etc/razor" "$STAGE_MNT/usr/local/etc/mail" \
+    "$STAGE_MNT/usr/local/etc/newsyslog.conf.d" "$ZFS_DATA_MNT/spamassassin/etc" \
+    "$STAGE_MNT/usr/ports/mail/spamassassin"
+
+  # install_spamassassin_razor aborts without it
   echo "logfile = razor-agent.log" > "$STAGE_MNT/etc/razor/razor-agent.conf"
 
-  # install_spamassassin_port checks for a ports tree before building
-  mkdir -p "$STAGE_MNT/usr/ports/mail/spamassassin"
-
-  # local.cf.sample seed: configure_spamassassin globs *.sample and uses
-  # `cut -f1-2 -d.` to derive the target name, so it needs to exist.
-  mkdir -p "$STAGE_MNT/data/spamassassin/etc"
-  touch "$STAGE_MNT/data/spamassassin/etc/local.cf.sample"
+  touch "$ZFS_DATA_MNT/spamassassin/etc/local.cf.sample"
 
   # shellcheck source=/dev/null
-  . "$BATS_TEST_DIRNAME/../../provision/spamassassin.sh"
+  . "$SA_SCRIPT"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
+setup() {
+  load '../test_helper/load'
+  SA_ETC="$ZFS_DATA_MNT/spamassassin/etc"
+}
+
+load_sa_fns() {
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=/dev/null
+  . "$SA_FNS"
 }
 
 # --- JAIL variable exports ---
 
-@test "spamassassin - JAIL_START_EXTRA is empty" {
+@test "spamassassin - declares no jail extras beyond the GeoIP mount" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "spamassassin - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "spamassassin - JAIL_FSTAB contains GeoIP nullfs mount when geoip present" {
-  assert_equal "$JAIL_FSTAB" "$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0"
+  assert_equal "$JAIL_FSTAB" \
+    "$ZFS_DATA_MNT/geoip/db $ZFS_JAIL_MNT/spamassassin/usr/local/share/GeoIP nullfs rw 0 0"
 }
 
 @test "spamassassin - JAIL_FSTAB empty when geoip dataset absent" {
-  # Re-run only the fstab guard from the provision script with the geoip
-  # dataset reported missing; the mount must not be declared.
   zfs_filesystem_exists() { return 1; }
   JAIL_FSTAB="preset"
-  eval "$(sed -n '/^export JAIL_FSTAB=""$/,/^fi$/p' \
-    "$BATS_TEST_DIRNAME/../../provision/spamassassin.sh")"
+  eval "$(sed -n '/^export JAIL_FSTAB=""$/,/^fi$/p' "$SA_SCRIPT")"
   assert_equal "$JAIL_FSTAB" ""
 }
 
-# --- Function existence ---
-
-@test "spamassassin - defines install_spamassassin" {
-  run type install_spamassassin
-  assert_success
-}
-
-@test "spamassassin - defines configure_spamassassin" {
-  run type configure_spamassassin
-  assert_success
-}
-
-@test "spamassassin - defines start_spamassassin" {
-  run type start_spamassassin
-  assert_success
-}
-
-@test "spamassassin - defines test_spamassassin" {
-  run type test_spamassassin
-  assert_success
+@test "spamassassin - defines the jail lifecycle functions" {
+  load_sa_fns
+  local _fn
+  for _fn in install_spamassassin configure_spamassassin start_spamassassin \
+             test_spamassassin; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
 # --- install filesystem outcomes ---
 
-@test "spamassassin - install creates GeoIP share directory" {
+@test "spamassassin - install creates the GeoIP and data directories" {
   [ -d "$STAGE_MNT/usr/local/share/GeoIP" ]
-}
-
-@test "spamassassin - install creates data/spamassassin/etc directory" {
   [ -d "$ZFS_DATA_MNT/spamassassin/etc" ]
-}
-
-@test "spamassassin - install creates data/spamassassin/var directory" {
   [ -d "$ZFS_DATA_MNT/spamassassin/var" ]
 }
-
-# --- install_spamassassin_razor outcomes ---
 
 @test "spamassassin - razor config gets logfile path set" {
   run grep "^logfile" "$STAGE_MNT/etc/razor/razor-agent.conf"
@@ -114,42 +89,24 @@ teardown() {
 
 # --- configure_spamassassin filesystem outcomes ---
 
-@test "spamassassin - configure writes local.pre with TextCat plugin" {
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/local.pre"
+@test "spamassassin - configure writes local.pre with the plugins" {
+  run cat "$SA_ETC/local.pre"
   assert_output --partial "Mail::SpamAssassin::Plugin::TextCat"
-}
-
-@test "spamassassin - configure writes local.pre with ASN plugin" {
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/local.pre"
   assert_output --partial "Mail::SpamAssassin::Plugin::ASN"
-}
-
-@test "spamassassin - configure writes local.pre with DMARC plugin" {
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/local.pre"
   assert_output --partial "Mail::SpamAssassin::Plugin::DMARC"
 }
 
-@test "spamassassin - configure writes local.cf with report_safe 0" {
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/local.cf"
+@test "spamassassin - configure writes local.cf with the scanner settings" {
+  run cat "$SA_ETC/local.cf"
   assert_output --partial "report_safe"
-}
-
-@test "spamassassin - configure writes local.cf enabling razor2" {
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/local.cf"
   assert_output --partial "use_razor2"
-}
-
-@test "spamassassin - configure writes local.cf enabling DCC" {
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/local.cf"
   assert_output --partial "use_dcc"
 }
 
 # --- configure_geoip / RelayCountry outcomes ---
 
 @test "spamassassin - configure_geoip enables RelayCountry when geoip present" {
-  # setup() sources the script with the stub zfs_filesystem_exists returning 0,
-  # so configure_geoip has already written relaycountry.pre.
-  run cat "$ZFS_DATA_MNT/spamassassin/etc/relaycountry.pre"
+  run cat "$SA_ETC/relaycountry.pre"
   assert_success
   assert_output --partial "loadplugin Mail::SpamAssassin::Plugin::RelayCountry"
   assert_output --partial "country_db_type"
@@ -157,7 +114,10 @@ teardown() {
 }
 
 @test "spamassassin - configure_geoip removes RelayCountry when geoip absent" {
-  _sa_etc="$ZFS_DATA_MNT/spamassassin/etc"
+  load_sa_fns
+  # configure_spamassassin leaves _sa_etc set for it; work on a private copy so
+  # the file the previous test reads survives
+  _sa_etc="$BATS_TEST_TMPDIR/etc"
   mkdir -p "$_sa_etc"
   echo "loadplugin Mail::SpamAssassin::Plugin::RelayCountry" > "$_sa_etc/relaycountry.pre"
   zfs_filesystem_exists() { return 1; }
@@ -166,46 +126,32 @@ teardown() {
   [ ! -f "$_sa_etc/relaycountry.pre" ]
 }
 
-# --- install_spamassassin behaviour ---
+# --- install / start / test behaviour ---
 
 @test "spamassassin - install uses p5-Mail-SPF package" {
+  load_sa_fns
   stage_pkg_install() { echo "PKG:$*"; }
   stage_exec()        { :; }
   run install_spamassassin
   assert_output --partial "PKG:p5-Mail-SPF"
 }
 
-# --- start_spamassassin behaviour ---
-
-@test "spamassassin - start enables spamd service" {
+@test "spamassassin - start enables spamd and starts sa-spamd" {
+  load_sa_fns
   stage_sysrc() { echo "SYSRC:$*"; }
-  stage_exec()  { :; }
-  run start_spamassassin
-  assert_success
-  assert_output --partial "SYSRC:spamd_enable=YES"
-}
-
-@test "spamassassin - start calls service sa-spamd start" {
-  stage_sysrc() { :; }
   stage_exec()  { echo "EXEC:$*"; }
   run start_spamassassin
   assert_success
+  assert_output --partial "SYSRC:spamd_enable=YES"
   assert_output --partial "EXEC:service sa-spamd start"
 }
 
-# --- test_spamassassin behaviour ---
-
-@test "spamassassin - test checks for running perl process" {
+@test "spamassassin - test checks the perl process and port 783" {
+  load_sa_fns
   stage_test_running() { echo "RUNNING:$*"; }
-  stage_listening()    { :; }
-  run test_spamassassin
-  assert_output --partial "RUNNING:perl"
-}
-
-@test "spamassassin - test checks port 783" {
-  stage_test_running() { :; }
   stage_listening()    { echo "PORT:$*"; }
   run test_spamassassin
   assert_success
+  assert_output --partial "RUNNING:perl"
   assert_output --partial "PORT:783"
 }

--- a/test/provision/statsd.bats
+++ b/test/provision/statsd.bats
@@ -1,17 +1,20 @@
 #!/usr/bin/env bats
 # Functional tests for provision/statsd.sh
+#
+# setup_file sources statsd.sh once against $BATS_FILE_TMPDIR, through the stub
+# mail-toaster.sh on PATH.
 
-setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
-
+setup_file() {
   export MT6_TEST_ENV=1
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
+  export STAGE_MNT="$BATS_FILE_TMPDIR/stage"
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  export STATSD_FNS="$BATS_FILE_TMPDIR/statsd_fns_only.sh"
 
-  # Pre-create dirs and stub config.js so install_statsd can run
-  mkdir -p "$STAGE_MNT/var/lib"
-  mkdir -p "$STAGE_MNT/usr/local/share/statsd/lib"
+  awk '/^base_snapshot_exists/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/statsd.sh" > "$STATSD_FNS"
+
+  # install_statsd edits config.js in place, so it has to exist first
+  mkdir -p "$STAGE_MNT/var/lib" "$STAGE_MNT/usr/local/share/statsd/lib"
   printf ' process.EventEmitter = require("events").EventEmitter;\n' \
     > "$STAGE_MNT/usr/local/share/statsd/lib/config.js"
 
@@ -19,58 +22,34 @@ setup() {
   . "$BATS_TEST_DIRNAME/../../provision/statsd.sh"
 }
 
-teardown() {
-  rm -rf "$STAGE_MNT"
+setup() {
+  load '../test_helper/load'
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=/dev/null
+  . "$STATSD_FNS"
 }
 
-# --- JAIL variable exports ---
-
-@test "statsd - JAIL_START_EXTRA is empty" {
+@test "statsd - declares no jail extras" {
   assert_equal "$JAIL_START_EXTRA" ""
-}
-
-@test "statsd - JAIL_CONF_EXTRA is empty" {
   assert_equal "$JAIL_CONF_EXTRA" ""
-}
-
-@test "statsd - JAIL_FSTAB is empty" {
   assert_equal "$JAIL_FSTAB" ""
 }
 
-# --- Function existence ---
-
-@test "statsd - defines install_statsd" {
-  run type install_statsd
-  assert_success
+@test "statsd - defines the jail lifecycle functions" {
+  local _fn
+  for _fn in install_statsd start_statsd test_statsd; do
+    run type "$_fn"
+    assert_success
+  done
 }
 
-@test "statsd - defines start_statsd" {
-  run type start_statsd
-  assert_success
-}
-
-@test "statsd - defines test_statsd" {
-  run type test_statsd
-  assert_success
-}
-
-# --- install_statsd behaviour ---
-
-@test "statsd - install uses statsd package" {
+@test "statsd - install uses the statsd package and enables it" {
   stage_pkg_install() { echo "PKG:$*"; }
-  stage_sysrc()       { :; }
-  run install_statsd
-  assert_output --partial "PKG:statsd"
-}
-
-@test "statsd - install enables statsd via sysrc" {
-  stage_pkg_install() { return 0; }
   stage_sysrc()       { echo "SYSRC:$*"; }
   run install_statsd
+  assert_output --partial "PKG:statsd"
   assert_output --partial "SYSRC:statsd_enable=YES"
 }
-
-# --- start_statsd behaviour ---
 
 @test "statsd - start calls service statsd start" {
   stage_exec() { echo "EXEC:$*"; }
@@ -78,8 +57,6 @@ teardown() {
   assert_success
   assert_output --partial "EXEC:service statsd start"
 }
-
-# --- test_statsd behaviour ---
 
 @test "statsd - test checks statsd is running" {
   stage_test_running() { echo "RUNNING:$*"; }

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -76,15 +76,42 @@ seed_pkg_audit()           { :; }
 
 # Jail helpers
 jail_is_running()          { return 1; }
+# mirrors include/jail.sh, less the host(1) fallback for an unlisted jail
 get_jail_ip() {
-  local _name="$1" _idx=1
+  local _start=${JAIL_NET_START:-1} _octet
+
+  case "$1" in
+    syslog) echo "$JAIL_NET_PREFIX.$_start";         return ;;
+    base*)  echo "$JAIL_NET_PREFIX.$((_start + 1))"; return ;;
+    stage)  echo "$JAIL_NET_PREFIX.254";             return ;;
+  esac
+
+  _octet="$_start"
   for _j in $JAIL_ORDERED_LIST; do
-    if [ "$_j" = "$_name" ]; then echo "$JAIL_NET_PREFIX.$_idx"; return 0; fi
-    _idx=$((_idx + 1))
+    if [ "$1" = "$_j" ]; then echo "$JAIL_NET_PREFIX.$_octet"; return; fi
+    _octet=$((_octet + 1))
   done
-  echo "172.16.15.1"
+
+  return 2
 }
-get_jail_ip6()             { echo "fd7a:e5cd:1fc1:c597:dead:beef:cafe:00fe"; }
+
+get_jail_ip6() {
+  local _start=${JAIL_NET_START:-1} _octet
+
+  case "$1" in
+    syslog) echo "$JAIL_NET6:$(dec_to_hex "$_start")";       return ;;
+    base*)  echo "$JAIL_NET6:$(dec_to_hex $((_start + 1)))"; return ;;
+    stage)  echo "$JAIL_NET6:$(dec_to_hex 254)";             return ;;
+  esac
+
+  _octet="$_start"
+  for _j in $JAIL_ORDERED_LIST; do
+    if [ "$1" = "$_j" ]; then echo "$JAIL_NET6:$(dec_to_hex "$_octet")"; return; fi
+    _octet=$((_octet + 1))
+  done
+
+  return 2
+}
 get_jail_data()            { echo "${ZFS_DATA_MNT}/$1"; }
 export MT6_ETC=${MT6_ETC:-"/etc/mail-toaster"}
 get_jail_host_etc()        { echo "${MT6_ETC}/$1"; }

--- a/test/provision/unifi.bats
+++ b/test/provision/unifi.bats
@@ -4,23 +4,24 @@
 # store_unifi_mongodb_dsn mints a credential and writes it to conf.d/, so every
 # test runs with MT6_CONF_DIR pointed at a tmpdir.
 
+setup_file() {
+  export UNIFI_FNS="$BATS_FILE_TMPDIR/unifi_fns_only.sh"
+  awk '/^store_unifi_mongodb_dsn$/{exit} {print}' \
+    "$BATS_TEST_DIRNAME/../../provision/unifi.sh" > "$UNIFI_FNS"
+}
+
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export MT6_TEST_ENV=1
   export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
-  export STAGE_MNT; STAGE_MNT=$(mktemp -d)
-  export ZFS_DATA_MNT; ZFS_DATA_MNT=$(mktemp -d)
-  export ZFS_JAIL_MNT; ZFS_JAIL_MNT=$(mktemp -d)
-  export MT6_CONF_DIR; MT6_CONF_DIR=$(mktemp -d)/conf.d
+  export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
+  export ZFS_DATA_MNT="$BATS_TEST_TMPDIR/data"
+  export ZFS_JAIL_MNT="$BATS_TEST_TMPDIR/jails"
+  export MT6_CONF_DIR="$BATS_TEST_TMPDIR/conf.d"
 
-  # Function definitions only; the execution block provisions a jail.
-  local _fns="$BATS_TEST_TMPDIR/unifi_fns_only.sh"
-  awk '/^store_unifi_mongodb_dsn$/{exit} {print}' \
-    "$BATS_TEST_DIRNAME/../../provision/unifi.sh" > "$_fns"
   # shellcheck source=/dev/null
-  . "$_fns"
+  . "$UNIFI_FNS"
 }
 
 @test "unifi - defines store_unifi_mongodb_dsn" {

--- a/test/provision/webmail.bats
+++ b/test/provision/webmail.bats
@@ -33,8 +33,7 @@ setup_file() {
 }
 
 setup() {
-  load '../test_helper/bats-support/load'
-  load '../test_helper/bats-assert/load'
+  load '../test_helper/load'
 
   export MT6_TEST_ENV=1
   export ZFS_DATA_MNT="$BATS_FILE_TMPDIR/data"

--- a/test/run.sh
+++ b/test/run.sh
@@ -5,6 +5,9 @@ if [ -n "$1" ]; then
     exit
 fi
 
+# One shellcheck run per directory. Handing it every file at once makes it
+# follow `. mail-toaster.sh` from each of the 70 provision scripts, which takes
+# 20s instead of 2s.
 echo "shellcheck *.sh"
 shellcheck ./*.sh
 
@@ -17,7 +20,13 @@ shellcheck include/*.sh
 echo "shellcheck provision/*.sh"
 shellcheck provision/*.sh
 
-bats test/*.bats
-bats test/include/*.bats
-bats test/provision/*.bats
-bats test/contrib/*.bats
+# bats --jobs needs GNU parallel. Files run concurrently, tests within a file
+# stay in order: they share the tree their setup_file built.
+BATS_JOBS=""
+if command -v parallel > /dev/null 2>&1; then
+    _cpus=$(sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
+    BATS_JOBS="--jobs $_cpus --no-parallelize-within-files"
+fi
+
+# shellcheck disable=SC2086
+bats $BATS_JOBS test/*.bats test/include/*.bats test/provision/*.bats test/contrib/*.bats

--- a/test/test_helper/load.bash
+++ b/test/test_helper/load.bash
@@ -1,0 +1,30 @@
+# bats-support and bats-assert in one load.
+#
+# Their own load.bash resolves each src file with $(dirname ...). Bats traps
+# DEBUG, which makes every subshell costly, and 15 of them per test is most of
+# a test's runtime. Parameter expansion resolves the same paths for free.
+
+_BATS_TEST_HELPER="${BASH_SOURCE[0]%/*}"
+
+# BATS_SAVED_PATH pins the PATH bats-support saw, so a test's own stubs cannot
+# redirect the utilities the assertions run
+BATS_SAVED_PATH="${BATS_SAVED_PATH-$PATH}"
+
+source "$_BATS_TEST_HELPER/bats-support/src/output.bash"
+source "$_BATS_TEST_HELPER/bats-support/src/error.bash"
+source "$_BATS_TEST_HELPER/bats-support/src/lang.bash"
+
+source "$_BATS_TEST_HELPER/bats-assert/src/assert.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/refute.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_equal.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_not_equal.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_success.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_failure.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_output.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/refute_output.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_line.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/refute_line.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/assert_regex.bash"
+source "$_BATS_TEST_HELPER/bats-assert/src/refute_regex.bash"
+
+unset _BATS_TEST_HELPER


### PR DESCRIPTION
- test: add test_helper/load.bash, one source pass for bats-support and bats-assert
- test: run the provision script once per file in setup_file, not once per test
- test: fold per-jail port, package and service checks into tables
- test: single pass for the jail-private setting check
- test: run.sh and CI run bats with --jobs when GNU parallel is installed
