### PR TITLE
Pr716

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 ## 2026-08
 
 - base: jails get minimal /etc/hosts w/IPv6
-- host: syslogd binds the jail IPv6 address, not just the IPv4
+- host: syslogd binds the jail IPv6 address when present
 - jail: rename get_jail_ip to get_jail_ip4
 - perf(test): source the assertion libraries once, scripts once per file
 - nginx: add nginx_listen(), emitting IPv4 and IPv6 listen directives

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@ refer to [https://github.com/msimerson/Mail-Toaster-6/commits/master](https://gi
 
 ## 2026-08
 
+- base: jails get minimal /etc/hosts w/IPv6
+- host: syslogd binds the jail IPv6 address, not just the IPv4
 - jail: rename get_jail_ip to get_jail_ip4
 - perf(test): source the assertion libraries once, scripts once per file
 - nginx: add nginx_listen(), emitting IPv4 and IPv6 listen directives

--- a/include/network.sh
+++ b/include/network.sh
@@ -109,9 +109,18 @@ EO_ACME_CRON
 
 install_minimal_hosts()
 {
+	local _hosts6=""
+
+	if jail_has_ip6; then
+		_hosts6="
+$(get_jail_ip6 dns) dns
+$(get_jail_ip6 syslog) syslog
+$(get_jail_ip6 bsd_cache) pkg vulnxml freebsd-update"
+	fi
+
 	store_config "$STAGE_MNT/etc/hosts" "append" <<EO_HOSTS
-$(get_jail_ip dns) dns
-$(get_jail_ip syslog) syslog
-$(get_jail_ip bsd_cache) pkg vulnxml freebsd-update
+$(get_jail_ip4 dns) dns
+$(get_jail_ip4 syslog) syslog
+$(get_jail_ip4 bsd_cache) pkg vulnxml freebsd-update$_hosts6
 EO_HOSTS
 }

--- a/include/network.sh
+++ b/include/network.sh
@@ -106,3 +106,11 @@ install_acme_sh()
 /usr/local/sbin/acme.sh --cron
 EO_ACME_CRON
 }
+
+install_minimal_hosts()
+{
+	store_config "$STAGE_MNT/etc/hosts" "append" <<EO_HOSTS
+$(get_jail_ip syslog) syslog
+$(get_jail_ip bsd_cache) pkg vulnxml freebsd-update
+EO_HOSTS
+}

--- a/include/network.sh
+++ b/include/network.sh
@@ -107,20 +107,25 @@ install_acme_sh()
 EO_ACME_CRON
 }
 
-install_minimal_hosts()
+hosts_entry()
 {
-	local _hosts6=""
+	local _has6="$1" _jail="$2"; shift 2
 
-	if jail_has_ip6; then
-		_hosts6="
-$(get_jail_ip6 dns) dns
-$(get_jail_ip6 syslog) syslog
-$(get_jail_ip6 bsd_cache) pkg vulnxml freebsd-update"
+	if [ "$_has6" = 1 ]; then
+		printf '%s %s\n' "$(get_jail_ip6 "$_jail")" "$*"
 	fi
 
-	store_config "$STAGE_MNT/etc/hosts" "append" <<EO_HOSTS
-$(get_jail_ip4 dns) dns
-$(get_jail_ip4 syslog) syslog
-$(get_jail_ip4 bsd_cache) pkg vulnxml freebsd-update$_hosts6
-EO_HOSTS
+	printf '%s %s\n' "$(get_jail_ip4 "$_jail")" "$*"
+}
+
+install_minimal_hosts()
+{
+	local _has6=0
+	if jail_has_ip6; then _has6=1; fi
+
+	{
+		hosts_entry "$_has6" dns dns
+		hosts_entry "$_has6" syslog syslog
+		hosts_entry "$_has6" bsd_cache pkg vulnxml freebsd-update
+	} | store_config "$STAGE_MNT/etc/hosts" "append"
 }

--- a/include/network.sh
+++ b/include/network.sh
@@ -110,6 +110,7 @@ EO_ACME_CRON
 install_minimal_hosts()
 {
 	store_config "$STAGE_MNT/etc/hosts" "append" <<EO_HOSTS
+$(get_jail_ip dns) dns
 $(get_jail_ip syslog) syslog
 $(get_jail_ip bsd_cache) pkg vulnxml freebsd-update
 EO_HOSTS

--- a/mail-toaster.sh
+++ b/mail-toaster.sh
@@ -279,6 +279,7 @@ create_staged_fs()
 
 	assure_ip6_addr_is_declared "$1"
 	stage_resolv_conf
+	install_minimal_hosts
 	for _dma_conf in "$STAGE_MNT/usr/local/etc/dma/dma.conf" "$STAGE_MNT/etc/dma/dma.conf"; do
 		if [ -f "$_dma_conf" ]; then
 			echo "MASQUERADE $1@$TOASTER_MAIL_DOMAIN" >> "$_dma_conf"

--- a/provision/base.sh
+++ b/provision/base.sh
@@ -199,9 +199,6 @@ configure_base()
 	tell_status "setting base jail timezone (to hosts)"
 	cp /etc/localtime "$BASE_MNT/etc"
 
-	tell_status "installing $BASE_MNT/etc/hosts"
-	cp /etc/hosts "$BASE_MNT/etc"
-
 	configure_make_conf
 
 	tell_status "adding base rc.conf settings"

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -298,7 +298,6 @@ EO_PRESTOP
 
 base_snapshot_exists || exit 1
 create_staged_fs dns
-install_minimal_hosts
 start_staged_jail dns
 install_unbound
 configure_unbound

--- a/provision/dns.sh
+++ b/provision/dns.sh
@@ -298,6 +298,7 @@ EO_PRESTOP
 
 base_snapshot_exists || exit 1
 create_staged_fs dns
+install_minimal_hosts
 start_staged_jail dns
 install_unbound
 configure_unbound

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -89,10 +89,12 @@ disable_ntpd()
 
 update_syslogd()
 {
-	local _bind6=""
-	if jail_has_ip6; then _bind6=" -b [$JAIL_NET6:1]"; fi
+	local _ip6=""
+	if jail_has_ip6; then
+		_ip6=" -b [$JAIL_NET6:1] -a [$JAIL_NET6:0]/112:*"
+	fi
 
-	local _sysflags="-b $JAIL_NET_PREFIX.1$_bind6 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* -a [$JAIL_NET6:0]/112:* -cc"
+	local _sysflags="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:*$_ip6 -cc"
 
 	if grep -q ^syslogd_flags /etc/rc.conf; then
 		tell_status "preserving syslogd_flags"

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -89,7 +89,10 @@ disable_ntpd()
 
 update_syslogd()
 {
-	local _sysflags="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* -a [$JAIL_NET6:0]/112:* -cc"
+	local _bind6=""
+	if jail_has_ip6; then _bind6=" -b [$JAIL_NET6:1]"; fi
+
+	local _sysflags="-b $JAIL_NET_PREFIX.1$_bind6 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* -a [$JAIL_NET6:0]/112:* -cc"
 
 	if grep -q ^syslogd_flags /etc/rc.conf; then
 		tell_status "preserving syslogd_flags"

--- a/provision/host.sh
+++ b/provision/host.sh
@@ -87,6 +87,22 @@ disable_ntpd()
 	fi
 }
 
+# values update_syslogd has generated over time, safe to replace on upgrade
+syslogd_flags_are_ours()
+{
+	local _v4="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:*"
+
+	case "$1" in
+		"$_v4 -cc") ;;
+		"$_v4 -a [$JAIL_NET6]/64:* -cc") ;;
+		"$_v4 -a [$JAIL_NET6]/112:* -cc") ;;
+		"$_v4 -a [$JAIL_NET6:0]/112:* -cc") ;;
+		"$_v4 -b [$JAIL_NET6:1] -a [$JAIL_NET6:0]/112:* -cc") ;;
+		"-b $JAIL_NET_PREFIX.1 -b [$JAIL_NET6:1] -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* -a [$JAIL_NET6:0]/112:* -cc") ;;
+		*) return 1 ;;
+	esac
+}
+
 update_syslogd()
 {
 	local _ip6=""
@@ -96,11 +112,15 @@ update_syslogd()
 
 	local _sysflags="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:*$_ip6 -cc"
 
-	if grep -q ^syslogd_flags /etc/rc.conf; then
+	local _current; _current=$(sysrc -n syslogd_flags 2>/dev/null)
+
+	if [ "$_current" = "$_sysflags" ]; then return; fi
+
+	if [ -n "$_current" ] && ! syslogd_flags_are_ours "$_current"; then
 		tell_status "preserving syslogd_flags"
 		echo "CAUTION: double check syslogd_flags in /etc/rc.conf"
 		echo "existing:"
-		grep ^syslogd_flags /etc/rc.conf
+		echo "syslogd_flags=$_current"
 		echo "desired:"
 		echo "syslogd_flags=$_sysflags"
 		return

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -786,6 +786,8 @@ setup_unprovision_tree() {
 
   run cat "$BATS_TEST_TMPDIR/rm.log"
   refute_output --regexp '(^| )/$'
+}
+
 # --- every jail resolves the names it needs before unbound answers ---
 
 setup_minimal_hosts() {

--- a/test/mail-toaster.bats
+++ b/test/mail-toaster.bats
@@ -786,4 +786,115 @@ setup_unprovision_tree() {
 
   run cat "$BATS_TEST_TMPDIR/rm.log"
   refute_output --regexp '(^| )/$'
+# --- every jail resolves the names it needs before unbound answers ---
+
+setup_minimal_hosts() {
+  export STAGE_MNT="$BATS_TEST_TMPDIR/stage"
+  mkdir -p "$STAGE_MNT/etc"
+  # what base.txz ships, via lib/libc/net/hosts
+  printf '::1\t\t\tlocalhost localhost.my.domain\n127.0.0.1\t\tlocalhost localhost.my.domain\n' \
+    > "$STAGE_MNT/etc/hosts"
+  tell_status() { :; }
+  get_public_ip6() { export PUBLIC_IP6=""; }
+}
+
+@test "install_minimal_hosts - adds the names a jail needs to bootstrap" {
+  setup_minimal_hosts
+
+  install_minimal_hosts
+
+  run cat "$STAGE_MNT/etc/hosts"
+  assert_output --partial "$(get_jail_ip4 dns) dns"
+  assert_output --partial "$(get_jail_ip4 syslog) syslog"
+  assert_output --partial "$(get_jail_ip4 bsd_cache) pkg vulnxml freebsd-update"
+}
+
+# it appends; overwriting would take localhost with it
+@test "install_minimal_hosts - keeps the localhost entries base ships" {
+  setup_minimal_hosts
+
+  install_minimal_hosts
+
+  run cat "$STAGE_MNT/etc/hosts"
+  assert_output --partial "127.0.0.1"
+  assert_output --partial "::1"
+  assert_line --regexp '^127\.0\.0\.1[[:space:]]+localhost'
+}
+
+@test "create_staged_fs - every jail gets the minimal hosts, not just dns" {
+  setup_minimal_hosts
+  export ZFS_JAIL_VOL="zroot/jails" ZFS_DATA_VOL="zroot/data" BASE_SNAP="zroot/jails/base@p0"
+  cleanup_staged_fs()           { :; }
+  zfs()                         { :; }
+  stage_sysrc()                 { :; }
+  assure_ip6_addr_is_declared() { :; }
+  stage_resolv_conf()           { :; }
+  zfs_create_fs()               { :; }
+  adopt_jail_host_etc()         { :; }
+  install_fstab()               { :; }
+  install_pfrule()              { :; }
+
+  create_staged_fs myjail > /dev/null
+
+  run cat "$STAGE_MNT/etc/hosts"
+  assert_output --partial "$(get_jail_ip4 dns) dns"
+  assert_output --partial "127.0.0.1"
+}
+
+@test "install_minimal_hosts - a jail with IPv6 gets those addresses too" {
+  setup_minimal_hosts
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  install_minimal_hosts
+
+  run cat "$STAGE_MNT/etc/hosts"
+  assert_output --partial "$(get_jail_ip6 dns) dns"
+  assert_output --partial "$(get_jail_ip6 bsd_cache) pkg vulnxml freebsd-update"
+}
+
+@test "install_minimal_hosts - syslog gets both families" {
+  setup_minimal_hosts
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  install_minimal_hosts
+
+  run grep -c ' syslog$' "$STAGE_MNT/etc/hosts"
+  assert_output "2"
+
+  run cat "$STAGE_MNT/etc/hosts"
+  assert_output --partial "$(get_jail_ip4 syslog) syslog"
+  assert_output --partial "$(get_jail_ip6 syslog) syslog"
+}
+
+@test "install_minimal_hosts - a jail without IPv6 gets no v6 entries" {
+  setup_minimal_hosts
+  get_public_ip6() { export PUBLIC_IP6=""; }
+
+  install_minimal_hosts
+
+  run grep -c ' dns$' "$STAGE_MNT/etc/hosts"
+  assert_output "1"
+
+  run grep -c 'freebsd-update$' "$STAGE_MNT/etc/hosts"
+  assert_output "1"
+}
+
+# base pairs ::1 above 127.0.0.1 for localhost; match that
+@test "install_minimal_hosts - IPv6 precedes IPv4 for each name" {
+  setup_minimal_hosts
+  get_public_ip6() { export PUBLIC_IP6="2001:db8::1"; }
+
+  install_minimal_hosts
+
+  run awk '$2 == "dns" { print $1 }' "$STAGE_MNT/etc/hosts"
+  assert_line --index 0 "$(get_jail_ip6 dns)"
+  assert_line --index 1 "$(get_jail_ip4 dns)"
+
+  run awk '$2 == "syslog" { print $1 }' "$STAGE_MNT/etc/hosts"
+  assert_line --index 0 "$(get_jail_ip6 syslog)"
+  assert_line --index 1 "$(get_jail_ip4 syslog)"
+
+  run awk '$2 == "pkg" { print $1 }' "$STAGE_MNT/etc/hosts"
+  assert_line --index 0 "$(get_jail_ip6 bsd_cache)"
+  assert_line --index 1 "$(get_jail_ip4 bsd_cache)"
 }

--- a/test/provision/host.bats
+++ b/test/provision/host.bats
@@ -248,3 +248,12 @@ syslogd_flags() {
   assert_output --partial "-b $JAIL_NET_PREFIX.1"
   refute_output --partial "-b [$JAIL_NET6:1]"
 }
+
+# an allow rule for a range nothing can send from reads like working IPv6 syslog
+@test "update_syslogd - allows only the families it binds" {
+  host_has "203.0.113.7" ""
+
+  run syslogd_flags
+  assert_output --partial "-a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:*"
+  refute_output --partial "-a [$JAIL_NET6:0]/112:*"
+}

--- a/test/provision/host.bats
+++ b/test/provision/host.bats
@@ -219,3 +219,32 @@ host_has() {
   assert_output --partial "-4"
   assert_output --partial "-6"
 }
+
+# --- syslogd listens on the families the jails can send from ---
+
+syslogd_flags() {
+  grep()    { return 1; }
+  service() { :; }
+  sysrc()   { echo "$*" > "$BATS_TEST_TMPDIR/sysrc"; }
+
+  update_syslogd > /dev/null
+  cat "$BATS_TEST_TMPDIR/sysrc"
+}
+
+# the -a rule already allowed the jail IPv6 range, but nothing ever bound it
+@test "update_syslogd - binds IPv6 when the jails have it" {
+  host_has "203.0.113.7" "2001:db8::1"
+
+  run syslogd_flags
+  assert_output --partial "-b $JAIL_NET_PREFIX.1"
+  assert_output --partial "-b [$JAIL_NET6:1]"
+  assert_output --partial "-a [$JAIL_NET6:0]/112:*"
+}
+
+@test "update_syslogd - binds IPv4 only when the jails have no IPv6" {
+  host_has "203.0.113.7" ""
+
+  run syslogd_flags
+  assert_output --partial "-b $JAIL_NET_PREFIX.1"
+  refute_output --partial "-b [$JAIL_NET6:1]"
+}

--- a/test/provision/host.bats
+++ b/test/provision/host.bats
@@ -223,12 +223,14 @@ host_has() {
 # --- syslogd listens on the families the jails can send from ---
 
 syslogd_flags() {
-  grep()    { return 1; }
   service() { :; }
-  sysrc()   { echo "$*" > "$BATS_TEST_TMPDIR/sysrc"; }
+  sysrc() {
+    if [ "$1" = "-n" ]; then echo "${SYSRC_CURRENT:-}"; return; fi
+    echo "$*" > "$BATS_TEST_TMPDIR/sysrc"
+  }
 
-  update_syslogd > /dev/null
-  cat "$BATS_TEST_TMPDIR/sysrc"
+  update_syslogd > "$BATS_TEST_TMPDIR/said"
+  cat "$BATS_TEST_TMPDIR/sysrc" 2>/dev/null
 }
 
 # the -a rule already allowed the jail IPv6 range, but nothing ever bound it
@@ -256,4 +258,40 @@ syslogd_flags() {
   run syslogd_flags
   assert_output --partial "-a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:*"
   refute_output --partial "-a [$JAIL_NET6:0]/112:*"
+}
+
+# every host built by a previous version has flags already set, and the old
+# guard returned on sight of them
+@test "update_syslogd - upgrades flags a previous version generated" {
+  host_has "203.0.113.7" "2001:db8::1"
+  export SYSRC_CURRENT="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* -a [$JAIL_NET6:0]/112:* -cc"
+
+  run syslogd_flags
+  assert_output --partial "-b [$JAIL_NET6:1]"
+}
+
+@test "update_syslogd - upgrades the older /64 and /112 forms too" {
+  host_has "203.0.113.7" "2001:db8::1"
+  local _form
+  for _form in "-a [$JAIL_NET6]/64:*" "-a [$JAIL_NET6]/112:*"; do
+    export SYSRC_CURRENT="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* $_form -cc"
+    run syslogd_flags
+    assert_output --partial "-b [$JAIL_NET6:1]"
+  done
+}
+
+@test "update_syslogd - leaves a customized value alone" {
+  host_has "203.0.113.7" "2001:db8::1"
+  export SYSRC_CURRENT="-b 198.51.100.9 -a 10.0.0.0/8:* -vv"
+
+  run syslogd_flags
+  assert_output ""
+}
+
+@test "update_syslogd - writes nothing when the flags are already right" {
+  host_has "203.0.113.7" "2001:db8::1"
+  export SYSRC_CURRENT="-b $JAIL_NET_PREFIX.1 -a $JAIL_NET_PREFIX.0$JAIL_NET_MASK:* -b [$JAIL_NET6:1] -a [$JAIL_NET6:0]/112:* -cc"
+
+  run syslogd_flags
+  assert_output ""
 }

--- a/test/provision/stubs/mail-toaster.sh
+++ b/test/provision/stubs/mail-toaster.sh
@@ -154,6 +154,7 @@ get_public_ip6()           { :; }
 get_public_facing_nic()    { :; }
 install_pfrule()           { :; }
 install_acme_sh()          { :; }
+install_minimal_hosts()    { :; }
 
 # Config / util
 sed_inplace()              { sed -i.bak "$@"; }


### PR DESCRIPTION
- includes part of #716 
- adds fallback (when no DNS) entries for basic svs: dns, syslog, bsd_cache
  - including IPv6 when present
- syslog: binds to IPv6 when present

Fixes closes #716
